### PR TITLE
Analyze and Applications can determine current and next OpenStack release

### DIFF
--- a/cou/apps/app.py
+++ b/cou/apps/app.py
@@ -150,6 +150,7 @@ class Application:
 
         :raises MismatchedOpenStackVersions: Raise MismatchedOpenStackVersions if units of
             an application are running mismatched OpenStack versions.
+        :return: OpenStackRelease object
         :rtype: OpenStackRelease
         """
         os_versions = {unit_values.get("os_version") for unit_values in self.units.values()}

--- a/cou/apps/app.py
+++ b/cou/apps/app.py
@@ -148,6 +148,11 @@ class Application:
         os_versions = {unit_values.get("os_version") for unit_values in self.units.values()}
         if len(os_versions) == 1:
             return list(os_versions)[0]
+        logger.warning(
+            "%s has more than one OpenStack version: %s. Setting current release to None.",
+            self.name,
+            os_versions,
+        )
         return None
 
     def _get_os_origin(self) -> str:

--- a/cou/apps/app.py
+++ b/cou/apps/app.py
@@ -25,10 +25,7 @@ from juju.client._definitions import ApplicationStatus
 from ruamel.yaml import YAML
 
 from cou.utils.juju_utils import extract_charm_name_from_url
-from cou.utils.openstack import (
-    OpenStackCodenameLookup,
-    determine_next_openstack_release,
-)
+from cou.utils.openstack import OpenStackCodenameLookup, OpenStackRelease
 
 logger = logging.getLogger(__name__)
 
@@ -98,7 +95,7 @@ class Application:
 
         if len(self.os_versions) == 1:
             self.current_os_release = list(self.os_versions)[0]
-            _, self.next_os_release = determine_next_openstack_release(self.current_os_release)
+            self.next_os_release = OpenStackRelease(self.current_os_release).next_release
 
     def __hash__(self) -> int:
         """Hash magic method for Application.

--- a/cou/apps/app.py
+++ b/cou/apps/app.py
@@ -25,7 +25,10 @@ from juju.client._definitions import ApplicationStatus
 from ruamel.yaml import YAML
 
 from cou.utils.juju_utils import extract_charm_name_from_url
-from cou.utils.openstack import OpenStackCodenameLookup
+from cou.utils.openstack import (
+    OpenStackCodenameLookup,
+    determine_next_openstack_release,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -45,14 +48,19 @@ class Application:
     :param charm: Name of the charm.
     :type charm: str
     :param charm_origin: Origin of the charm (local, ch, cs and etc.), defaults to ""
-    :type charm_origin: str, optional
+    :type charm_origin: str, defaults to ""
     :param os_origin: OpenStack origin of the application. E.g: cloud:focal-wallaby, defaults to ""
-    :type os_origin: str, optional
+    :type os_origin: str, defaults to ""
     :param channel: Channel that the charm tracks. E.g: "ussuri/stable", defaults to ""
-    :type channel: str, optional
+    :type channel: str, defaults to ""
     :param units: Units representation of an application.
         E.g: {"keystone/0": {'os_version': 'victoria', 'workload_version': '2:18.1'}}
     :type units: defaultdict[str, dict]
+    :param current_os_release: Current OpenStack release codename of the application
+    :type current_os_release: str, defaults to ""
+    :param next_os_release: Next OpenStack release codename of the application
+    :param os_versions: OpenStack releases codename encountered on the application
+    :type os_versions: set
     """
 
     # pylint: disable=too-many-instance-attributes
@@ -66,6 +74,9 @@ class Application:
     os_origin: str = ""
     channel: str = ""
     units: defaultdict[str, dict] = field(default_factory=lambda: defaultdict(dict))
+    current_os_release: str = ""
+    next_os_release: str = ""
+    os_versions: set = field(default_factory=set)
 
     def __post_init__(self) -> None:
         """Initialize the Application dataclass."""
@@ -79,9 +90,15 @@ class Application:
             compatible_os_versions = OpenStackCodenameLookup.lookup(self.charm, workload_version)
             # NOTE(gabrielcocenza) get the latest compatible OpenStack version.
             if compatible_os_versions:
-                self.units[unit]["os_version"] = compatible_os_versions[-1]
+                unit_os_version = compatible_os_versions[-1]
+                self.units[unit]["os_version"] = unit_os_version
+                self.os_versions.add(unit_os_version)
             else:
                 self.units[unit]["os_version"] = ""
+
+        if len(self.os_versions) == 1:
+            self.current_os_release = list(self.os_versions)[0]
+            _, self.next_os_release = determine_next_openstack_release(self.current_os_release)
 
     def __hash__(self) -> int:
         """Hash magic method for Application.
@@ -127,6 +144,15 @@ class Application:
         with StringIO() as stream:
             yaml.dump(summary, stream)
             return stream.getvalue()
+
+    @property
+    def series(self) -> str:
+        """Ubuntu series of the application.
+
+        :return: Ubuntu series of application. E.g: focal
+        :rtype: str
+        """
+        return self.status.series
 
     def _get_os_origin(self) -> str:
         """Get application configuration for openstack-origin or source.

--- a/cou/apps/app.py
+++ b/cou/apps/app.py
@@ -148,7 +148,8 @@ class Application:
     def current_os_release(self) -> Optional[OpenStackRelease]:
         """Current OpenStack Release of the application.
 
-        :return: OpenStackRelease object
+        :raises MismatchedOpenStackVersions: Raise MismatchedOpenStackVersions if units of
+            an application are running mismatched OpenStack versions.
         :rtype: OpenStackRelease
         """
         os_versions = {unit_values.get("os_version") for unit_values in self.units.values()}

--- a/cou/apps/app.py
+++ b/cou/apps/app.py
@@ -164,7 +164,7 @@ class Application:
         logger.error(
             (
                 "Units of application %s are running mismatched OpenStack versions: %s. "
-                "Setting current release to None."
+                "This is not currently handled."
             ),
             self.name,
             os_versions,

--- a/cou/exceptions.py
+++ b/cou/exceptions.py
@@ -40,6 +40,10 @@ class JujuError(Exception):
     """Exception when libjuju does something unexpected."""
 
 
+class MismatchedOpenStackVersions(Exception):
+    """Exception when more than one OpenStack version are found in the Application."""
+
+
 class ActionFailed(Exception):
     # pylint: disable=consider-using-f-string
     """Exception raised when action fails."""

--- a/cou/steps/analyze.py
+++ b/cou/steps/analyze.py
@@ -51,7 +51,7 @@ class Analysis:
 
     @classmethod
     async def _populate(cls) -> List[Application]:
-        """Generate the applications model.
+        """Analyze the applications in the model.
 
         :return: Application objects with their respective information.
         :rtype: List[Application]
@@ -67,7 +67,12 @@ class Analysis:
             )
             for app, app_status in juju_status.applications.items()
         }
-        return sorted(apps, key=lambda app: UPGRADE_ORDER.index(app.charm))
+        upgradeable_apps = {app for app in apps if app.charm in UPGRADE_ORDER}
+        unknown_apps = apps - upgradeable_apps
+        upgradeable_apps_sorted = sorted(
+            upgradeable_apps, key=lambda app: UPGRADE_ORDER.index(app.charm)
+        )
+        return upgradeable_apps_sorted + list(unknown_apps)
 
     def __str__(self) -> str:
         """Dump as string.

--- a/cou/steps/analyze.py
+++ b/cou/steps/analyze.py
@@ -17,20 +17,45 @@ from __future__ import annotations
 
 import logging
 import os
-from dataclasses import dataclass
-from typing import Iterable
+from collections import defaultdict
+from dataclasses import dataclass, field
+from typing import Iterable, List, Optional
 
 from cou.apps.app import Application
 from cou.utils.juju_utils import async_get_application_config, async_get_status
+from cou.utils.openstack import (
+    LTS_SERIES,
+    SPECIAL_CHARMS,
+    UPGRADE_ORDER,
+    CompareOpenStack,
+    determine_next_openstack_release,
+)
 
 logger = logging.getLogger(__name__)
 
 
 @dataclass
 class Analysis:
-    """Analyze result."""
+    """Analyze result.
+
+    :param apps: Applications in the model
+    :type apps:  Iterable[Application]
+    :param apps_to_upgrade: Applications to upgrade in the model
+    :type apps_to_upgrade: Optional[List[Application]]
+    :param os_versions: Dictionary containing OpenStack codenames and set of Applications
+    :type os_versions:  defaultdict[str, set]
+    """
 
     apps: Iterable[Application]
+    apps_to_upgrade: Optional[List[Application]] = None
+    os_versions: defaultdict[str, set] = field(default_factory=lambda: defaultdict(set))
+
+    def __post_init__(self) -> None:
+        """Initialize the Analysis dataclass."""
+        for app in self.apps:
+            if app.current_os_release:
+                self.os_versions[app.current_os_release].add(app)
+        self.apps_to_upgrade = self.determine_apps_to_upgrade()
 
     @classmethod
     async def create(cls) -> Analysis:
@@ -71,3 +96,60 @@ class Analysis:
         :rtype: str
         """
         return os.linesep.join([str(app) for app in self.apps])
+
+    @property
+    def current_cloud_os_release(self) -> str:
+        """Shows the current OpenStack release codename.
+
+        :return: OpenStack release codename
+        :rtype: str
+        """
+        os_sequence = sorted(self.os_versions.keys(), key=CompareOpenStack)
+        return os_sequence[0]
+
+    @property
+    def next_cloud_os_release(self) -> str:
+        """Shows the next OpenStack release codename.
+
+        :return: OpenStack release codename
+        :rtype: str
+        """
+        _, next_cloud_os_release = determine_next_openstack_release(self.current_cloud_os_release)
+        return next_cloud_os_release
+
+    def determine_apps_to_upgrade(self) -> List[Application]:
+        """Determine applications to upgrade.
+
+        This function find the oldest OpenStack version in the deployment and
+        select the applications to upgrade for the next version (N + 1).
+
+        :return: List of applications to be upgraded.
+        :rtype: List[Application]
+        """
+        apps_to_upgrade = self.os_versions[self.current_cloud_os_release].copy()
+        special_charms_to_upgrade = self._add_special_charms_to_upgrade()
+        apps_to_upgrade.update(special_charms_to_upgrade)
+
+        return sorted(apps_to_upgrade, key=lambda app: UPGRADE_ORDER.index(app.charm))
+
+    def _add_special_charms_to_upgrade(self) -> set:
+        """Add special charms to upgrade if openstack-origin is set to a lower OpenStack version.
+
+        Special charms are those that can have multiple OpenStack releases for a workload version.
+        When source is configured to "distro", we should check the ubuntu series that matches with
+        this configuration.
+        :return: Set of Applications to upgrade
+        :rtype: set
+        """
+        special_charms_to_upgrade = set()
+        for app in self.apps:
+            if app.charm in SPECIAL_CHARMS and app.os_origin:
+                os_origin = app.os_origin.split("-")[-1]
+                if os_origin == "distro":
+                    os_origin = LTS_SERIES[app.series]
+                if (
+                    CompareOpenStack(app.current_os_release) < self.next_cloud_os_release
+                    or CompareOpenStack(os_origin) < self.next_cloud_os_release
+                ):
+                    special_charms_to_upgrade.add(app)
+        return special_charms_to_upgrade

--- a/cou/steps/analyze.py
+++ b/cou/steps/analyze.py
@@ -101,14 +101,14 @@ class Analysis:
                     os_versions.add(app.current_os_release)
                 else:
                     logger.warning(
-                        "Disconsidering %s to determine the minimum version of the cloud.",
+                        "Ignoring %s when determining the minimum version of the cloud.",
                         app.name,
                     )
             else:
                 logger.debug(
                     (
-                        "Disconsidering %s to determine the min version of the cloud "
-                        "because isn't an OpenStack charm."
+                        "Ignoring %s when determining the minimum version of the cloud: "
+                        "not an OpenStack charm."
                     ),
                     app.name,
                 )

--- a/cou/steps/analyze.py
+++ b/cou/steps/analyze.py
@@ -27,8 +27,7 @@ from cou.utils.openstack import (
     LTS_SERIES,
     SPECIAL_CHARMS,
     UPGRADE_ORDER,
-    CompareOpenStack,
-    determine_next_openstack_release,
+    OpenStackRelease,
 )
 
 logger = logging.getLogger(__name__)
@@ -104,7 +103,7 @@ class Analysis:
         :return: OpenStack release codename
         :rtype: str
         """
-        os_sequence = sorted(self.os_versions.keys(), key=CompareOpenStack)
+        os_sequence = sorted(self.os_versions.keys(), key=OpenStackRelease)
         return os_sequence[0]
 
     @property
@@ -114,8 +113,7 @@ class Analysis:
         :return: OpenStack release codename
         :rtype: str
         """
-        _, next_cloud_os_release = determine_next_openstack_release(self.current_cloud_os_release)
-        return next_cloud_os_release
+        return OpenStackRelease(self.current_cloud_os_release).next_release
 
     def determine_apps_to_upgrade(self) -> List[Application]:
         """Determine applications to upgrade.
@@ -148,8 +146,8 @@ class Analysis:
                 if os_origin == "distro":
                     os_origin = LTS_SERIES[app.series]
                 if (
-                    CompareOpenStack(app.current_os_release) < self.next_cloud_os_release
-                    or CompareOpenStack(os_origin) < self.next_cloud_os_release
+                    OpenStackRelease(app.current_os_release) < self.next_cloud_os_release
+                    or OpenStackRelease(os_origin) < self.next_cloud_os_release
                 ):
                     special_charms_to_upgrade.add(app)
         return special_charms_to_upgrade

--- a/cou/steps/analyze.py
+++ b/cou/steps/analyze.py
@@ -34,7 +34,7 @@ class Analysis:
 
     :param apps: Applications in the model
     :type apps:  Iterable[Application]
-    :param os_versions: Dictionary containing OpenStack codenames and set of Applications
+    :param os_versions: Dictionary containing OpenStack codenames and set of Applications name.
     :type os_versions:  defaultdict[str, set]
     """
 
@@ -45,7 +45,7 @@ class Analysis:
         """Initialize the Analysis dataclass."""
         for app in self.apps:
             if app.current_os_release:
-                self.os_versions[app.current_os_release].add(app.charm)
+                self.os_versions[app.current_os_release].add(app.name)
 
     @classmethod
     async def create(cls) -> Analysis:

--- a/cou/steps/analyze.py
+++ b/cou/steps/analyze.py
@@ -19,16 +19,11 @@ import logging
 import os
 from collections import defaultdict
 from dataclasses import dataclass, field
-from typing import Iterable, List, Optional
+from typing import Iterable, List
 
 from cou.apps.app import Application
 from cou.utils.juju_utils import async_get_application_config, async_get_status
-from cou.utils.openstack import (
-    LTS_SERIES,
-    SPECIAL_CHARMS,
-    UPGRADE_ORDER,
-    OpenStackRelease,
-)
+from cou.utils.openstack import UPGRADE_ORDER, OpenStackRelease
 
 logger = logging.getLogger(__name__)
 
@@ -39,22 +34,18 @@ class Analysis:
 
     :param apps: Applications in the model
     :type apps:  Iterable[Application]
-    :param apps_to_upgrade: Applications to upgrade in the model
-    :type apps_to_upgrade: Optional[List[Application]]
     :param os_versions: Dictionary containing OpenStack codenames and set of Applications
     :type os_versions:  defaultdict[str, set]
     """
 
     apps: Iterable[Application]
-    apps_to_upgrade: Optional[List[Application]] = None
     os_versions: defaultdict[str, set] = field(default_factory=lambda: defaultdict(set))
 
     def __post_init__(self) -> None:
         """Initialize the Analysis dataclass."""
         for app in self.apps:
             if app.current_os_release:
-                self.os_versions[app.current_os_release].add(app)
-        self.apps_to_upgrade = self.determine_apps_to_upgrade()
+                self.os_versions[app.current_os_release].add(app.charm)
 
     @classmethod
     async def create(cls) -> Analysis:
@@ -69,11 +60,11 @@ class Analysis:
         return Analysis(apps=apps)
 
     @classmethod
-    async def _populate(cls) -> set[Application]:
+    async def _populate(cls) -> List[Application]:
         """Generate the applications model.
 
         :return: Application objects with their respective information.
-        :rtype: set[Application]
+        :rtype: List[Application]
         """
         juju_status = await async_get_status()
         model_name = juju_status.model.name
@@ -86,7 +77,7 @@ class Analysis:
             )
             for app, app_status in juju_status.applications.items()
         }
