### PR TITLE
Move Application unit tests to its own module

### DIFF
--- a/tests/unit/apps/test_app.py
+++ b/tests/unit/apps/test_app.py
@@ -1,0 +1,114 @@
+# Copyright 2023 Canonical Limited.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+from collections import defaultdict
+
+import pytest
+
+from cou.apps.app import Application
+
+
+def test_application_eq(status, config):
+    """Name of the app is used as comparison between Applications objects."""
+    status_keystone_1 = status["keystone_ussuri"]
+    config_keystone_1 = config["openstack_ussuri"]
+    status_keystone_2 = status["keystone_wallaby"]
+    config_keystone_2 = config["openstack_wallaby"]
+    keystone_1 = Application("keystone", status_keystone_1, config_keystone_1, "my_model")
+    keystone_2 = Application("keystone", status_keystone_2, config_keystone_2, "my_model")
+    keystone_3 = Application("keystone_foo", status_keystone_1, config_keystone_1, "my_model")
+
+    # keystone_1 is equal to keystone_2 because they have the same name
+    # even if they have different status and config.
+    assert keystone_1 == keystone_2
+    # keystone_1 is different then keystone_3 even if they have same status and config.
+    assert keystone_1 != keystone_3
+
+
+@pytest.mark.parametrize(
+    "condition",
+    [
+        "keystone_ussuri",
+        "keystone_ussuri_different_wl_version",
+        "keystone_ussuri_cs",
+        "keystone_wallaby",
+    ],
+)
+@pytest.mark.asyncio
+async def test_application(condition, status, config, mocker, units):
+    """Test the object Application on different scenarios."""
+    if "ussuri" in condition:
+        app_status = status["keystone_ussuri"]
+        app_config = config["openstack_ussuri"]
+        expected_charm_origin = "ch"
+        expected_os_origin = "distro"
+        expected_units = units["units_ussuri"]
+
+    if condition == "keystone_ussuri_different_wl_version":
+        # different workload version for keystone/2
+        mock_unit_2 = mocker.MagicMock()
+        mock_unit_2.workload_version = "18.1.0"
+        app_status.units["keystone/2"] = mock_unit_2
+
+        expected_units["keystone/2"]["os_version"] = "victoria"
+        expected_units["keystone/2"]["workload_version"] = "18.1.0"
+
+    elif condition == "keystone_ussuri_cs":
+        # application is from charm store
+        expected_charm_origin = "cs"
+        app_status = status["keystone_ussuri_cs"]
+
+    elif condition == "keystone_wallaby":
+        expected_units = units["units_wallaby"]
+        expected_charm_origin = "ch"
+        app_config = config["openstack_wallaby"]
+        app_status = status["keystone_wallaby"]
+        expected_os_origin = "cloud:focal-wallaby"
+
+    app = Application("keystone", app_status, app_config, "my_model")
+    assert app.name == "keystone"
+    assert app.status == app_status
+    assert app.config == app_config
+    assert app.model_name == "my_model"
+    assert app.charm == "keystone"
+    assert app.charm_origin == expected_charm_origin
+    assert app.os_origin == expected_os_origin
+    assert app.units == expected_units
+    assert app.channel == app_status.charm_channel
+
+
+@pytest.mark.parametrize(
+    "condition",
+    ["rabbitmq_server", "unknown_rabbitmq_server"],
+)
+def test_app_more_than_one_compatible_os_release(condition, status, config):
+    expected_units = defaultdict(dict)
+    # version 3.8 on rabbitmq can be from ussuri to yoga. In that case it will be set as yoga.
+    if condition == "rabbitmq_server":
+        expected_units["rabbitmq-server/0"]["os_version"] = "yoga"
+        expected_units["rabbitmq-server/0"]["workload_version"] = "3.8"
+    # unknown version of rabbitmq
+    elif condition == "unknown_rabbitmq_server":
+        expected_units["rabbitmq-server/0"]["os_version"] = ""
+        expected_units["rabbitmq-server/0"]["workload_version"] = "80.5"
+
+    app = Application("rabbitmq-server", status[condition], config["openstack_ussuri"], "my_model")
+    assert app.units == expected_units
+
+
+def test_application_no_openstack_origin(status):
+    """Test when application doesn't have openstack-origin or source config."""
+    app_status = status["keystone_wallaby"]
+    app_config = {}
+    app = Application("my_app", app_status, app_config, "my_model")
+    assert app._get_os_origin() == ""

