### PR TITLE
Add charm upgrade and channel refresh utilities

### DIFF
--- a/cou/steps/charm_operation.py
+++ b/cou/steps/charm_operation.py
@@ -15,24 +15,17 @@
 
 """Charm operation utilities."""
 import logging
-from cou.zaza_utils.model import upgrade_charm, block_until_all_units_idle
+
+from cou.zaza_utils.model import upgrade_charm
 
 
 def charm_upgrade(application_name: str) -> None:
     """Upgrade a charm to the latest revision in the current channel."""
-    logging.info(
-        "Upgrading %s to the latest revision in the current channel",
-        application_name
-    )
+    logging.info("Upgrading %s to the latest revision in the current channel", application_name)
     upgrade_charm(application_name)
-    block_until_all_units_idle()
 
 
 def charm_channel_refresh(application_name: str, target_channel: str) -> None:
     """Refresh a charm to track a target channel."""
-    logging.info(
-        "Refresh %s to the %s channel",
-        application_name, target_channel
-    )
-    upgrade_charm(application_name, target_channel)
-    block_until_all_units_idle()
+    logging.info("Refresh %s to the %s channel", application_name, target_channel)
+    upgrade_charm(application_name, channel=target_channel)

--- a/cou/steps/charm_operation.py
+++ b/cou/steps/charm_operation.py
@@ -25,7 +25,7 @@ def charm_upgrade(application_name: str) -> None:
     upgrade_charm(application_name)
 
 
-def charm_channel_refresh(application_name: str, target_channel: str) -> None:
+def charm_channel_refresh(application_name: str, channel: str) -> None:
     """Refresh a charm to track a target channel."""
     logging.info("Refresh %s to the %s channel", application_name, target_channel)
     upgrade_charm(application_name, channel=target_channel)

--- a/cou/steps/charm_operation.py
+++ b/cou/steps/charm_operation.py
@@ -1,0 +1,38 @@
+# Copyright 2023 Canonical Limited.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Charm operation utilities."""
+import logging
+from cou.zaza_utils.model import upgrade_charm, block_until_all_units_idle
+
+
+def charm_upgrade(application_name: str) -> None:
+    """Upgrade a charm to the latest revision in the current channel."""
+    logging.info(
+        "Upgrading %s to the latest revision in the current channel",
+        application_name
+    )
+    upgrade_charm(application_name)
+    block_until_all_units_idle()
+
+
+def charm_channel_refresh(application_name: str, target_channel: str) -> None:
+    """Refresh a charm to track a target channel."""
+    logging.info(
+        "Refresh %s to the %s channel",
+        application_name, target_channel
+    )
+    upgrade_charm(application_name, target_channel)
+    block_until_all_units_idle()

--- a/cou/steps/charm_operation.py
+++ b/cou/steps/charm_operation.py
@@ -27,5 +27,5 @@ def charm_upgrade(application_name: str) -> None:
 
 def charm_channel_refresh(application_name: str, channel: str) -> None:
     """Refresh a charm to track a target channel."""
-    logging.info("Refresh %s to the %s channel", application_name, target_channel)
-    upgrade_charm(application_name, channel=target_channel)
+    logging.info("Refresh %s to the %s channel", application_name, channel)
+    upgrade_charm(application_name, channel=channel)

--- a/tests/unit/steps/test_charm_operation.py
+++ b/tests/unit/steps/test_charm_operation.py
@@ -1,0 +1,23 @@
+import unittest
+from unittest.mock import patch
+
+from cou.steps.charm_operation import charm_channel_refresh, charm_upgrade
+
+
+class StepsCharmOperationTestCase(unittest.TestCase):
+    def test_charm_upgrade(self):
+        application_name = "example_charm"
+        with patch("cou.steps.charm_operation.upgrade_charm") as mock_upgrade, patch(
+            "cou.steps.charm_operation.logging.info"
+        ):
+            charm_upgrade(application_name)
+            mock_upgrade.assert_called_once_with(application_name)
+
+    def test_charm_channel_refresh(log):
+        application_name = "example_charm"
+        target_channel = "exampe/stable"
+        with patch("cou.steps.charm_operation.upgrade_charm") as mock_upgrade, patch(
+            "cou.steps.charm_operation.logging.info"
+        ):
+            charm_channel_refresh(application_name, target_channel)
+            mock_upgrade.assert_called_once_with(application_name, channel=target_channel)


### PR DESCRIPTION
This PR adds `charm_operation.py` which make use of zaza's upgrade_charm function to upgrade revisions and switch channels.