-        return apps
+        return sorted(apps, key=lambda app: UPGRADE_ORDER.index(app.charm))
 
     def __str__(self) -> str:
         """Dump as string.
@@ -114,40 +105,3 @@ class Analysis:
         :rtype: str
         """
         return OpenStackRelease(self.current_cloud_os_release).next_release
-
-    def determine_apps_to_upgrade(self) -> List[Application]:
-        """Determine applications to upgrade.
-
-        This function find the oldest OpenStack version in the deployment and
-        select the applications to upgrade for the next version (N + 1).
-
-        :return: List of applications to be upgraded.
-        :rtype: List[Application]
-        """
-        apps_to_upgrade = self.os_versions[self.current_cloud_os_release].copy()
-        special_charms_to_upgrade = self._add_special_charms_to_upgrade()
-        apps_to_upgrade.update(special_charms_to_upgrade)
-
-        return sorted(apps_to_upgrade, key=lambda app: UPGRADE_ORDER.index(app.charm))
-
-    def _add_special_charms_to_upgrade(self) -> set:
-        """Add special charms to upgrade if openstack-origin is set to a lower OpenStack version.
-
-        Special charms are those that can have multiple OpenStack releases for a workload version.
-        When source is configured to "distro", we should check the ubuntu series that matches with
-        this configuration.
-        :return: Set of Applications to upgrade
-        :rtype: set
-        """
-        special_charms_to_upgrade = set()
-        for app in self.apps:
-            if app.charm in SPECIAL_CHARMS and app.os_origin:
-                os_origin = app.os_origin.split("-")[-1]
-                if os_origin == "distro":
-                    os_origin = LTS_SERIES[app.series]
-                if (
-                    OpenStackRelease(app.current_os_release) < self.next_cloud_os_release
-                    or OpenStackRelease(os_origin) < self.next_cloud_os_release
-                ):
-                    special_charms_to_upgrade.add(app)
-        return special_charms_to_upgrade

--- a/cou/steps/analyze.py
+++ b/cou/steps/analyze.py
@@ -17,9 +17,8 @@ from __future__ import annotations
 
 import logging
 import os
-from collections import defaultdict
-from dataclasses import dataclass, field
-from typing import Iterable, List
+from dataclasses import dataclass
+from typing import Iterable, List, Optional
 
 from cou.apps.app import Application
 from cou.utils.juju_utils import async_get_application_config, async_get_status
@@ -34,18 +33,9 @@ class Analysis:
 
     :param apps: Applications in the model
     :type apps:  Iterable[Application]
-    :param os_versions: Dictionary containing OpenStack codenames and set of Applications name.
-    :type os_versions:  defaultdict[str, set]
     """
 
     apps: Iterable[Application]
-    os_versions: defaultdict[str, set] = field(default_factory=lambda: defaultdict(set))
-
-    def __post_init__(self) -> None:
-        """Initialize the Analysis dataclass."""
-        for app in self.apps:
-            if app.current_os_release:
-                self.os_versions[app.current_os_release].add(app.name)
 
     @classmethod
     async def create(cls) -> Analysis:
@@ -88,20 +78,14 @@ class Analysis:
         return os.linesep.join([str(app) for app in self.apps])
 
     @property
-    def current_cloud_os_release(self) -> str:
+    def current_cloud_os_release(self) -> Optional[OpenStackRelease]:
         """Shows the current OpenStack release codename.
 
         :return: OpenStack release codename
-        :rtype: str
+        :rtype: OpenStackRelease
         """
-        os_sequence = sorted(self.os_versions.keys(), key=OpenStackRelease)
-        return os_sequence[0]
-
-    @property
-    def next_cloud_os_release(self) -> str:
-        """Shows the next OpenStack release codename.
-
-        :return: OpenStack release codename
-        :rtype: str
-        """
-        return OpenStackRelease(self.current_cloud_os_release).next_release
+        os_versions = set()
+        for app in self.apps:
+            if app.current_os_release:
+                os_versions.add(app.current_os_release)
+        return min(os_versions) if os_versions else None

--- a/cou/steps/analyze.py
+++ b/cou/steps/analyze.py
@@ -86,11 +86,30 @@ class Analysis:
     def current_cloud_os_release(self) -> Optional[OpenStackRelease]:
         """Shows the current OpenStack release codename.
 
+        This property just consider OpenStack charms as those that have
+        openstack-origin or source on the charm configuration (app.os_origin).
         :return: OpenStack release codename
         :rtype: OpenStackRelease
         """
         os_versions = set()
         for app in self.apps:
-            if app.current_os_release:
-                os_versions.add(app.current_os_release)
+            if app.os_origin:
+                # NOTE (gabrielcocenza) this is temporarily skipping subordinate charms
+                # until there is a specific class able to get the OpenStack release.
+                # It's also skipping applications with no identified OpenStack release.
+                if app.current_os_release:
+                    os_versions.add(app.current_os_release)
+                else:
+                    logger.warning(
+                        "Disconsidering %s to determine the minimum version of the cloud.",
+                        app.name,
+                    )
+            else:
+                logger.debug(
+                    (
+                        "Disconsidering %s to determine the min version of the cloud "
+                        "because isn't an OpenStack charm."
+                    ),
+                    app.name,
+                )
         return min(os_versions) if os_versions else None

--- a/cou/utils/openstack.py
+++ b/cou/utils/openstack.py
@@ -129,37 +129,37 @@ class OpenStackRelease:
         """
         return hash(f"{self.codename}{self.date}")
 
-    def __eq__(self, other):
+    def __eq__(self, other: Any) -> bool:
         """Do equals."""
         if not isinstance(other, (str, OpenStackRelease)):
             return NotImplemented
-        return self.index == self.openstack_codenames.index(other)
+        return self.index == self.openstack_codenames.index(str(other))
 
-    def __ne__(self, other):
+    def __ne__(self, other: Any) -> bool:
         """Do not equals."""
         return not self.__eq__(other)
 
-    def __lt__(self, other):
+    def __lt__(self, other: Any) -> bool:
         """Do less than."""
         if not isinstance(other, (str, OpenStackRelease)):
             return NotImplemented
-        return self.index < self.openstack_codenames.index(other)
+        return self.index < self.openstack_codenames.index(str(other))
 
-    def __ge__(self, other):
+    def __ge__(self, other: Any) -> bool:
         """Do greater than or equal."""
         return not self.__lt__(other)
 
-    def __gt__(self, other):
+    def __gt__(self, other: Any) -> bool:
         """Do greater than."""
         if not isinstance(other, (str, OpenStackRelease)):
             return NotImplemented
-        return self.index > self.openstack_codenames.index(other)
+        return self.index > self.openstack_codenames.index(str(other))
 
-    def __le__(self, other):
+    def __le__(self, other: Any) -> bool:
         """Do less than or equals."""
         return not self.__gt__(other)
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         """Return the representation of CompareOpenStack."""
         return f"{self.__class__.__name__}<{self.codename}>"
 
@@ -173,7 +173,7 @@ class OpenStackRelease:
         return self._codename
 
     @codename.setter
-    def codename(self, value: str):
+    def codename(self, value: str) -> None:
         """Setter of OpenStack release codename.
 
         :param value: OpenStack release codename.

--- a/cou/utils/openstack.py
+++ b/cou/utils/openstack.py
@@ -20,7 +20,7 @@ import logging
 from collections import OrderedDict, defaultdict
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, List, Tuple
+from typing import Any, List, Optional, Tuple
 
 from packaging.version import Version
 
@@ -110,16 +110,16 @@ class OpenStackRelease:
     """
 
     openstack_codenames = list(OPENSTACK_CODENAMES.keys())
-    openstack_release_year = list(OPENSTACK_CODENAMES.values())
+    openstack_release_date = list(OPENSTACK_CODENAMES.values())
 
-    def __init__(self, os_release: str):
+    def __init__(self, codename: str):
         """Initialize the OpenStackRelease object.
 
-        :param os_release: OpenStack release codename.
-        :type os_release: str
+        :param codename: OpenStack release codename.
+        :type codename: str
         :raises ValueError: Raises ValueError if OpenStack codename is unknown.
         """
-        self.os_release = os_release
+        self.codename = codename
 
     def __hash__(self) -> int:
         """Hash magic method for OpenStackRelease.
@@ -127,7 +127,7 @@ class OpenStackRelease:
         :return: Unique hash identifier for OpenStackRelease object.
         :rtype: int
         """
-        return hash(f"{self.os_release}{self.release_year}")
+        return hash(f"{self.codename}{self.date}")
 
     def __eq__(self, other):
         """Do equals."""
@@ -161,7 +161,7 @@ class OpenStackRelease:
 
     def __repr__(self):
         """Return the representation of CompareOpenStack."""
-        return f"{self.__class__.__name__}<{self.os_release}>"
+        return f"{self.__class__.__name__}<{self.codename}>"
 
     @property
     def codename(self) -> str:
@@ -170,10 +170,10 @@ class OpenStackRelease:
         :return: OpenStack release codename.
         :rtype: str
         """
-        return self._os_release
+        return self._codename
 
-    @os_release.setter
-    def os_release(self, value: str):
+    @codename.setter
+    def codename(self, value: str):
         """Setter of OpenStack release codename.
 
         :param value: OpenStack release codename.