--- a/tests/unit/apps/test_app.py
+++ b/tests/unit/apps/test_app.py
@@ -11,10 +11,6 @@
 
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
-from collections import defaultdict
-
-import pytest
-
 from cou.apps.app import Application
 
 
@@ -35,74 +31,146 @@ def test_application_eq(status, config):
     assert keystone_1 != keystone_3
 
 
-@pytest.mark.parametrize(
-    "condition",
-    [
-        "keystone_ussuri",
-        "keystone_ussuri_different_wl_version",
-        "keystone_ussuri_cs",
-        "keystone_wallaby",
-    ],
-)
-@pytest.mark.asyncio
-async def test_application(condition, status, config, mocker, units):
-    """Test the object Application on different scenarios."""
-    if "ussuri" in condition:
-        app_status = status["keystone_ussuri"]
-        app_config = config["openstack_ussuri"]
-        expected_charm_origin = "ch"
-        expected_os_origin = "distro"
-        expected_units = units["units_ussuri"]
-
-    if condition == "keystone_ussuri_different_wl_version":
-        # different workload version for keystone/2
-        mock_unit_2 = mocker.MagicMock()
-        mock_unit_2.workload_version = "18.1.0"
-        app_status.units["keystone/2"] = mock_unit_2
-
-        expected_units["keystone/2"]["os_version"] = "victoria"
-        expected_units["keystone/2"]["workload_version"] = "18.1.0"
-
-    elif condition == "keystone_ussuri_cs":
-        # application is from charm store
-        expected_charm_origin = "cs"
-        app_status = status["keystone_ussuri_cs"]
-
-    elif condition == "keystone_wallaby":
-        expected_units = units["units_wallaby"]
-        expected_charm_origin = "ch"
-        app_config = config["openstack_wallaby"]
-        app_status = status["keystone_wallaby"]
-        expected_os_origin = "cloud:focal-wallaby"
-
-    app = Application("keystone", app_status, app_config, "my_model")
-    assert app.name == "keystone"
-    assert app.status == app_status
-    assert app.config == app_config
-    assert app.model_name == "my_model"
-    assert app.charm == "keystone"
-    assert app.charm_origin == expected_charm_origin
-    assert app.os_origin == expected_os_origin
-    assert app.units == expected_units
-    assert app.channel == app_status.charm_channel
+def assert_application(
+    app,
+    exp_name,
+    exp_status,
+    exp_config,
+    exp_model,
+    exp_charm,
+    exp_charm_origin,
+    exp_os_origin,
+    exp_units,
+    exp_channel,
+):
+    assert app.name == exp_name
+    assert app.status == exp_status
+    assert app.config == exp_config
+    assert app.model_name == exp_model
+    assert app.charm == exp_charm
+    assert app.charm_origin == exp_charm_origin
+    assert app.os_origin == exp_os_origin
+    assert app.units == exp_units
+    assert app.channel == exp_channel
 
 
-@pytest.mark.parametrize(
-    "condition",
-    ["rabbitmq_server", "unknown_rabbitmq_server"],
-)
-def test_app_more_than_one_compatible_os_release(condition, status, config):
-    expected_units = defaultdict(dict)
+def test_application_ussuri(status, config, units):
+    app_status = status["keystone_ussuri"]
+    app_config = config["openstack_ussuri"]
+    exp_charm_origin = "ch"
+    exp_os_origin = "distro"
+    exp_units = units["units_ussuri"]
+    exp_channel = app_status.charm_channel
+
+    app = Application("my_keystone", app_status, app_config, "my_model")
+    assert_application(
+        app,
+        "my_keystone",
+        app_status,
+        app_config,
+        "my_model",
+        "keystone",
+        exp_charm_origin,
+        exp_os_origin,
+        exp_units,
+        exp_channel,
+    )
+
+
+def test_application_different_wl(status, config, units, mocker):
+    """Different OpenStack Version on units if workload version is different."""
+    app_status = status["keystone_ussuri"]
+    app_config = config["openstack_ussuri"]
+    exp_charm_origin = "ch"
+    exp_os_origin = "distro"
+    exp_units = units["units_ussuri"]
+    exp_channel = app_status.charm_channel
+
+    mock_unit_2 = mocker.MagicMock()
+    mock_unit_2.workload_version = "18.1.0"
+    app_status.units["keystone/2"] = mock_unit_2
+    exp_units["keystone/2"]["os_version"] = "victoria"
+    exp_units["keystone/2"]["workload_version"] = "18.1.0"
+
+    app = Application("my_keystone", app_status, app_config, "my_model")
+    assert_application(
+        app,
+        "my_keystone",
+        app_status,
+        app_config,
+        "my_model",
+        "keystone",
+        exp_charm_origin,
+        exp_os_origin,
+        exp_units,
+        exp_channel,
+    )
+
+
+def test_application_cs(status, config, units):
+    """Test when application is from charm store."""
+    app_status = status["keystone_ussuri_cs"]
+    app_config = config["openstack_ussuri"]
+    exp_os_origin = "distro"
+    exp_units = units["units_ussuri"]
+    exp_channel = app_status.charm_channel
+    exp_charm_origin = "cs"
+
+    app = Application("my_keystone", app_status, app_config, "my_model")
+    assert_application(
+        app,
+        "my_keystone",
+        app_status,
+        app_config,
+        "my_model",
+        "keystone",
+        exp_charm_origin,
+        exp_os_origin,
+        exp_units,
+        exp_channel,
+    )
+
+
+def test_application_wallaby(status, config, units):
+    exp_units = units["units_wallaby"]
+    exp_charm_origin = "ch"
+    app_config = config["openstack_wallaby"]
+    app_status = status["keystone_wallaby"]
+    exp_os_origin = "cloud:focal-wallaby"
+    exp_channel = app_status.charm_channel
+
+    app = Application("my_keystone", app_status, app_config, "my_model")
+    assert_application(
+        app,
+        "my_keystone",
+        app_status,
+        app_config,
+        "my_model",
+        "keystone",
+        exp_charm_origin,
+        exp_os_origin,
+        exp_units,
+        exp_channel,
+    )
+
+
+def test_special_app_more_than_one_compatible_os_release(status, config):
     # version 3.8 on rabbitmq can be from ussuri to yoga. In that case it will be set as yoga.
