### PR TITLE
Fix logging to not use root logger

### DIFF
--- a/cou/cli.py
+++ b/cou/cli.py
@@ -80,8 +80,11 @@ def setup_logging(log_level: str = "INFO") -> None:
     :returns: Nothing: This function is executed for its side effect
     :rtype: None
     """
-    log_formatter = logging.Formatter(
+    log_formatter_file = logging.Formatter(
         fmt="%(asctime)s [%(name)s] [%(levelname)s] %(message)s", datefmt="%Y-%m-%d %H:%M:%S"
+    )
+    log_formatter_console = logging.Formatter(
+        fmt="%(asctime)s [%(levelname)s] %(message)s", datefmt="%Y-%m-%d %H:%M:%S"
     )
     root_logger = logging.getLogger()
     root_logger.setLevel("DEBUG")
@@ -91,12 +94,12 @@ def setup_logging(log_level: str = "INFO") -> None:
     file_name = f"{COU_DIR_LOG}/cou-{time_stamp}.log"
     pathlib.Path(COU_DIR_LOG).mkdir(parents=True, exist_ok=True)
     log_file_handler = logging.FileHandler(file_name)
-    log_file_handler.setFormatter(log_formatter)
+    log_file_handler.setFormatter(log_formatter_file)
 
     # handler for the console. Log level comes from the CLI
     console_handler = logging.StreamHandler()
     console_handler.setLevel(log_level)
-    console_handler.setFormatter(log_formatter)
+    console_handler.setFormatter(log_formatter_console)
     # just cou logs on console
     console_handler.addFilter(logging.Filter(__package__))
 

--- a/cou/cli.py
+++ b/cou/cli.py
@@ -33,8 +33,7 @@ from cou.utils import juju_utils as utils
 COU_DIR_LOG = pathlib.Path(os.getenv("HOME", ""), ".local/share/cou/log")
 AVAILABLE_OPTIONS = "cas"
 
-# NOTE(gabrielcocenza) top-level module to reference the same logger object across modules.
-logger = logging.getLogger(__package__)
+logger = logging.getLogger(__name__)
 
 
 def parse_args(args: Any) -> argparse.Namespace:
@@ -98,6 +97,7 @@ def setup_logging(log_level: str = "INFO") -> None:
     console_handler = logging.StreamHandler()
     console_handler.setLevel(log_level)
     console_handler.setFormatter(log_formatter)
+    # just cou logs on console
     console_handler.addFilter(logging.Filter(__package__))
 
     root_logger.addHandler(log_file_handler)

--- a/cou/cli.py
+++ b/cou/cli.py
@@ -100,7 +100,6 @@ def setup_logging(log_level: str = "INFO") -> None:
     console_handler.setFormatter(log_formatter)
     console_handler.addFilter(logging.Filter(__package__))
 
-
     root_logger.addHandler(log_file_handler)
     root_logger.addHandler(console_handler)
     logger.info("Logs of this execution can be found at %s", file_name)

--- a/cou/cli.py
+++ b/cou/cli.py
@@ -33,6 +33,9 @@ from cou.utils import juju_utils as utils
 COU_DIR_LOG = pathlib.Path(os.getenv("HOME", ""), ".local/share/cou/log")
 AVAILABLE_OPTIONS = "cas"
 
+# NOTE(gabrielcocenza) top-level module to reference the same logger object across modules.
+logger = logging.getLogger("cou")
+
 
 def parse_args(args: Any) -> argparse.Namespace:
     """Parse cli arguments.
@@ -58,6 +61,7 @@ def parse_args(args: Any) -> argparse.Namespace:
         default="INFO",
         dest="loglevel",
         choices=["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"],