@@ -182,31 +182,30 @@ class OpenStackRelease:
         """
         if value not in self.openstack_codenames:
             raise ValueError(f"OpenStack '{value}' is not in '{self.openstack_codenames}'")
-        self._os_release = value
+        self._codename = value
         self.index = self.openstack_codenames.index(value)
 
     @property
-    def next_release(self) -> str:
+    def next_release(self) -> Optional[str]:
         """Return the next OpenStack release codename.
 
         :return: OpenStack release codename.
         :rtype: str
         """
         try:
-            os_release = self.openstack_codenames[self.index + 1]
+            return self.openstack_codenames[self.index + 1]
         except IndexError:
-            logger.warning("There is no OpenStack release after %s", self.os_release)
-            os_release = self.openstack_codenames[self.index]
-        return os_release
+            logger.warning("There is no OpenStack release after %s", self.codename)
+            return None
 
     @property
     def date(self) -> str:
-        """Release year of the OpenStack release.
+        """Release date of the OpenStack release.
 
-        :return: Release year.
+        :return: Release date.
         :rtype: str
         """
-        return self.openstack_release_year[self.index]
+        return self.openstack_release_date[self.index]
 
     def __str__(self) -> str:
         """Give back the item at the index.
@@ -220,7 +219,7 @@ class OpenStackRelease:
 
         :returns: <string>
         """
-        return self.os_release
+        return self.codename
 
 
 @dataclass(frozen=True)

--- a/cou/utils/openstack.py
+++ b/cou/utils/openstack.py
@@ -58,8 +58,8 @@ UPGRADE_ORDER = [
     "manila-ganesha",
     "neutron-api",
     "neutron-gateway",
-    "ovn-central",
     "ovn-dedicated-chassis",
+    "ovn-central",
     "placement",
     "nova-cloud-controller",
     "nova-compute",
@@ -97,16 +97,16 @@ OPENSTACK_CODENAMES = OrderedDict(
         ("zed", "2022.2"),
         ("antelope", "2023.1"),
         ("bobcat", "2023.2"),
+        ("caracal", "2024.1"),
     ]
 )
 
 
 class OpenStackRelease:
-    """Provides a class that will compare strings from an iterator type object.
+    """Provides a class that will compare OpenStack releases by the codename.
 
     Used to provide > and < comparisons on strings that may not necessarily be
-    alphanumerically ordered.  e.g. OpenStack or Ubuntu releases AFTER the
-    z-wrap.
+    alphanumerically ordered.  e.g. OpenStack releases AFTER the z-wrap.
     """
 
     openstack_codenames = list(OPENSTACK_CODENAMES.keys())

--- a/cou/utils/openstack.py
+++ b/cou/utils/openstack.py
@@ -38,21 +38,6 @@ CHARM_TYPES = {
     "horizon": ["openstack-dashboard"],
 }
 
-# list of charms that the workload version can match more than one OpenStack release
-SPECIAL_CHARMS = [
-    "ceph-mon",
-    "ceph-fs",
-    "ceph-radosgw",
-    "ceph-osd",
-    "ovn-dedicated-chassis",
-    "ovn-central",
-    "mysql",
-    "hacluster",
-    "rabbitmq-server",
-    "vault",
-    "designate-bind",
-]
-
 # https://docs.openstack.org/charm-guide/latest/admin/upgrades/openstack.html#list-the-upgrade-order
 UPGRADE_ORDER = [
     "rabbitmq-server",
@@ -114,12 +99,6 @@ OPENSTACK_CODENAMES = OrderedDict(
         ("bobcat", "2023.2"),
     ]
 )
-
-LTS_SERIES = {
-    "bionic": "queens",
-    "focal": "ussuri",
-    "jammy": "yoga",
-}
 
 
 @dataclass(frozen=True)

--- a/cou/utils/openstack.py
+++ b/cou/utils/openstack.py
@@ -101,115 +101,6 @@ OPENSTACK_CODENAMES = OrderedDict(
 )
 
 
-@dataclass(frozen=True)
-class VersionRange:
-    """Structure for holding version."""
-
-    lower: str
-    upper: str
-
-    def __contains__(self, version: str) -> bool:
-        """Magic method to check if a version is within the range.
-
-        :param version: version of a service.
-        :type version: str
-        :return: True if version is in the range.
-        :rtype: bool
-        """
-        lower_v = Version(self.lower)
-        upper_v = Version(self.upper)
-        service_version = Version(version)
-        return lower_v <= service_version < upper_v
-
-
-# pylint: disable=too-few-public-methods
-class OpenStackCodenameLookup:
-    """Class to determine compatible OpenStack codenames for a given component."""
-
-    _OPENSTACK_LOOKUP: OrderedDict = OrderedDict()
-    _DEFAULT_CSV_FILE = Path(__file__).parent / "openstack_lookup.csv"
-
-    @classmethod
-    def _generate_lookup(cls, resource: Path) -> OrderedDict:
-        """Generate an OpenStack lookup dictionary based on the version of the components.
-
-        The dictionary is generated from a static csv file that should be updated regularly
-        to include new OpenStack releases and updates to the lower and upper versions of
-        the services. The csv table is made from the release page [0] charm delivery [1],
-        cmadison and rmadison. The lower version is the lowest version of a certain release (N)
-        while the upper is the first incompatible version. This way, new patches
-        won't affect the comparison.
-
-        Charm designate-bind workload_version tracks the version of the deb package bind9.
-        For charm gnocchi it was used cmadison.
-
-        [0] https://releases.openstack.org/
-        [1] https://docs.openstack.org/charm-guide/latest/project/charm-delivery.html
-
-        :param resource: Path to the csv file
-        :type resource: Path
-        :return: Ordered dictionary containing the version and the compatible OpenStack release.
-        :rtype: OrderedDict
-        """
-        with open(resource, encoding=encodings.utf_8.getregentry().name) as csv_file:
-            openstack_lookup = OrderedDict()
-            csv_reader = csv.reader(csv_file, delimiter=",")
-            header = next(csv_reader)
-            for row in csv_reader:
-                service, service_dict = cls._parse_row(header, row)
-                openstack_lookup[service] = service_dict
-        # add openstack charms
-        for charm_type, charms in CHARM_TYPES.items():
-            for charm in charms:
-                openstack_lookup[charm] = openstack_lookup[charm_type]
-        return openstack_lookup
-
-    @classmethod
-    def _parse_row(cls, header: List[str], row: List[str]) -> Tuple[str, defaultdict[str, Any]]:
-        """Parse single row.
-
-        :param header: header list
-        :type header: list[str]
-        :param row: row list
-        :type row: list[str]
-        :return: service and service dictionary
-        :rtype: tuple
-        """
-        service_dict: defaultdict[str, Any] = defaultdict(OrderedDict)
-        service = row[SERVICE_COLUMN_INDEX]
-        for column_index in range(VERSION_START_COLUMN_INDEX, len(row), 2):
-            os_version, _ = header[column_index].split("-")
-            lower = row[column_index]
-            upper = row[column_index + 1]
-            service_dict[os_version] = VersionRange(lower, upper)
-        return service, service_dict
-
-    @classmethod
-    def lookup(cls, component: str, version: str) -> List[str]:
-        """Get the compatible OpenStack codenames based on the component and version.
-
-        :param component: Name of the component. E.g: "keystone"
-        :type component: str
-        :param version: Version of the component. E.g: "17.0.2"
-        :type version: str
-        :return: Return a sorted list of compatible OpenStack codenames.
-        :rtype: List[str]
-        """
-        if not cls._OPENSTACK_LOOKUP:
-            cls._OPENSTACK_LOOKUP = cls._generate_lookup(cls._DEFAULT_CSV_FILE)
-        compatible_os_releases: List[str] = []
-        if not cls._OPENSTACK_LOOKUP.get(component):
-            logger.warning(
-                "Not possible to find the component %s in the lookup",
-                component,
-            )
-            return compatible_os_releases
-        for openstack_release, version_range in cls._OPENSTACK_LOOKUP[component].items():
-            if version in version_range:
-                compatible_os_releases.append(openstack_release)
-        return compatible_os_releases
-
-
 class OpenStackRelease:
     """Provides a class that will compare strings from an iterator type object.
 
@@ -229,6 +120,14 @@ class OpenStackRelease:
         :raises ValueError: Raises ValueError if OpenStack codename is unknown.
         """
         self.os_release = os_release
+
+    def __hash__(self) -> int:
+        """Hash magic method for OpenStackRelease.
+
+        :return: Unique hash identifier for OpenStackRelease object.
+        :rtype: int
+        """
+        return hash(f"{self.os_release}{self.release_year}")
 
     def __eq__(self, other):
         """Do equals."""
@@ -322,3 +221,112 @@ class OpenStackRelease:
         :returns: <string>
         """
         return self.os_release
+
+
+@dataclass(frozen=True)
+class VersionRange:
+    """Structure for holding version."""
+
+    lower: str
+    upper: str
+
+    def __contains__(self, version: str) -> bool:
+        """Magic method to check if a version is within the range.
+
+        :param version: version of a service.
+        :type version: str
+        :return: True if version is in the range.
+        :rtype: bool
+        """
+        lower_v = Version(self.lower)
+        upper_v = Version(self.upper)
+        service_version = Version(version)
+        return lower_v <= service_version < upper_v
+
+
+# pylint: disable=too-few-public-methods
+class OpenStackCodenameLookup:
+    """Class to determine compatible OpenStack codenames for a given component."""
+
+    _OPENSTACK_LOOKUP: OrderedDict = OrderedDict()
+    _DEFAULT_CSV_FILE = Path(__file__).parent / "openstack_lookup.csv"
+
+    @classmethod
+    def _generate_lookup(cls, resource: Path) -> OrderedDict:
+        """Generate an OpenStack lookup dictionary based on the version of the components.
+
+        The dictionary is generated from a static csv file that should be updated regularly
+        to include new OpenStack releases and updates to the lower and upper versions of
+        the services. The csv table is made from the release page [0] charm delivery [1],
+        cmadison and rmadison. The lower version is the lowest version of a certain release (N)
+        while the upper is the first incompatible version. This way, new patches
+        won't affect the comparison.
+
+        Charm designate-bind workload_version tracks the version of the deb package bind9.
+        For charm gnocchi it was used cmadison.
+
+        [0] https://releases.openstack.org/
+        [1] https://docs.openstack.org/charm-guide/latest/project/charm-delivery.html
+
+        :param resource: Path to the csv file
+        :type resource: Path
+        :return: Ordered dictionary containing the version and the compatible OpenStack release.
+        :rtype: OrderedDict
+        """
+        with open(resource, encoding=encodings.utf_8.getregentry().name) as csv_file:
+            openstack_lookup = OrderedDict()
+            csv_reader = csv.reader(csv_file, delimiter=",")
+            header = next(csv_reader)
+            for row in csv_reader:
+                service, service_dict = cls._parse_row(header, row)
+                openstack_lookup[service] = service_dict
+        # add openstack charms
+        for charm_type, charms in CHARM_TYPES.items():
+            for charm in charms:
+                openstack_lookup[charm] = openstack_lookup[charm_type]
+        return openstack_lookup
+
+    @classmethod
+    def _parse_row(cls, header: List[str], row: List[str]) -> Tuple[str, defaultdict[str, Any]]:
+        """Parse single row.
+
+        :param header: header list
+        :type header: list[str]
+        :param row: row list
+        :type row: list[str]
+        :return: service and service dictionary
+        :rtype: tuple
+        """
+        service_dict: defaultdict[str, Any] = defaultdict(OrderedDict)
+        service = row[SERVICE_COLUMN_INDEX]
+        for column_index in range(VERSION_START_COLUMN_INDEX, len(row), 2):
+            os_version, _ = header[column_index].split("-")
+            lower = row[column_index]
+            upper = row[column_index + 1]
+            service_dict[os_version] = VersionRange(lower, upper)
+        return service, service_dict
+
+    @classmethod
+    def lookup(cls, component: str, version: str) -> List[OpenStackRelease]:
+        """Get the compatible OpenStack codenames based on the component and version.
+
+        :param component: Name of the component. E.g: "keystone"
+        :type component: str
+        :param version: Version of the component. E.g: "17.0.2"
+        :type version: str
+        :return: Return a sorted list of compatible OpenStack codenames.
+        :rtype: List[str]
+        """
+        if not cls._OPENSTACK_LOOKUP:
+            cls._OPENSTACK_LOOKUP = cls._generate_lookup(cls._DEFAULT_CSV_FILE)
+        compatible_os_releases: List[OpenStackRelease] = []
+        if not cls._OPENSTACK_LOOKUP.get(component):
+            logger.warning(
+                "Not possible to find the component %s in the lookup",
+                component,
+            )
+            return compatible_os_releases
+        for openstack_release, version_range in cls._OPENSTACK_LOOKUP[component].items():
+            if version in version_range:
+                compatible_os_releases.append(OpenStackRelease(openstack_release))
+        return compatible_os_releases