-    if condition == "rabbitmq_server":
-        expected_units["rabbitmq-server/0"]["os_version"] = "yoga"
-        expected_units["rabbitmq-server/0"]["workload_version"] = "3.8"
-    # unknown version of rabbitmq
-    elif condition == "unknown_rabbitmq_server":
-        expected_units["rabbitmq-server/0"]["os_version"] = ""
-        expected_units["rabbitmq-server/0"]["workload_version"] = "80.5"
+    expected_units = {"rabbitmq-server/0": {"os_version": "yoga", "workload_version": "3.8"}}
+    app = Application(
+        "rabbitmq-server", status["rabbitmq_server"], config["openstack_ussuri"], "my_model"
+    )
+    assert app.units == expected_units
 
-    app = Application("rabbitmq-server", status[condition], config["openstack_ussuri"], "my_model")
+
+def test_special_app_unknown_version(status, config):
+    expected_units = {"rabbitmq-server/0": {"os_version": "", "workload_version": "80.5"}}
+    app = Application(
+        "rabbitmq-server",
+        status["unknown_rabbitmq_server"],
+        config["openstack_ussuri"],
+        "my_model",
+    )
     assert app.units == expected_units
 
 

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -18,7 +18,7 @@ from collections import OrderedDict, defaultdict
 import mock
 import pytest
 
-from cou.steps import analyze
+from cou.apps.app import Application
 
 
 @pytest.fixture
@@ -129,8 +129,8 @@ def apps(status, config):
     keystone_status = status["keystone_ussuri"]
     cinder_status = status["cinder_ussuri"]
     app_config = config["openstack_ussuri"]
-    app_keystone = analyze.Application("keystone", keystone_status, app_config, "my_model")
-    app_cinder = analyze.Application("cinder", cinder_status, app_config, "my_model")
+    app_keystone = Application("keystone", keystone_status, app_config, "my_model")
+    app_cinder = Application("cinder", cinder_status, app_config, "my_model")
 
     return [app_keystone, app_cinder]
 

--- a/tests/unit/steps/test_steps_analyze.py
+++ b/tests/unit/steps/test_steps_analyze.py
@@ -12,104 +12,10 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from collections import defaultdict
-
 import pytest
 
 from cou.steps import analyze
 from cou.steps.analyze import Analysis