+        type=str.upper,
         help="Set the logging level",
     )
     parser.add_argument(
@@ -80,14 +84,14 @@ def setup_logging(log_level: str = "INFO") -> None:
     log_formatter = logging.Formatter(
         fmt="%(asctime)s [%(levelname)s] %(message)s", datefmt="%Y-%m-%d %H:%M:%S"
     )
-    root_logger = logging.getLogger()
-    root_logger.setLevel("DEBUG")
+    logger.setLevel("DEBUG")
 
     # handler for the log file. Log level is DEBUG
     time_stamp = datetime.now().strftime("%Y%m%d%H%M%S")
     file_name = f"{COU_DIR_LOG}/cou-{time_stamp}.log"
     pathlib.Path(COU_DIR_LOG).mkdir(parents=True, exist_ok=True)
     log_file_handler = logging.FileHandler(file_name)
+    log_file_handler.setLevel("DEBUG")
     log_file_handler.setFormatter(log_formatter)
 
     # handler for the console. Log level comes from the CLI
@@ -95,9 +99,9 @@ def setup_logging(log_level: str = "INFO") -> None:
     console_handler.setLevel(log_level)
     console_handler.setFormatter(log_formatter)
 
-    root_logger.addHandler(log_file_handler)
-    root_logger.addHandler(console_handler)
-    logging.info("Logs of this execution can be found at %s", file_name)
+    logger.addHandler(log_file_handler)
+    logger.addHandler(console_handler)
+    logger.info("Logs of this execution can be found at %s", file_name)
 
 
 def prompt(parameter: str) -> str:
@@ -141,12 +145,12 @@ async def apply_plan(upgrade_plan: UpgradeStep) -> None:
                 for sub_step in upgrade_plan.sub_steps:
                     await apply_plan(sub_step)
             case "a":
-                logging.info("Aborting plan")
+                logger.info("Aborting plan")
                 sys.exit(1)
             case "s":
-                logging.info("Skipped")
+                logger.info("Skipped")
             case _:
-                logging.info("No valid input provided!")
+                logger.info("No valid input provided!")
 
 
 async def entrypoint() -> None:
@@ -154,10 +158,10 @@ async def entrypoint() -> None:
     try:
         args = parse_args(sys.argv[1:])
 
-        model_name = await utils.async_set_current_model_name(args.model_name)
-        logging.info("Setting current model name: %s", model_name)
-
         setup_logging(log_level=args.loglevel)
+
+        model_name = await utils.async_set_current_model_name(args.model_name)
+        logger.info("Setting current model name: %s", model_name)
 
         analysis_result = await Analysis.create()
         print(analysis_result)
@@ -168,5 +172,5 @@ async def entrypoint() -> None:
             await apply_plan(upgrade_plan)
 
     except Exception as exc:  # pylint: disable=broad-exception-caught
-        logging.exception(exc)
+        logger.exception(exc)
         sys.exit(1)

--- a/cou/cli.py
+++ b/cou/cli.py
@@ -34,7 +34,7 @@ COU_DIR_LOG = pathlib.Path(os.getenv("HOME", ""), ".local/share/cou/log")
 AVAILABLE_OPTIONS = "cas"
 
 # NOTE(gabrielcocenza) top-level module to reference the same logger object across modules.
-logger = logging.getLogger("cou")
+logger = logging.getLogger(__package__)
 
 
 def parse_args(args: Any) -> argparse.Namespace:
@@ -82,25 +82,27 @@ def setup_logging(log_level: str = "INFO") -> None:
     :rtype: None
     """
     log_formatter = logging.Formatter(
-        fmt="%(asctime)s [%(levelname)s] %(message)s", datefmt="%Y-%m-%d %H:%M:%S"
+        fmt="%(asctime)s [%(name)s] [%(levelname)s] %(message)s", datefmt="%Y-%m-%d %H:%M:%S"
     )
-    logger.setLevel("DEBUG")
+    root_logger = logging.getLogger()
+    root_logger.setLevel("DEBUG")
 
     # handler for the log file. Log level is DEBUG
     time_stamp = datetime.now().strftime("%Y%m%d%H%M%S")
     file_name = f"{COU_DIR_LOG}/cou-{time_stamp}.log"
     pathlib.Path(COU_DIR_LOG).mkdir(parents=True, exist_ok=True)
     log_file_handler = logging.FileHandler(file_name)
-    log_file_handler.setLevel("DEBUG")
     log_file_handler.setFormatter(log_formatter)
 
     # handler for the console. Log level comes from the CLI
     console_handler = logging.StreamHandler()
     console_handler.setLevel(log_level)
     console_handler.setFormatter(log_formatter)
+    console_handler.addFilter(logging.Filter(__package__))
 
-    logger.addHandler(log_file_handler)
-    logger.addHandler(console_handler)
+
+    root_logger.addHandler(log_file_handler)
+    root_logger.addHandler(console_handler)
     logger.info("Logs of this execution can be found at %s", file_name)
 
 

--- a/cou/steps/analyze.py
+++ b/cou/steps/analyze.py
@@ -33,6 +33,8 @@ from cou.utils.juju_utils import (
 )
 from cou.utils.openstack import OpenStackCodenameLookup
 
+logger = logging.getLogger(__name__)
+
 
 @dataclass
 class Analysis:
@@ -47,7 +49,7 @@ class Analysis:
         :return: Analysis object populated with the model applications.
         :rtype: Analysis
         """
-        logging.info("Analyzing the OpenStack deployment...")
+        logger.info("Analyzing the OpenStack deployment...")
         apps = await Analysis._populate()
 
         return Analysis(apps=apps)
@@ -190,5 +192,5 @@ class Application:
             if self.config.get(origin):
                 return self.config[origin].get("value", "")
 
-        logging.warning("Failed to get origin for %s, no origin config found", self.name)
+        logger.warning("Failed to get origin for %s, no origin config found", self.name)
         return ""

--- a/cou/steps/plan.py
+++ b/cou/steps/plan.py
@@ -21,6 +21,8 @@ from cou.steps import UpgradeStep
 from cou.steps.analyze import Analysis
 from cou.steps.backup import backup
 
+logger = logging.getLogger(__name__)
+
 
 async def generate_plan(args: Analysis) -> UpgradeStep:
     """Generate plan for upgrade.
@@ -30,7 +32,7 @@ async def generate_plan(args: Analysis) -> UpgradeStep:
     :return: Plan with all upgrade steps necessary based on the Analysis.
     :rtype: UpgradeStep
     """
-    logging.info(args)  # for placeholder
+    logger.info(args)  # for placeholder
     plan = UpgradeStep(description="Top level plan", parallel=False, function=None)
     plan.add_step(
         UpgradeStep(description="backup mysql databases", parallel=False, function=backup)

--- a/cou/utils/juju_utils.py
+++ b/cou/utils/juju_utils.py
@@ -28,6 +28,8 @@ JUJU_MAX_FRAME_SIZE = 2**30
 CURRENT_MODEL_NAME: Optional[str] = None
 CURRENT_MODEL: Optional[Model] = None
 
+logger = logging.getLogger(__name__)
+
 
 # remove when fixed: https://github.com/juju/python-libjuju/issues/888
 def extract_charm_name_from_url(charm_url):
@@ -232,7 +234,7 @@ async def async_get_unit_from_name(unit_name, model=None, model_name=None):
         units = model.applications[app].units
     except KeyError:
         msg = "Application: {} does not exist in current model".format(app)
-        logging.error(msg)
+        logger.error(msg)
         raise UnitNotFound(unit_name)
     for u in units:
         if u.entity_id == unit_name:

--- a/cou/utils/openstack.py
+++ b/cou/utils/openstack.py
@@ -23,6 +23,8 @@ from typing import Any, List
 
 from packaging.version import Version
 
+logger = logging.getLogger(__name__)
+
 SERVICE_COLUMN_INDEX = 0
 VERSION_START_COLUMN_INDEX = 1
 CHARM_TYPES = {
@@ -115,7 +117,7 @@ class OpenStackCodenameLookup(object):
             cls._OPENSTACK_LOOKUP = cls._generate_lookup(cls._DEFAULT_CSV_FILE)
         compatible_os_releases: List[str] = []
         if not cls._OPENSTACK_LOOKUP.get(component):
-            logging.warning(
+            logger.warning(
                 "Not possible to find the component %s in the lookup",
                 component,
             )

--- a/tests/unit/steps/test_steps_backup.py
+++ b/tests/unit/steps/test_steps_backup.py
@@ -11,9 +11,9 @@ from cou.steps.backup import _check_db_relations, backup, get_database_app_unit_
 
 @pytest.mark.asyncio
 async def test_backup():
-    with patch("cou.steps.backup.logging.info") as log, patch(
-        "cou.steps.backup.utils"
-    ) as utils, patch("cou.steps.backup.get_database_app_unit_name") as database_app_name:
+    with patch("cou.steps.backup.logger") as log, patch("cou.steps.backup.utils") as utils, patch(
+        "cou.steps.backup.get_database_app_unit_name"
+    ) as database_app_name:
         database_app_name.return_value = "test"
         utils.async_run_action = AsyncMock()
         utils.async_run_on_unit = AsyncMock()
@@ -22,7 +22,7 @@ async def test_backup():
         utils.async_get_current_model_name = AsyncMock()
 
         await backup(None)
-        assert log.call_count == 5
+        assert log.info.call_count == 5
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -19,15 +19,14 @@ def test_parse_args():
 
 
 def test_setup_logging():
-    with patch("cou.cli.logging") as mock_logging:
+    with patch("cou.cli.logger") as mock_logger, patch("cou.cli.logging") as mock_logging:
         log_file_handler = MagicMock()
         console_handler = MagicMock()
-        mock_root_logger = mock_logging.getLogger.return_value
         mock_logging.FileHandler.return_value = log_file_handler
         mock_logging.StreamHandler.return_value = console_handler
         setup_logging("INFO")
-        mock_root_logger.addHandler.assert_any_call(log_file_handler)
-        mock_root_logger.addHandler.assert_any_call(console_handler)
+        mock_logger.addHandler.assert_any_call(log_file_handler)
+        mock_logger.addHandler.assert_any_call(console_handler)
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -19,14 +19,15 @@ def test_parse_args():
 
 
 def test_setup_logging():
-    with patch("cou.cli.logger") as mock_logger, patch("cou.cli.logging") as mock_logging:
+    with patch("cou.cli.logging") as mock_logging:
         log_file_handler = MagicMock()
         console_handler = MagicMock()
+        mock_root_logger = mock_logging.getLogger.return_value
         mock_logging.FileHandler.return_value = log_file_handler
         mock_logging.StreamHandler.return_value = console_handler
         setup_logging("INFO")
-        mock_logger.addHandler.assert_any_call(log_file_handler)
-        mock_logger.addHandler.assert_any_call(console_handler)
+        mock_root_logger.addHandler.assert_any_call(log_file_handler)
+        mock_root_logger.addHandler.assert_any_call(console_handler)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
- configure the top-level module for log
- every module references to the same logger object
- avoid duplicated logs by getting the logger on every sub module and not log via root logger
- added %(name)s to identify where the logs comes from
- filter console logs to have just logs from cou
- file logs have all logs on debug level

[0] https://docs.python.org/3/howto/logging.html#configuring-logging-for-a-library
[1] https://docs.python.org/3/howto/logging-cookbook.html#using-logging-in-multiple-modules

Closes #18 