--- a/cou/utils/openstack.py
+++ b/cou/utils/openstack.py
@@ -250,16 +250,12 @@ class OpenStackRelease:
         :raises ValueError: Raises ValueError if OpenStack codename is unknown.
         """
         self.os_release = os_release
-        try:
-            self.index = self.openstack_codenames.index(os_release)
-        except ValueError as exc:
-            raise ValueError(
-                f"OpenStack '{os_release}' is not in '{self.openstack_codenames}'"
-            ) from exc
+        self.index = self.openstack_codenames.index(os_release)
 
     def __eq__(self, other):
         """Do equals."""
-        assert isinstance(other, (str, self.__class__))
+        if not isinstance(other, (str, OpenStackRelease)):
+            return NotImplemented
         return self.index == self.openstack_codenames.index(other)
 
     def __ne__(self, other):
@@ -268,7 +264,8 @@ class OpenStackRelease:
 
     def __lt__(self, other):
         """Do less than."""
-        assert isinstance(other, (str, self.__class__))
+        if not isinstance(other, (str, OpenStackRelease)):
+            return NotImplemented
         return self.index < self.openstack_codenames.index(other)
 
     def __ge__(self, other):
@@ -277,7 +274,8 @@ class OpenStackRelease:
 
     def __gt__(self, other):
         """Do greater than."""
-        assert isinstance(other, (str, self.__class__))
+        if not isinstance(other, (str, OpenStackRelease)):
+            return NotImplemented
         return self.index > self.openstack_codenames.index(other)
 
     def __le__(self, other):
@@ -286,7 +284,28 @@ class OpenStackRelease:
 
     def __repr__(self):
         """Return the representation of CompareOpenStack."""
-        return f"{self.__class__.__name__}<{self.openstack_codenames[self.index]}>"
+        return f"{self.__class__.__name__}<{self.os_release}>"
+
+    @property
+    def os_release(self) -> str:
+        """Return the next OpenStack release codename.
+
+        :return: OpenStack release codename.
+        :rtype: str
+        """
+        return self._os_release
+
+    @os_release.setter
+    def os_release(self, value: str):
+        """Setter of OpenStack release codename.
+
+        :param value: OpenStack release codename.
+        :type value: str
+        :raises ValueError: Raise ValueError if codename is unknown.
+        """
+        if value not in self.openstack_codenames:
+            raise ValueError(f"OpenStack '{value}' is not in '{self.openstack_codenames}'")
+        self._os_release = value
 
     @property
     def next_release(self) -> str:
@@ -298,7 +317,7 @@ class OpenStackRelease:
         try:
             os_release = self.openstack_codenames[self.index + 1]
         except IndexError:
-            logger.warning("There are no OpenStack release after %s", self.os_release)
+            logger.warning("There is no OpenStack release after %s", self.os_release)
             os_release = self.openstack_codenames[self.index]
         return os_release
 

--- a/cou/utils/openstack.py
+++ b/cou/utils/openstack.py
@@ -20,7 +20,7 @@ import logging
 from collections import OrderedDict, defaultdict
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, List, Optional, Tuple
+from typing import Any, List, Tuple
 
 from packaging.version import Version
 
@@ -87,30 +87,31 @@ UPGRADE_ORDER = [
 
 OPENSTACK_CODENAMES = OrderedDict(
     [
-        ("2011.2", "diablo"),
-        ("2012.1", "essex"),
-        ("2012.2", "folsom"),
-        ("2013.1", "grizzly"),
-        ("2013.2", "havana"),
-        ("2014.1", "icehouse"),
-        ("2014.2", "juno"),
-        ("2015.1", "kilo"),
-        ("2015.2", "liberty"),
-        ("2016.1", "mitaka"),
-        ("2016.2", "newton"),
-        ("2017.1", "ocata"),
-        ("2017.2", "pike"),
-        ("2018.1", "queens"),
-        ("2018.2", "rocky"),
-        ("2019.1", "stein"),
-        ("2019.2", "train"),
-        ("2020.1", "ussuri"),
-        ("2020.2", "victoria"),
-        ("2021.1", "wallaby"),
-        ("2021.2", "xena"),
-        ("2022.1", "yoga"),
-        ("2022.2", "zed"),
-        ("2023.1", "antelope"),
+        ("diablo", "2011.2"),
+        ("essex", "2012.1"),
+        ("folsom", "2012.2"),
+        ("grizzly", "2013.1"),
+        ("havana", "2013.2"),
+        ("icehouse", "2014.1"),
+        ("juno", "2014.2"),
+        ("kilo", "2015.1"),
+        ("liberty", "2015.2"),
+        ("mitaka", "2016.1"),
+        ("newton", "2016.2"),
+        ("ocata", "2017.1"),
+        ("pike", "2017.2"),
+        ("queens", "2018.1"),
+        ("rocky", "2018.2"),
+        ("stein", "2019.1"),
+        ("train", "2019.2"),
+        ("ussuri", "2020.1"),
+        ("victoria", "2020.2"),
+        ("wallaby", "2021.1"),
+        ("xena", "2021.2"),
+        ("yoga", "2022.1"),
+        ("zed", "2022.2"),
+        ("antelope", "2023.1"),
+        ("bobcat", "2023.2"),
     ]
 )
 
@@ -230,23 +231,7 @@ class OpenStackCodenameLookup:
         return compatible_os_releases
 
 
-def determine_next_openstack_release(release: str) -> Tuple[str, str]:
-    """Determine the next release after the one passed as a str.
-
-    The returned value is a tuple of the form: ('2020.1', 'ussuri')
-
-    :param release: the release to use as the base
-    :type release: str
-    :returns: the release tuple immediately after the current one.
-    :rtype: Tuple[str, str]
-    :raises: ValueError if the current release doesn't actually exist
-    """
-    old_index = list(OPENSTACK_CODENAMES.values()).index(release)
-    new_index = old_index + 1
-    return list(OPENSTACK_CODENAMES.items())[new_index]
-
-
-class BasicStringComparator:
+class OpenStackRelease:
     """Provides a class that will compare strings from an iterator type object.
 
     Used to provide > and < comparisons on strings that may not necessarily be
@@ -254,21 +239,28 @@ class BasicStringComparator:
     z-wrap.
     """
 
-    _list: Optional[List] = None
+    openstack_codenames = list(OPENSTACK_CODENAMES.keys())
+    openstack_release_year = list(OPENSTACK_CODENAMES.values())
 
-    def __init__(self, item):
-        """Do init."""
-        if self._list is None:
-            raise ValueError("Must define the _list in the class definition!")
+    def __init__(self, os_release: str):
+        """Initialize the OpenStackRelease object.
+
+        :param os_release: OpenStack release codename.
+        :type os_release: str
+        :raises ValueError: Raises ValueError if OpenStack codename is unknown.
+        """
+        self.os_release = os_release
         try:
-            self.index = self._list.index(item)
+            self.index = self.openstack_codenames.index(os_release)
         except ValueError as exc:
-            raise ValueError(f"Item '{item}' is not in list '{self._list}'") from exc
+            raise ValueError(
+                f"OpenStack '{os_release}' is not in '{self.openstack_codenames}'"
+            ) from exc
 
     def __eq__(self, other):
         """Do equals."""
         assert isinstance(other, (str, self.__class__))
-        return self.index == self._list.index(other)
+        return self.index == self.openstack_codenames.index(other)
 
     def __ne__(self, other):
         """Do not equals."""
@@ -277,7 +269,7 @@ class BasicStringComparator:
     def __lt__(self, other):
         """Do less than."""
         assert isinstance(other, (str, self.__class__))
-        return self.index < self._list.index(other)
+        return self.index < self.openstack_codenames.index(other)
 
     def __ge__(self, other):
         """Do greater than or equal."""
@@ -286,7 +278,7 @@ class BasicStringComparator:
     def __gt__(self, other):
         """Do greater than."""
         assert isinstance(other, (str, self.__class__))
-        return self.index > self._list.index(other)
+        return self.index > self.openstack_codenames.index(other)
 
     def __le__(self, other):
         """Do less than or equals."""
@@ -294,32 +286,41 @@ class BasicStringComparator:
 
     def __repr__(self):
         """Return the representation of CompareOpenStack."""
-        # pylint: disable=unsubscriptable-object
-        return f"{self.__class__.__name__}<{self._list[self.index]}>"
+        return f"{self.__class__.__name__}<{self.openstack_codenames[self.index]}>"
 
-    def __str__(self):
+    @property
+    def next_release(self) -> str:
+        """Return the next OpenStack release codename.
+
+        :return: OpenStack release codename.
+        :rtype: str
+        """
+        try:
+            os_release = self.openstack_codenames[self.index + 1]
+        except IndexError:
+            logger.warning("There are no OpenStack release after %s", self.os_release)
+            os_release = self.openstack_codenames[self.index]
+        return os_release
+
+    @property
+    def release_year(self) -> str:
+        """Release year of the OpenStack release.
+
+        :return: Release year.
+        :rtype: str
+        """
+        return self.openstack_release_year[self.index]
+
+    def __str__(self) -> str:
         """Give back the item at the index.
 
         This is so it can be used in comparisons like:
 
-        s_mitaka = CompareOpenStack('mitaka')
-        s_newton = CompareOpenstack('newton')
+        s_mitaka = OpenStackRelease('mitaka')
+        s_newton = OpenStackRelease('newton')
 
         assert s_newton > s_mitaka
 
         :returns: <string>
         """
-        # pylint: disable=unsubscriptable-object
-        return self._list[self.index]
-
-
-class CompareOpenStack(BasicStringComparator):
-    """Provide comparisons of OpenStack releases.
-
-    Use in the form of
-
-    if CompareOpenStack(release) > 'yoga':
-        # do something
-    """
-
-    _list = list(OPENSTACK_CODENAMES.values())
+        return self.os_release

--- a/cou/utils/openstack.py
+++ b/cou/utils/openstack.py
@@ -164,8 +164,8 @@ class OpenStackRelease:
         return f"{self.__class__.__name__}<{self.os_release}>"
 
     @property
-    def os_release(self) -> str:
-        """Return the next OpenStack release codename.
+    def codename(self) -> str:
+        """Return the OpenStack release codename.
 
         :return: OpenStack release codename.
         :rtype: str
@@ -200,7 +200,7 @@ class OpenStackRelease:
         return os_release
 
     @property
-    def release_year(self) -> str:
+    def date(self) -> str:
         """Release year of the OpenStack release.
 
         :return: Release year.

