### PR TITLE
Add MySQL charms on OpenStack lookup

### DIFF
--- a/cou/utils/openstack.py
+++ b/cou/utils/openstack.py
@@ -36,6 +36,7 @@ CHARM_TYPES = {
     "neutron": ["neutron-api", "neutron-gateway"],
     "manila": ["manila-ganesha"],
     "horizon": ["openstack-dashboard"],
+    "mysql": ["mysql-innodb-cluster", "mysql-router"],
 }
 
 


### PR DESCRIPTION
- the OpenStack lookup is ready for MySQL charms, but it was missing the specific charms.