-
-
-def test_application_eq(status, config):
-    """Name of the app is used as comparison between Applications objects."""
-    status_keystone_1 = status["keystone_ussuri"]
-    config_keystone_1 = config["openstack_ussuri"]
-    status_keystone_2 = status["keystone_wallaby"]
-    config_keystone_2 = config["openstack_wallaby"]
-    keystone_1 = analyze.Application("keystone", status_keystone_1, config_keystone_1, "my_model")
-    keystone_2 = analyze.Application("keystone", status_keystone_2, config_keystone_2, "my_model")
-    keystone_3 = analyze.Application(
-        "keystone_foo", status_keystone_1, config_keystone_1, "my_model"
-    )
-
-    # keystone_1 is equal to keystone_2 because they have the same name
-    # even if they have different status and config.
-    assert keystone_1 == keystone_2
-    # keystone_1 is different then keystone_3 even if they have same status and config.
-    assert keystone_1 != keystone_3
-
-
-@pytest.mark.parametrize(
-    "condition",
-    [
-        "keystone_ussuri",
-        "keystone_ussuri_different_wl_version",
-        "keystone_ussuri_cs",
-        "keystone_wallaby",
-    ],
-)
-@pytest.mark.asyncio
-async def test_application(condition, status, config, mocker, units):
-    """Test the object Application on different scenarios."""
-    if "ussuri" in condition:
-        app_status = status["keystone_ussuri"]
-        app_config = config["openstack_ussuri"]
-        expected_charm_origin = "ch"
-        expected_os_origin = "distro"
-        expected_units = units["units_ussuri"]
-
-    if condition == "keystone_ussuri_different_wl_version":
-        # different workload version for keystone/2
-        mock_unit_2 = mocker.MagicMock()
-        mock_unit_2.workload_version = "18.1.0"
-        app_status.units["keystone/2"] = mock_unit_2
-
-        expected_units["keystone/2"]["os_version"] = "victoria"
-        expected_units["keystone/2"]["workload_version"] = "18.1.0"
-
-    elif condition == "keystone_ussuri_cs":
-        # application is from charm store
-        expected_charm_origin = "cs"
-        app_status = status["keystone_ussuri_cs"]
-
-    elif condition == "keystone_wallaby":
-        expected_units = units["units_wallaby"]
-        expected_charm_origin = "ch"
-        app_config = config["openstack_wallaby"]
-        app_status = status["keystone_wallaby"]
-        expected_os_origin = "cloud:focal-wallaby"
-
-    app = analyze.Application("keystone", app_status, app_config, "my_model")
-    assert app.name == "keystone"
-    assert app.status == app_status
-    assert app.config == app_config
-    assert app.model_name == "my_model"
-    assert app.charm == "keystone"
-    assert app.charm_origin == expected_charm_origin
-    assert app.os_origin == expected_os_origin
-    assert app.units == expected_units
-    assert app.channel == app_status.charm_channel
-
-
-@pytest.mark.parametrize(
-    "condition",
-    ["rabbitmq_server", "unknown_rabbitmq_server"],
-)
-def test_app_more_than_one_compatible_os_release(condition, status, config):
-    expected_units = defaultdict(dict)
-    # version 3.8 on rabbitmq can be from ussuri to yoga. In that case it will be set as yoga.
-    if condition == "rabbitmq_server":
-        expected_units["rabbitmq-server/0"]["os_version"] = "yoga"
-        expected_units["rabbitmq-server/0"]["workload_version"] = "3.8"
-    # unknown version of rabbitmq
-    elif condition == "unknown_rabbitmq_server":
-        expected_units["rabbitmq-server/0"]["os_version"] = ""
-        expected_units["rabbitmq-server/0"]["workload_version"] = "80.5"
-
-    app = analyze.Application(
-        "rabbitmq-server", status[condition], config["openstack_ussuri"], "my_model"
-    )
-    assert app.units == expected_units
 
 
 @pytest.mark.asyncio
@@ -154,14 +60,6 @@ async def test_analysis_dump(mocker, apps):
     mocker.patch.object(analyze.Analysis, "_populate", return_value=apps)
     result = await analyze.Analysis.create()
     assert str(result) == expected_result
-
-
-def test_application_no_openstack_origin(status):
-    """Test when application doesn't have openstack-origin or source config."""
-    app_status = status["keystone_wallaby"]
-    app_config = {}
-    app = analyze.Application("keystone", app_status, app_config, "my_model")
-    assert app._get_os_origin() == ""
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
- #22 moved Application data class object to its own module, but unit tests were not moved and were together with the analyze.