--- a/cou/utils/openstack.py
+++ b/cou/utils/openstack.py
@@ -229,7 +229,6 @@ class OpenStackRelease:
         :raises ValueError: Raises ValueError if OpenStack codename is unknown.
         """
         self.os_release = os_release
-        self.index = self.openstack_codenames.index(os_release)
 
     def __eq__(self, other):
         """Do equals."""
@@ -285,6 +284,7 @@ class OpenStackRelease:
         if value not in self.openstack_codenames:
             raise ValueError(f"OpenStack '{value}' is not in '{self.openstack_codenames}'")
         self._os_release = value
+        self.index = self.openstack_codenames.index(value)
 
     @property
     def next_release(self) -> str:

--- a/cou/utils/openstack.py
+++ b/cou/utils/openstack.py
@@ -20,7 +20,7 @@ import logging
 from collections import OrderedDict, defaultdict
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, List, Tuple
+from typing import Any, List, Optional, Tuple
 
 from packaging.version import Version
 
@@ -36,6 +36,88 @@ CHARM_TYPES = {
     "neutron": ["neutron-api", "neutron-gateway"],
     "manila": ["manila-ganesha"],
     "horizon": ["openstack-dashboard"],
+}
+
+# list of charms that the workload version can match more than one OpenStack release
+SPECIAL_CHARMS = [
+    "ceph-mon",
+    "ceph-fs",
+    "ceph-radosgw",
+    "ceph-osd",
+    "ovn-dedicated-chassis",
+    "ovn-central",
+    "mysql",
+    "hacluster",
+    "rabbitmq-server",
+    "vault",
+    "designate-bind",
+]
+
+# https://docs.openstack.org/charm-guide/latest/admin/upgrades/openstack.html#list-the-upgrade-order
+UPGRADE_ORDER = [
+    "rabbitmq-server",
+    "ceph-mon",
+    "keystone",
+    "aodh",
+    "barbican",
+    "ceilometer",
+    "ceph-fs",
+    "ceph-radosgw",
+    "cinder",
+    "designate",
+    "designate-bind",
+    "glance",
+    "gnocchi",
+    "heat",
+    "manila",
+    "manila-ganesha",
+    "neutron-api",
+    "neutron-gateway",
+    "ovn-central",
+    "ovn-dedicated-chassis",
+    "placement",
+    "nova-cloud-controller",
+    "nova-compute",
+    "openstack-dashboard",
+    "ceph-osd",
+    "swift-proxy",
+    "swift-storage",
+    "octavia",
+]
+
+OPENSTACK_CODENAMES = OrderedDict(
+    [
+        ("2011.2", "diablo"),
+        ("2012.1", "essex"),
+        ("2012.2", "folsom"),
+        ("2013.1", "grizzly"),
+        ("2013.2", "havana"),
+        ("2014.1", "icehouse"),
+        ("2014.2", "juno"),
+        ("2015.1", "kilo"),
+        ("2015.2", "liberty"),
+        ("2016.1", "mitaka"),
+        ("2016.2", "newton"),
+        ("2017.1", "ocata"),
+        ("2017.2", "pike"),
+        ("2018.1", "queens"),
+        ("2018.2", "rocky"),
+        ("2019.1", "stein"),
+        ("2019.2", "train"),
+        ("2020.1", "ussuri"),
+        ("2020.2", "victoria"),
+        ("2021.1", "wallaby"),
+        ("2021.2", "xena"),
+        ("2022.1", "yoga"),
+        ("2022.2", "zed"),
+        ("2023.1", "antelope"),
+    ]
+)
+
+LTS_SERIES = {
+    "bionic": "queens",
+    "focal": "ussuri",
+    "jammy": "yoga",
 }
 
 
@@ -146,3 +228,98 @@ class OpenStackCodenameLookup:
             if version in version_range:
                 compatible_os_releases.append(openstack_release)
         return compatible_os_releases
+
+
+def determine_next_openstack_release(release: str) -> Tuple[str, str]:
+    """Determine the next release after the one passed as a str.
+
+    The returned value is a tuple of the form: ('2020.1', 'ussuri')
+
+    :param release: the release to use as the base
+    :type release: str
+    :returns: the release tuple immediately after the current one.
+    :rtype: Tuple[str, str]
+    :raises: ValueError if the current release doesn't actually exist
+    """
+    old_index = list(OPENSTACK_CODENAMES.values()).index(release)
+    new_index = old_index + 1
+    return list(OPENSTACK_CODENAMES.items())[new_index]
+
+
+class BasicStringComparator:
+    """Provides a class that will compare strings from an iterator type object.
+
+    Used to provide > and < comparisons on strings that may not necessarily be
+    alphanumerically ordered.  e.g. OpenStack or Ubuntu releases AFTER the
+    z-wrap.
+    """
+
+    _list: Optional[List] = None
+
+    def __init__(self, item):
+        """Do init."""
+        if self._list is None:
+            raise ValueError("Must define the _list in the class definition!")
+        try:
+            self.index = self._list.index(item)
+        except ValueError as exc:
+            raise ValueError(f"Item '{item}' is not in list '{self._list}'") from exc
+
+    def __eq__(self, other):
+        """Do equals."""
+        assert isinstance(other, (str, self.__class__))
+        return self.index == self._list.index(other)
+
+    def __ne__(self, other):
+        """Do not equals."""
+        return not self.__eq__(other)
+
+    def __lt__(self, other):
+        """Do less than."""
+        assert isinstance(other, (str, self.__class__))
+        return self.index < self._list.index(other)
+
+    def __ge__(self, other):
+        """Do greater than or equal."""
+        return not self.__lt__(other)
+
+    def __gt__(self, other):
+        """Do greater than."""
+        assert isinstance(other, (str, self.__class__))
+        return self.index > self._list.index(other)
+
+    def __le__(self, other):
+        """Do less than or equals."""
+        return not self.__gt__(other)
+
+    def __repr__(self):
+        """Return the representation of CompareOpenStack."""
+        # pylint: disable=unsubscriptable-object
+        return f"{self.__class__.__name__}<{self._list[self.index]}>"
+
+    def __str__(self):
+        """Give back the item at the index.
+
+        This is so it can be used in comparisons like:
+
+        s_mitaka = CompareOpenStack('mitaka')
+        s_newton = CompareOpenstack('newton')
+
+        assert s_newton > s_mitaka
+
+        :returns: <string>
+        """
+        # pylint: disable=unsubscriptable-object
+        return self._list[self.index]
+
+
+class CompareOpenStack(BasicStringComparator):
+    """Provide comparisons of OpenStack releases.
+
+    Use in the form of
+
+    if CompareOpenStack(release) > 'yoga':
+        # do something
+    """
+
+    _list = list(OPENSTACK_CODENAMES.values())

--- a/tests/unit/apps/test_app.py
+++ b/tests/unit/apps/test_app.py
@@ -47,7 +47,6 @@ def assert_application(
     exp_units,
     exp_channel,
     exp_current_os_release,
-    exp_next_os_release=None,
 ):
     assert app.name == exp_name
     assert app.series == exp_series
@@ -60,8 +59,6 @@ def assert_application(
     assert app.units == exp_units
     assert app.channel == exp_channel
     assert app.current_os_release == exp_current_os_release
-    if exp_next_os_release:
-        assert app.current_os_release.next_release == exp_next_os_release
 
 
 def test_application_ussuri(status, config, units):
@@ -73,7 +70,6 @@ def test_application_ussuri(status, config, units):
     exp_channel = app_status.charm_channel
     exp_series = app_status.series
     exp_current_os_release = "ussuri"
-    exp_next_os_release = "victoria"
 
     app = Application("my_keystone", app_status, app_config, "my_model")
     assert_application(
@@ -89,7 +85,6 @@ def test_application_ussuri(status, config, units):
         exp_units,
         exp_channel,
         exp_current_os_release,
-        exp_next_os_release,
     )
 
 
@@ -120,7 +115,6 @@ def test_application_cs(status, config, units):
     exp_charm_origin = "cs"
     exp_series = app_status.series
     exp_current_os_release = "ussuri"
-    exp_next_os_release = "victoria"
 
     app = Application("my_keystone", app_status, app_config, "my_model")
     assert_application(
@@ -136,7 +130,6 @@ def test_application_cs(status, config, units):
         exp_units,
         exp_channel,
         exp_current_os_release,
-        exp_next_os_release,
     )
 
 
@@ -149,7 +142,6 @@ def test_application_wallaby(status, config, units):
     exp_channel = app_status.charm_channel
     exp_series = app_status.series
     exp_current_os_release = "wallaby"
-    exp_next_os_release = "xena"
 
     app = Application("my_keystone", app_status, app_config, "my_model")
     assert_application(
@@ -165,7 +157,6 @@ def test_application_wallaby(status, config, units):
         exp_units,
         exp_channel,
         exp_current_os_release,
-        exp_next_os_release,
     )
 
 

--- a/tests/unit/apps/test_app.py
+++ b/tests/unit/apps/test_app.py
@@ -34,6 +34,7 @@ def test_application_eq(status, config):
 def assert_application(
     app,
     exp_name,
+    exp_series,
     exp_status,
     exp_config,
     exp_model,
@@ -42,8 +43,12 @@ def assert_application(
     exp_os_origin,
     exp_units,
     exp_channel,
+    exp_current_os_release,
+    exp_next_os_release,
+    exp_os_versions,
 ):
     assert app.name == exp_name
+    assert app.series == exp_series
     assert app.status == exp_status
     assert app.config == exp_config
     assert app.model_name == exp_model
@@ -52,6 +57,9 @@ def assert_application(
     assert app.os_origin == exp_os_origin
     assert app.units == exp_units
     assert app.channel == exp_channel
+    assert app.current_os_release == exp_current_os_release
+    assert app.next_os_release == exp_next_os_release
+    assert app.os_versions == exp_os_versions
 
 
 def test_application_ussuri(status, config, units):
@@ -61,11 +69,16 @@ def test_application_ussuri(status, config, units):
     exp_os_origin = "distro"
     exp_units = units["units_ussuri"]
     exp_channel = app_status.charm_channel
+    exp_series = app_status.series
+    exp_current_os_release = "ussuri"
+    exp_next_os_release = "victoria"
+    exp_os_versions = {"ussuri"}
 
     app = Application("my_keystone", app_status, app_config, "my_model")
     assert_application(
         app,
         "my_keystone",
+        exp_series,
         app_status,
         app_config,
         "my_model",
@@ -74,6 +87,9 @@ def test_application_ussuri(status, config, units):
         exp_os_origin,
         exp_units,
         exp_channel,
+        exp_current_os_release,
+        exp_next_os_release,
+        exp_os_versions,
     )
 
 
@@ -85,6 +101,10 @@ def test_application_different_wl(status, config, units, mocker):
     exp_os_origin = "distro"
     exp_units = units["units_ussuri"]
     exp_channel = app_status.charm_channel
+    exp_series = app_status.series
+    exp_current_os_release = ""
+    exp_next_os_release = ""
+    exp_os_versions = {"ussuri", "victoria"}
 
     mock_unit_2 = mocker.MagicMock()
     mock_unit_2.workload_version = "18.1.0"
@@ -96,6 +116,7 @@ def test_application_different_wl(status, config, units, mocker):
     assert_application(
         app,
         "my_keystone",
+        exp_series,
         app_status,
         app_config,
         "my_model",
@@ -104,6 +125,9 @@ def test_application_different_wl(status, config, units, mocker):
         exp_os_origin,
         exp_units,
         exp_channel,
+        exp_current_os_release,
+        exp_next_os_release,
+        exp_os_versions,
     )
 
 
@@ -115,11 +139,16 @@ def test_application_cs(status, config, units):
     exp_units = units["units_ussuri"]
     exp_channel = app_status.charm_channel
     exp_charm_origin = "cs"
+    exp_series = app_status.series
+    exp_current_os_release = "ussuri"
+    exp_next_os_release = "victoria"
+    exp_os_versions = {"ussuri"}
 
     app = Application("my_keystone", app_status, app_config, "my_model")
     assert_application(
         app,
         "my_keystone",
+        exp_series,
         app_status,
         app_config,
         "my_model",
@@ -128,6 +157,9 @@ def test_application_cs(status, config, units):
         exp_os_origin,
         exp_units,
         exp_channel,
+        exp_current_os_release,
+        exp_next_os_release,
+        exp_os_versions,
     )
 
 
@@ -138,11 +170,16 @@ def test_application_wallaby(status, config, units):
     app_status = status["keystone_wallaby"]
     exp_os_origin = "cloud:focal-wallaby"
     exp_channel = app_status.charm_channel
+    exp_series = app_status.series
+    exp_current_os_release = "wallaby"
+    exp_next_os_release = "xena"
+    exp_os_versions = {"wallaby"}
 
     app = Application("my_keystone", app_status, app_config, "my_model")
     assert_application(
         app,
         "my_keystone",
+        exp_series,
         app_status,
         app_config,
         "my_model",
@@ -151,6 +188,9 @@ def test_application_wallaby(status, config, units):
         exp_os_origin,
         exp_units,
         exp_channel,
+        exp_current_os_release,
+        exp_next_os_release,
+        exp_os_versions,
     )
 
 

--- a/tests/unit/apps/test_app.py
+++ b/tests/unit/apps/test_app.py
@@ -9,9 +9,12 @@
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 
+import pytest
+
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 from cou.apps.app import Application
+from cou.exceptions import MismatchedOpenStackVersions
 
 
 def test_application_eq(status, config):
@@ -94,36 +97,17 @@ def test_application_different_wl(status, config, units, mocker):
     """Different OpenStack Version on units if workload version is different."""
     app_status = status["keystone_ussuri"]
     app_config = config["openstack_ussuri"]
-    exp_charm_origin = "ch"
-    exp_os_origin = "distro"
-    exp_units = units["units_ussuri"]
-    exp_channel = app_status.charm_channel
-    exp_series = app_status.series
-    exp_current_os_release = None
-    exp_next_os_release = None
 
     mock_unit_2 = mocker.MagicMock()
     mock_unit_2.workload_version = "18.1.0"
     app_status.units["keystone/2"] = mock_unit_2
-    exp_units["keystone/2"]["os_version"] = "victoria"
-    exp_units["keystone/2"]["workload_version"] = "18.1.0"
+
+    mock_logger = mocker.patch("cou.apps.app.logger")
 
     app = Application("my_keystone", app_status, app_config, "my_model")
-    assert_application(
-        app,
-        "my_keystone",
-        exp_series,
-        app_status,
-        app_config,
-        "my_model",
-        "keystone",
-        exp_charm_origin,
-        exp_os_origin,
-        exp_units,
-        exp_channel,
-        exp_current_os_release,
-        exp_next_os_release,
-    )
+    with pytest.raises(MismatchedOpenStackVersions):
+        app.current_os_release
+        mock_logger.error.assert_called_once
 
 
 def test_application_cs(status, config, units):
@@ -185,6 +169,14 @@ def test_application_wallaby(status, config, units):
     )
 
 
+def test_application_subordinate(status):
+    app_status = status["mysql_router"]
+    app_config = {"source": {"value": "distro"}}
+    app = Application("mysql_router", app_status, app_config, "my_model")
+    assert app.current_os_release is None
+    assert app.units == {}
+
+
 def test_special_app_more_than_one_compatible_os_release(status, config):
     # version 3.8 on rabbitmq can be from ussuri to yoga. In that case it will be set as yoga.
     expected_units = {"rabbitmq-server/0": {"os_version": "yoga", "workload_version": "3.8"}}
@@ -194,8 +186,9 @@ def test_special_app_more_than_one_compatible_os_release(status, config):
     assert app.units == expected_units
 
 
-def test_special_app_unknown_version(status, config):
-    expected_units = {"rabbitmq-server/0": {"os_version": "", "workload_version": "80.5"}}
+def test_special_app_unknown_version(status, config, mocker):
+    expected_units = {"rabbitmq-server/0": {"os_version": None, "workload_version": "80.5"}}
+    mock_logger = mocker.patch("cou.apps.app.logger")
     app = Application(
         "rabbitmq-server",
         status["unknown_rabbitmq_server"],
@@ -203,6 +196,11 @@ def test_special_app_unknown_version(status, config):
         "my_model",
     )
     assert app.units == expected_units
+    mock_logger.warning.assert_called_once_with(
+        "No compatible OpenStack versions were found to %s with workload version %s",
+        "rabbitmq-server",
+        "80.5",
+    )
 
 
 def test_application_no_openstack_origin(status):

--- a/tests/unit/apps/test_app.py
+++ b/tests/unit/apps/test_app.py
@@ -44,8 +44,7 @@ def assert_application(
     exp_units,
     exp_channel,
     exp_current_os_release,
-    exp_next_os_release,
-    exp_os_versions,
+    exp_next_os_release=None,
 ):
     assert app.name == exp_name
     assert app.series == exp_series
@@ -58,8 +57,8 @@ def assert_application(
     assert app.units == exp_units
     assert app.channel == exp_channel
     assert app.current_os_release == exp_current_os_release
-    assert app.next_os_release == exp_next_os_release
-    assert app.os_versions == exp_os_versions
+    if exp_next_os_release:
+        assert app.current_os_release.next_release == exp_next_os_release
 
 
 def test_application_ussuri(status, config, units):
@@ -72,7 +71,6 @@ def test_application_ussuri(status, config, units):
     exp_series = app_status.series
     exp_current_os_release = "ussuri"
     exp_next_os_release = "victoria"
-    exp_os_versions = {"ussuri"}
 
     app = Application("my_keystone", app_status, app_config, "my_model")
     assert_application(
@@ -89,7 +87,6 @@ def test_application_ussuri(status, config, units):
         exp_channel,
         exp_current_os_release,
         exp_next_os_release,
-        exp_os_versions,
     )
 
 
@@ -102,9 +99,8 @@ def test_application_different_wl(status, config, units, mocker):
     exp_units = units["units_ussuri"]
     exp_channel = app_status.charm_channel
     exp_series = app_status.series
-    exp_current_os_release = ""
-    exp_next_os_release = ""
-    exp_os_versions = {"ussuri", "victoria"}
+    exp_current_os_release = None
+    exp_next_os_release = None
 
     mock_unit_2 = mocker.MagicMock()
     mock_unit_2.workload_version = "18.1.0"
@@ -127,7 +123,6 @@ def test_application_different_wl(status, config, units, mocker):
         exp_channel,
         exp_current_os_release,
         exp_next_os_release,
-        exp_os_versions,
     )
 
 
@@ -142,7 +137,6 @@ def test_application_cs(status, config, units):
     exp_series = app_status.series
     exp_current_os_release = "ussuri"
     exp_next_os_release = "victoria"
-    exp_os_versions = {"ussuri"}
 
     app = Application("my_keystone", app_status, app_config, "my_model")
     assert_application(
@@ -159,7 +153,6 @@ def test_application_cs(status, config, units):
         exp_channel,
         exp_current_os_release,
         exp_next_os_release,
-        exp_os_versions,
     )
 
 
@@ -173,7 +166,6 @@ def test_application_wallaby(status, config, units):
     exp_series = app_status.series
     exp_current_os_release = "wallaby"
     exp_next_os_release = "xena"
-    exp_os_versions = {"wallaby"}
 
     app = Application("my_keystone", app_status, app_config, "my_model")
     assert_application(
@@ -190,7 +182,6 @@ def test_application_wallaby(status, config, units):
         exp_channel,
         exp_current_os_release,
         exp_next_os_release,
-        exp_os_versions,
     )
 
 

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -147,6 +147,7 @@ def units():
 @pytest.fixture
 def apps(status, config):
     keystone_ussuri_status = status["keystone_ussuri"]
+    keystone_wallaby_status = status["keystone_wallaby"]
     cinder_ussuri_status = status["cinder_ussuri"]
     rmq_status = status["rabbitmq_server"]
     mysql_router_status = status["mysql_router"]
@@ -154,6 +155,9 @@ def apps(status, config):
 
     keystone_ussuri = Application(
         "keystone", keystone_ussuri_status, config["openstack_ussuri"], "my_model"
+    )
+    keystone_wallaby = Application(
+        "keystone", keystone_wallaby_status, config["openstack_wallaby"], "my_model"
     )
     cinder_ussuri = Application(
         "cinder", cinder_ussuri_status, config["openstack_ussuri"], "my_model"
@@ -167,6 +171,7 @@ def apps(status, config):
 
     return {
         "keystone_ussuri": keystone_ussuri,
+        "keystone_wallaby": keystone_wallaby,
         "cinder_ussuri": cinder_ussuri,
         "rmq_ussuri": rmq_ussuri,
         "rmq_wallaby": rmq_wallaby,

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -91,6 +91,13 @@ def status():
     mock_rmq_unknown.charm = "ch:amd64/focal/rabbitmq-server-638"
     mock_rmq_unknown.units = OrderedDict([("rabbitmq-server/0", mock_units_unknown_rmq)])
 
+    mock_unknown_app = mock.MagicMock()
+    mock_units_unknown_app = mock.MagicMock()
+    mock_unknown_app.charm_channel = "12.5/stable"
+    mock_units_unknown_app.workload_version = "12.5"
+    mock_unknown_app.charm = "ch:amd64/focal/my-app-638"
+    mock_unknown_app.units = OrderedDict([("my-app/0", mock_units_unknown_app)])
+
     status = {
         "keystone_ussuri": mock_keystone_ussuri,
         "cinder_ussuri": mock_cinder_ussuri,
@@ -98,6 +105,7 @@ def status():
         "unknown_rabbitmq_server": mock_rmq_unknown,
         "keystone_ussuri_cs": mock_keystone_ussuri_cs,
         "keystone_wallaby": mock_keystone_wallaby,
+        "unknown_app": mock_unknown_app,
     }
     return status
 
@@ -111,6 +119,7 @@ def full_status(status):
             ("keystone", status["keystone_ussuri"]),
             ("cinder", status["cinder_ussuri"]),
             ("rabbitmq_server", status["rabbitmq_server"]),
+            ("my_app", status["unknown_app"]),
         ]
     )
     return mock_full_status

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -23,6 +23,7 @@ from cou.apps.app import Application
 @pytest.fixture
 def status():
     mock_keystone_ussuri = mock.MagicMock()
+    mock_keystone_ussuri.series = "focal"
     mock_keystone_ussuri.charm_channel = "ussuri/stable"
     mock_keystone_ussuri.charm = "ch:amd64/focal/keystone-638"
     mock_units_keystone_ussuri = mock.MagicMock()
@@ -36,6 +37,7 @@ def status():
     )
 
     mock_cinder_ussuri = mock.MagicMock()
+    mock_cinder_ussuri.series = "focal"
     mock_cinder_ussuri.charm_channel = "ussuri/stable"
     mock_cinder_ussuri.charm = "ch:amd64/focal/cinder-633"
     mock_units_cinder_ussuri = mock.MagicMock()
@@ -49,6 +51,7 @@ def status():
     )
 
     mock_keystone_ussuri_cs = mock.MagicMock()
+    mock_keystone_ussuri_cs.series = "focal"
     mock_keystone_ussuri_cs.charm_channel = "ussuri/stable"
     mock_keystone_ussuri_cs.charm = "cs:amd64/focal/keystone-638"
     mock_keystone_ussuri_cs.units = OrderedDict(
@@ -60,6 +63,7 @@ def status():
     )
 
     mock_keystone_wallaby = mock.MagicMock()
+    mock_keystone_wallaby.series = "focal"
     mock_keystone_wallaby.charm_channel = "wallaby/stable"
     mock_keystone_wallaby.charm = "ch:amd64/focal/keystone-638"
     mock_units_keystone_wallaby = mock.MagicMock()
@@ -73,6 +77,7 @@ def status():
     )
 
     mock_rmq = mock.MagicMock()
+    mock_rmq.series = "focal"
     mock_units_rmq = mock.MagicMock()
     mock_rmq.charm_channel = "3.8/stable"
     mock_units_rmq.workload_version = "3.8"
@@ -125,13 +130,25 @@ def units():
 
 @pytest.fixture
 def apps(status, config):
-    keystone_status = status["keystone_ussuri"]
-    cinder_status = status["cinder_ussuri"]
-    app_config = config["openstack_ussuri"]
-    app_keystone = Application("keystone", keystone_status, app_config, "my_model")
-    app_cinder = Application("cinder", cinder_status, app_config, "my_model")
+    keystone_ussuri_status = status["keystone_ussuri"]
+    cinder_ussuri_status = status["cinder_ussuri"]
+    rmq_status = status["rabbitmq_server"]
 
-    return [app_keystone, app_cinder]
+    keystone_ussuri = Application(
+        "keystone", keystone_ussuri_status, config["openstack_ussuri"], "my_model"
+    )
+    cinder_ussuri = Application(
+        "cinder", cinder_ussuri_status, config["openstack_ussuri"], "my_model"
+    )
+    rmq_ussuri = Application("rabbitmq-server", rmq_status, config["rmq_ussuri"], "my_model")
+    rmq_wallaby = Application("rabbitmq-server", rmq_status, config["rmq_wallaby"], "my_model")
+
+    return {
+        "keystone_ussuri": keystone_ussuri,
+        "cinder_ussuri": cinder_ussuri,
+        "rmq_ussuri": rmq_ussuri,
+        "rmq_wallaby": rmq_wallaby,
+    }
 
 
 @pytest.fixture
@@ -141,4 +158,6 @@ def config():
             "openstack-origin": {"value": "distro"},
         },
         "openstack_wallaby": {"openstack-origin": {"value": "cloud:focal-wallaby"}},
+        "rmq_ussuri": {"source": {"value": "distro"}},
+        "rmq_wallaby": {"source": {"value": "cloud:focal-wallaby"}},
     }

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -98,6 +98,12 @@ def status():
     mock_unknown_app.charm = "ch:amd64/focal/my-app-638"
     mock_unknown_app.units = OrderedDict([("my-app/0", mock_units_unknown_app)])
 
+    # subordinate application
+    mock_mysql_router = mock.MagicMock()
+    mock_mysql_router.charm_channel = "8.0/stable"
+    mock_mysql_router.charm = "ch:amd64/focal/mysql-router-437"
+    mock_mysql_router.units = {}
+
     status = {
         "keystone_ussuri": mock_keystone_ussuri,
         "cinder_ussuri": mock_cinder_ussuri,
@@ -106,6 +112,7 @@ def status():
         "keystone_ussuri_cs": mock_keystone_ussuri_cs,
         "keystone_wallaby": mock_keystone_wallaby,
         "unknown_app": mock_unknown_app,
+        "mysql_router": mock_mysql_router,
     }
     return status
 
@@ -142,6 +149,8 @@ def apps(status, config):
     keystone_ussuri_status = status["keystone_ussuri"]
     cinder_ussuri_status = status["cinder_ussuri"]
     rmq_status = status["rabbitmq_server"]
+    mysql_router_status = status["mysql_router"]
+    no_openstack_status = status["unknown_app"]
 
     keystone_ussuri = Application(
         "keystone", keystone_ussuri_status, config["openstack_ussuri"], "my_model"
@@ -151,12 +160,18 @@ def apps(status, config):
     )
     rmq_ussuri = Application("rabbitmq-server", rmq_status, config["rmq_ussuri"], "my_model")
     rmq_wallaby = Application("rabbitmq-server", rmq_status, config["rmq_wallaby"], "my_model")
+    mysql_router_ussuri = Application(
+        "keystone-mysql-router", mysql_router_status, config["rmq_ussuri"], "my_model"
+    )
+    no_openstack = Application("my-app", no_openstack_status, {}, "my_model")
 
     return {
         "keystone_ussuri": keystone_ussuri,
         "cinder_ussuri": cinder_ussuri,
         "rmq_ussuri": rmq_ussuri,
         "rmq_wallaby": rmq_wallaby,
+        "mysql_router_ussuri": mysql_router_ussuri,
+        "no_openstack": no_openstack,
     }
 
 

--- a/tests/unit/steps/test_steps_analyze.py
+++ b/tests/unit/steps/test_steps_analyze.py
@@ -55,9 +55,24 @@ async def test_analysis_dump(mocker, apps):
         "    cinder/2:\n"
         "      workload_version: 16.4.2\n"
         "      os_version: ussuri\n"
+        "\n"
+        "rabbitmq-server:\n"
+        "  model_name: my_model\n"
+        "  charm: rabbitmq-server\n"
+        "  charm_origin: ch\n"
+        "  os_origin: distro\n"
+        "  channel: 3.8/stable\n"
+        "  units:\n"
+        "    rabbitmq-server/0:\n"
+        "      workload_version: '3.8'\n"
+        "      os_version: yoga\n"
     )
 
-    mocker.patch.object(analyze.Analysis, "_populate", return_value=apps)
+    mocker.patch.object(
+        analyze.Analysis,
+        "_populate",
+        return_value=[apps["keystone_ussuri"], apps["cinder_ussuri"], apps["rmq_ussuri"]],
+    )
     result = await analyze.Analysis.create()
     assert str(result) == expected_result
 
@@ -76,10 +91,47 @@ async def test_generate_model(mocker, full_status, config):
 
 
 @pytest.mark.asyncio
-async def test_analysis(mocker, apps):
-    """Test analysis function."""
-    expected_result = analyze.Analysis(apps=apps)
-    mocker.patch.object(analyze.Analysis, "_populate", return_value=apps)
+async def test_analysis_add_special_charm(mocker, apps):
+    """Test analysis object that adds special charm."""
+    app_keystone = apps["keystone_ussuri"]
+    app_cinder = apps["cinder_ussuri"]
+    app_rmq = apps["rmq_ussuri"]
+    expected_result = analyze.Analysis(apps=[app_keystone, app_cinder, app_rmq])
+    mocker.patch.object(
+        analyze.Analysis, "_populate", return_value=[app_keystone, app_cinder, app_rmq]
+    )
 
     result = await Analysis.create()
     assert result == expected_result
+    assert result.current_cloud_os_release == "ussuri"
+    assert result.next_cloud_os_release == "victoria"
+    # NOTE(gabrielcocenza) Although special charms, like rabbitmq, can have multiple OpenStack
+    # releases to a workload version, it's necessary to set the right source on the charm
+    # configuration. Rabbitmq with workload version 3.8, will always indicate that the application
+    # is on yoga. However, we should configure the source accordingly with the OpenStack version of
+    # the cloud. In this case, even that rabbitmq is theoretically on yoga, we should change the
+    # source to cloud:focal-victoria and that is why it's added on apps to upgrade.
+    assert result.os_versions == {"ussuri": {app_keystone, app_cinder}, "yoga": {app_rmq}}
+    # rabbitmq is included because source is configured as "distro" for ussuri.
+    assert result.apps_to_upgrade == [app_rmq, app_keystone, app_cinder]
+
+
+@pytest.mark.asyncio
+async def test_analysis_not_add_special_charms(mocker, apps):
+    """Test analysis object when special charms are configured for a higher OpenStack version."""
+    app_keystone = apps["keystone_ussuri"]
+    app_cinder = apps["cinder_ussuri"]
+    app_rmq = apps["rmq_wallaby"]
+    expected_result = analyze.Analysis(apps=[app_keystone, app_cinder, app_rmq])
+    mocker.patch.object(
+        analyze.Analysis, "_populate", return_value=[app_keystone, app_cinder, app_rmq]
+    )
+
+    result = await Analysis.create()
+    assert result == expected_result
+    assert result.current_cloud_os_release == "ussuri"
+    assert result.next_cloud_os_release == "victoria"
+    assert result.os_versions == {"ussuri": {app_keystone, app_cinder}, "yoga": {app_rmq}}
+    # rabbitmq is not included because source is configured for wallaby that is bigger than
+    # the cloud OpenStack Version that is on ussuri.
+    assert result.apps_to_upgrade == [app_keystone, app_cinder]

--- a/tests/unit/steps/test_steps_analyze.py
+++ b/tests/unit/steps/test_steps_analyze.py
@@ -110,7 +110,6 @@ async def test_analysis_add_special_charm(mocker, apps):
     # releases with workload version 3.8, the most recent version is considered and in this
     # case is yoga.
     assert result.os_versions == {
-        "ussuri": {app_keystone.charm, app_cinder.charm},
-        "yoga": {app_rmq.charm},
+        "ussuri": {app_keystone.name, app_cinder.name},
+        "yoga": {app_rmq.name},
     }
-    # rabbitmq is included because source is configured as "distro" for ussuri.

--- a/tests/unit/steps/test_steps_analyze.py
+++ b/tests/unit/steps/test_steps_analyze.py
@@ -78,17 +78,18 @@ async def test_analysis_dump(mocker, apps):
 
 
 @pytest.mark.asyncio
-async def test_generate_model(mocker, full_status, config):
+async def test_populate_model(mocker, full_status, config):
     mocker.patch.object(analyze, "async_get_status", return_value=full_status)
     mocker.patch.object(
         analyze, "async_get_application_config", return_value=config["openstack_ussuri"]
     )
-    # Initially, 3 applications are in the status (keystone, cinder and rabbitmq-server)
-    assert len(full_status.applications) == 3
+    # Initially, 4 applications are in the status: keystone, cinder, rabbitmq-server and my-app
+    # my-app is a unknown application in the model.
+    assert len(full_status.applications) == 4
     apps = await Analysis._populate()
-    assert len(apps) == 3
-    # apps are on the UPGRADE_ORDER sequence
-    assert [app.charm for app in apps] == ["rabbitmq-server", "keystone", "cinder"]
+    assert len(apps) == 4
+    # apps are on the UPGRADE_ORDER sequence and unknown in the end of the list
+    assert [app.charm for app in apps] == ["rabbitmq-server", "keystone", "cinder", "my-app"]
 
 
 @pytest.mark.asyncio

--- a/tests/unit/steps/test_steps_analyze.py
+++ b/tests/unit/steps/test_steps_analyze.py
@@ -84,7 +84,7 @@ async def test_populate_model(mocker, full_status, config):
         analyze, "async_get_application_config", return_value=config["openstack_ussuri"]
     )
     # Initially, 4 applications are in the status: keystone, cinder, rabbitmq-server and my-app
-    # my-app is a unknown application in the model.
+    # my-app is an unknown application in the model.
     assert len(full_status.applications) == 4
     apps = await Analysis._populate()
     assert len(apps) == 4

--- a/tests/unit/steps/test_steps_analyze.py
+++ b/tests/unit/steps/test_steps_analyze.py
@@ -92,8 +92,8 @@ async def test_generate_model(mocker, full_status, config):
 
 
 @pytest.mark.asyncio
-async def test_analysis_add_special_charm(mocker, apps):
-    """Test analysis object that adds special charm."""
+async def test_analysis(mocker, apps):
+    """Test analysis object."""
     app_keystone = apps["keystone_ussuri"]
     app_cinder = apps["cinder_ussuri"]
     app_rmq = apps["rmq_ussuri"]
@@ -105,11 +105,4 @@ async def test_analysis_add_special_charm(mocker, apps):
     result = await Analysis.create()
     assert result == expected_result
     assert result.current_cloud_os_release == "ussuri"
-    assert result.next_cloud_os_release == "victoria"
-    # NOTE(gabrielcocenza) Although special charms, like rabbitmq, can have multiple OpenStack
-    # releases with workload version 3.8, the most recent version is considered and in this
-    # case is yoga.
-    assert result.os_versions == {
-        "ussuri": {app_keystone.name, app_cinder.name},
-        "yoga": {app_rmq.name},
-    }
+    assert result.current_cloud_os_release.next_release == "victoria"

--- a/tests/unit/steps/test_steps_analyze.py
+++ b/tests/unit/steps/test_steps_analyze.py
@@ -87,7 +87,8 @@ async def test_generate_model(mocker, full_status, config):
     assert len(full_status.applications) == 3
     apps = await Analysis._populate()
     assert len(apps) == 3
-    assert {app.charm for app in apps} == {"keystone", "cinder", "rabbitmq-server"}
+    # apps are on the UPGRADE_ORDER sequence
+    assert [app.charm for app in apps] == ["rabbitmq-server", "keystone", "cinder"]
 
 
 @pytest.mark.asyncio
@@ -96,9 +97,9 @@ async def test_analysis_add_special_charm(mocker, apps):
     app_keystone = apps["keystone_ussuri"]
     app_cinder = apps["cinder_ussuri"]
     app_rmq = apps["rmq_ussuri"]
-    expected_result = analyze.Analysis(apps=[app_keystone, app_cinder, app_rmq])
+    expected_result = analyze.Analysis(apps=[app_rmq, app_keystone, app_cinder])
     mocker.patch.object(
-        analyze.Analysis, "_populate", return_value=[app_keystone, app_cinder, app_rmq]
+        analyze.Analysis, "_populate", return_value=[app_rmq, app_keystone, app_cinder]
     )
 
     result = await Analysis.create()
@@ -106,32 +107,10 @@ async def test_analysis_add_special_charm(mocker, apps):
     assert result.current_cloud_os_release == "ussuri"
     assert result.next_cloud_os_release == "victoria"
     # NOTE(gabrielcocenza) Although special charms, like rabbitmq, can have multiple OpenStack
-    # releases to a workload version, it's necessary to set the right source on the charm
-    # configuration. Rabbitmq with workload version 3.8, will always indicate that the application
-    # is on yoga. However, we should configure the source accordingly with the OpenStack version of
-    # the cloud. In this case, even that rabbitmq is theoretically on yoga, we should change the
-    # source to cloud:focal-victoria and that is why it's added on apps to upgrade.
-    assert result.os_versions == {"ussuri": {app_keystone, app_cinder}, "yoga": {app_rmq}}
+    # releases with workload version 3.8, the most recent version is considered and in this
+    # case is yoga.
+    assert result.os_versions == {
+        "ussuri": {app_keystone.charm, app_cinder.charm},
+        "yoga": {app_rmq.charm},
+    }
     # rabbitmq is included because source is configured as "distro" for ussuri.
-    assert result.apps_to_upgrade == [app_rmq, app_keystone, app_cinder]
-
-
-@pytest.mark.asyncio
-async def test_analysis_not_add_special_charms(mocker, apps):
-    """Test analysis object when special charms are configured for a higher OpenStack version."""
-    app_keystone = apps["keystone_ussuri"]
-    app_cinder = apps["cinder_ussuri"]
-    app_rmq = apps["rmq_wallaby"]
-    expected_result = analyze.Analysis(apps=[app_keystone, app_cinder, app_rmq])
-    mocker.patch.object(
-        analyze.Analysis, "_populate", return_value=[app_keystone, app_cinder, app_rmq]
-    )
-
-    result = await Analysis.create()
-    assert result == expected_result
-    assert result.current_cloud_os_release == "ussuri"
-    assert result.next_cloud_os_release == "victoria"
-    assert result.os_versions == {"ussuri": {app_keystone, app_cinder}, "yoga": {app_rmq}}
-    # rabbitmq is not included because source is configured for wallaby that is bigger than
-    # the cloud OpenStack Version that is on ussuri.
-    assert result.apps_to_upgrade == [app_keystone, app_cinder]

--- a/tests/unit/utils/test_openstack.py
+++ b/tests/unit/utils/test_openstack.py
@@ -13,13 +13,7 @@
 # limitations under the License.
 import pytest
 
-from cou.utils.openstack import (
-    BasicStringComparator,
-    CompareOpenStack,
-    OpenStackCodenameLookup,
-    VersionRange,
-    determine_next_openstack_release,
-)
+from cou.utils.openstack import OpenStackCodenameLookup, OpenStackRelease, VersionRange
 
 
 @pytest.mark.parametrize(
@@ -104,59 +98,53 @@ def test_generate_lookup(service):
 )
 def test_compare_openstack(release_1, release_2, comparison, expected_result):
     if comparison == "eq":
-        result = CompareOpenStack(release_1) == release_2
-        result_alternative = CompareOpenStack(release_1) == CompareOpenStack(release_2)
+        result = OpenStackRelease(release_1) == release_2
+        result_alternative = OpenStackRelease(release_1) == OpenStackRelease(release_2)
     elif comparison == "neq":
-        result = CompareOpenStack(release_1) != release_2
-        result_alternative = CompareOpenStack(release_1) != CompareOpenStack(release_2)
+        result = OpenStackRelease(release_1) != release_2
+        result_alternative = OpenStackRelease(release_1) != OpenStackRelease(release_2)
     elif comparison == "lt":
-        result = CompareOpenStack(release_1) < release_2
-        result_alternative = CompareOpenStack(release_1) < CompareOpenStack(release_2)
+        result = OpenStackRelease(release_1) < release_2
+        result_alternative = OpenStackRelease(release_1) < OpenStackRelease(release_2)
     elif comparison == "le":
-        result = CompareOpenStack(release_1) <= release_2
-        result_alternative = CompareOpenStack(release_1) <= CompareOpenStack(release_2)
+        result = OpenStackRelease(release_1) <= release_2
+        result_alternative = OpenStackRelease(release_1) <= OpenStackRelease(release_2)
     elif comparison == "ge":
-        result = CompareOpenStack(release_1) >= release_2
-        result_alternative = CompareOpenStack(release_1) >= CompareOpenStack(release_2)
+        result = OpenStackRelease(release_1) >= release_2
+        result_alternative = OpenStackRelease(release_1) >= OpenStackRelease(release_2)
     elif comparison == "gt":
-        result = CompareOpenStack(release_1) > release_2
-        result_alternative = CompareOpenStack(release_1) > CompareOpenStack(release_2)
+        result = OpenStackRelease(release_1) > release_2
+        result_alternative = OpenStackRelease(release_1) > OpenStackRelease(release_2)
     assert result == expected_result
     assert result_alternative == expected_result
 
 
 @pytest.mark.parametrize("os_release", ["victoria", "wallaby"])
 def test_compare_openstack_repr_str(os_release):
-    os_compare = CompareOpenStack(os_release)
+    os_compare = OpenStackRelease(os_release)
     expected_str = os_release
-    expected_repr = f"CompareOpenStack<{os_release}>"
+    expected_repr = f"OpenStackRelease<{os_release}>"
     assert repr(os_compare) == expected_repr
     assert str(os_compare) == expected_str
 
 
 def test_compare_openstack_raises_error():
     with pytest.raises(ValueError) as err:
-        CompareOpenStack("foo-release")
+        OpenStackRelease("foo-release")
         assert "Item foo-release is not in list" in str(err.value)
-    with pytest.raises(ValueError) as err:
-        BasicStringComparator("foo-release")
-        assert "Must define the _list in the class definition!" in str(err.value)
 
 
 @pytest.mark.parametrize(
-    "os_release, next_os_release",
+    "os_release, release_year, next_os_release",
     [
-        ("ussuri", ("2020.2", "victoria")),
-        ("victoria", ("2021.1", "wallaby")),
-        ("wallaby", ("2021.2", "xena")),
-        ("xena", ("2022.1", "yoga")),
+        ("ussuri", "2020.1", "victoria"),
+        ("victoria", "2020.2", "wallaby"),
+        ("wallaby", "2021.1", "xena"),
+        ("xena", "2021.2", "yoga"),
+        ("bobcat", "2023.2", "bobcat"),  # repeat when there is no next release
     ],
 )
-def test_determine_next_openstack_release(os_release, next_os_release):
-    result = determine_next_openstack_release(os_release)
-    assert result == next_os_release
-
-
-def test_determine_next_openstack_release_raises():
-    with pytest.raises(ValueError):
-        determine_next_openstack_release("foo-release")
+def test_determine_next_openstack_release(os_release, release_year, next_os_release):
+    release = OpenStackRelease(os_release)
+    assert release.next_release == next_os_release
+    assert release.release_year == release_year

--- a/tests/unit/utils/test_openstack.py
+++ b/tests/unit/utils/test_openstack.py
@@ -79,44 +79,105 @@ def test_generate_lookup(service):
 
 
 @pytest.mark.parametrize(
-    "release_1, release_2, comparison, expected_result",
+    "release_1, release_2, exp_result",
     [
-        ("victoria", "wallaby", "eq", False),
-        ("victoria", "victoria", "eq", True),
-        ("victoria", "wallaby", "neq", True),
-        ("wallaby", "wallaby", "neq", False),
-        ("victoria", "wallaby", "lt", True),
-        ("wallaby", "victoria", "lt", False),
-        ("victoria", "wallaby", "le", True),
-        ("wallaby", "victoria", "le", False),
-        ("wallaby", "wallaby", "le", True),
-        ("victoria", "wallaby", "ge", False),
-        ("wallaby", "victoria", "ge", True),
-        ("victoria", "wallaby", "gt", False),
-        ("wallaby", "victoria", "gt", True),
+        ("victoria", "victoria", True),
+        ("victoria", "wallaby", False),
+        ("wallaby", "victoria", False),
     ],
 )
-def test_compare_openstack(release_1, release_2, comparison, expected_result):
-    if comparison == "eq":
-        result = OpenStackRelease(release_1) == release_2
-        result_alternative = OpenStackRelease(release_1) == OpenStackRelease(release_2)
-    elif comparison == "neq":
-        result = OpenStackRelease(release_1) != release_2
-        result_alternative = OpenStackRelease(release_1) != OpenStackRelease(release_2)
-    elif comparison == "lt":
-        result = OpenStackRelease(release_1) < release_2
-        result_alternative = OpenStackRelease(release_1) < OpenStackRelease(release_2)
-    elif comparison == "le":
-        result = OpenStackRelease(release_1) <= release_2
-        result_alternative = OpenStackRelease(release_1) <= OpenStackRelease(release_2)
-    elif comparison == "ge":
-        result = OpenStackRelease(release_1) >= release_2
-        result_alternative = OpenStackRelease(release_1) >= OpenStackRelease(release_2)
-    elif comparison == "gt":
-        result = OpenStackRelease(release_1) > release_2
-        result_alternative = OpenStackRelease(release_1) > OpenStackRelease(release_2)
-    assert result == expected_result
-    assert result_alternative == expected_result
+def test_compare_openstack_release_eq(release_1, release_2, exp_result):
+    result_1 = OpenStackRelease(release_1) == release_2
+    result_2 = OpenStackRelease(release_1) == OpenStackRelease(release_2)
+    assert result_1 == exp_result
+    assert result_2 == exp_result
+
+
+def test_compare_openstack_release_eq_not_implemented():
+    assert OpenStackRelease("ussuri").__eq__(1) == NotImplemented
+
+
+@pytest.mark.parametrize(
+    "release_1, release_2, exp_result",
+    [
+        ("victoria", "victoria", False),
+        ("victoria", "wallaby", True),
+        ("wallaby", "victoria", True),
+    ],
+)
+def test_compare_openstack_release_neq(release_1, release_2, exp_result):
+    result_1 = OpenStackRelease(release_1) != release_2
+    result_2 = OpenStackRelease(release_1) != OpenStackRelease(release_2)
+    assert result_1 == exp_result
+    assert result_2 == exp_result
+
+
+@pytest.mark.parametrize(
+    "release_1, release_2, exp_result",
+    [
+        ("victoria", "victoria", False),
+        ("victoria", "wallaby", True),
+        ("wallaby", "victoria", False),
+    ],
+)
+def test_compare_openstack_release_lt(release_1, release_2, exp_result):
+    result_1 = OpenStackRelease(release_1) < release_2
+    result_2 = OpenStackRelease(release_1) < OpenStackRelease(release_2)
+    assert result_1 == exp_result
+    assert result_2 == exp_result
+
+
+def test_compare_openstack_release_lt_not_implemented():
+    assert OpenStackRelease("ussuri").__lt__(1) == NotImplemented
+
+
+@pytest.mark.parametrize(
+    "release_1, release_2, exp_result",
+    [
+        ("victoria", "victoria", True),
+        ("victoria", "wallaby", False),
+        ("wallaby", "victoria", True),
+    ],
+)
+def test_compare_openstack_release_ge(release_1, release_2, exp_result):
+    result_1 = OpenStackRelease(release_1) >= release_2
+    result_2 = OpenStackRelease(release_1) >= OpenStackRelease(release_2)
+    assert result_1 == exp_result
+    assert result_2 == exp_result
+
+
+@pytest.mark.parametrize(
+    "release_1, release_2, exp_result",
+    [
+        ("victoria", "victoria", False),
+        ("victoria", "wallaby", False),
+        ("wallaby", "victoria", True),
+    ],
+)
+def test_compare_openstack_release_gt(release_1, release_2, exp_result):
+    result_1 = OpenStackRelease(release_1) > release_2
+    result_2 = OpenStackRelease(release_1) > OpenStackRelease(release_2)
+    assert result_1 == exp_result
+    assert result_2 == exp_result
+
+
+def test_compare_openstack_gt_release_not_implemented():
+    assert OpenStackRelease("ussuri").__gt__(1) == NotImplemented
+
+
+@pytest.mark.parametrize(
+    "release_1, release_2, exp_result",
+    [
+        ("victoria", "victoria", True),
+        ("victoria", "wallaby", True),
+        ("wallaby", "victoria", False),
+    ],
+)
+def test_compare_openstack_release_le(release_1, release_2, exp_result):
+    result_1 = OpenStackRelease(release_1) <= release_2
+    result_2 = OpenStackRelease(release_1) <= OpenStackRelease(release_2)
+    assert result_1 == exp_result
+    assert result_2 == exp_result
 
 
 @pytest.mark.parametrize("os_release", ["victoria", "wallaby"])

--- a/tests/unit/utils/test_openstack.py
+++ b/tests/unit/utils/test_openstack.py
@@ -180,6 +180,22 @@ def test_compare_openstack_release_le(release_1, release_2, exp_result):
     assert result_2 == exp_result
 
 
+def test_compare_openstack_release_order():
+    ussuri = OpenStackRelease("ussuri")
+    wallaby = OpenStackRelease("wallaby")
+    antelope = OpenStackRelease("antelope")
+    bobcat = OpenStackRelease("bobcat")
+    os_releases = {
+        wallaby,
+        ussuri,
+        bobcat,
+        antelope,
+    }
+    assert min(os_releases) == ussuri
+    assert max(os_releases) == bobcat
+    assert sorted(os_releases) == [ussuri, wallaby, antelope, bobcat]
+
+
 def test_openstack_release_setter():
     openstack_release = OpenStackRelease("wallaby")
     assert openstack_release.next_release == "xena"

--- a/tests/unit/utils/test_openstack.py
+++ b/tests/unit/utils/test_openstack.py
@@ -180,6 +180,14 @@ def test_compare_openstack_release_le(release_1, release_2, exp_result):
     assert result_2 == exp_result
 
 
+def test_openstack_release_setter():
+    openstack_release = OpenStackRelease("wallaby")
+    assert openstack_release.next_release == "xena"
+    # change OpenStack release
+    openstack_release.os_release = "xena"
+    assert openstack_release.next_release == "yoga"
+
+
 @pytest.mark.parametrize("os_release", ["victoria", "wallaby"])
 def test_compare_openstack_repr_str(os_release):
     os_compare = OpenStackRelease(os_release)

--- a/tests/unit/utils/test_openstack.py
+++ b/tests/unit/utils/test_openstack.py
@@ -231,8 +231,5 @@ def test_compare_openstack_raises_error():
 )
 def test_determine_next_openstack_release(os_release, release_year, next_os_release):
     release = OpenStackRelease(os_release)
-    if next_os_release is None:
-        assert release.next_release is next_os_release
-    else:
-        assert release.next_release == next_os_release
+    assert release.next_release == next_os_release
     assert release.date == release_year

--- a/tests/unit/utils/test_openstack.py
+++ b/tests/unit/utils/test_openstack.py
@@ -226,7 +226,7 @@ def test_compare_openstack_raises_error():
         ("victoria", "2020.2", "wallaby"),
         ("wallaby", "2021.1", "xena"),
         ("xena", "2021.2", "yoga"),
-        ("bobcat", "2023.2", None),  # None when there is no next release
+        ("caracal", "2024.1", None),  # None when there is no next release
     ],
 )
 def test_determine_next_openstack_release(os_release, release_year, next_os_release):

--- a/tests/unit/utils/test_openstack.py
+++ b/tests/unit/utils/test_openstack.py
@@ -200,7 +200,7 @@ def test_openstack_release_setter():
     openstack_release = OpenStackRelease("wallaby")
     assert openstack_release.next_release == "xena"
     # change OpenStack release
-    openstack_release.os_release = "xena"
+    openstack_release.codename = "xena"
     assert openstack_release.next_release == "yoga"
 
 
@@ -226,10 +226,13 @@ def test_compare_openstack_raises_error():
         ("victoria", "2020.2", "wallaby"),
         ("wallaby", "2021.1", "xena"),
         ("xena", "2021.2", "yoga"),
-        ("bobcat", "2023.2", "bobcat"),  # repeat when there is no next release
+        ("bobcat", "2023.2", None),  # None when there is no next release
     ],
 )
 def test_determine_next_openstack_release(os_release, release_year, next_os_release):
     release = OpenStackRelease(os_release)
-    assert release.next_release == next_os_release
-    assert release.release_year == release_year
+    if next_os_release is None:
+        assert release.next_release is next_os_release
+    else:
+        assert release.next_release == next_os_release
+    assert release.date == release_year


### PR DESCRIPTION
- added helpers on openstack utils to determine next openstack
  release, list of the expected upgrade order, capability of compare
  openstack releases by its codename.
- Analyze can show current and next openstack version of the cloud
- added series, current and next openstack release properties on
  Application.
- analyze skip subordinate charms and those with unknown OpenStack
  release version.
- raise exception on mismatched OpenStack versions in an app.
- skip non-openstack charms on current cloud OpenStack release from Analyze.

This PR should be merged after #24 