### PR TITLE
Pre-upgrade package refresh

### DIFF
--- a/cou/apps/app.py
+++ b/cou/apps/app.py
@@ -430,7 +430,7 @@ class OpenStackApplication:
         return UpgradeStep(
             description=(
                 f"Upgrade software packages of '{self.name}' to the latest "
-                f"in '{self.current_os_release}' release"
+                f"'{self.current_os_release}' release"
             ),
             parallel=parallel,
             function=upgrade_packages,

--- a/cou/apps/app.py
+++ b/cou/apps/app.py
@@ -153,7 +153,7 @@ class OpenStackApplication:
     :raises MismatchedOpenStackVersions: When units part of this application are running mismatched
         OpenStack versions.
     :raises HaltUpgradePlanGeneration: When the class halts the upgrade plan generation
-    :raises PackageUpgradeError: When the upgrade command execution resulted in error.
+    :raises PackageUpgradeError: When the package upgrade fails.
     """
 
     # pylint: disable=too-many-instance-attributes

--- a/cou/apps/app.py
+++ b/cou/apps/app.py
@@ -29,10 +29,12 @@ from cou.exceptions import (
     ApplicationError,
     HaltUpgradePlanGeneration,
     MismatchedOpenStackVersions,
+    PackageUpgradeError,
 )
 from cou.steps import UpgradeStep
 from cou.utils.juju_utils import (
     async_get_status,
+    async_run_on_unit,
     async_set_application_config,
     async_upgrade_charm,
 )
@@ -152,6 +154,7 @@ class OpenStackApplication:
     :raises MismatchedOpenStackVersions: When units part of this application are running mismatched
         OpenStack versions.
     :raises HaltUpgradePlanGeneration: When the class halts the upgrade plan generation
+    :raises PackageUpgradeError: When the upgrade command execution resulted in error.
     """
 
     # pylint: disable=too-many-instance-attributes
@@ -342,6 +345,44 @@ class OpenStackApplication:
             )
             raise ApplicationError()
 
+    async def _run_package_upgrade_command(self, unit: str, command: str) -> None:
+        """Run package upgrade command and raise Exception if fails.
+
+        :param unit: The name of the unit where the command runs on.
+        :type str
+        :param command: The upgrade command to run.
+        :type str
+        :raises PackageUpgradeError: When the upgrade command execution resulted in error.
+        """
+        logger.info("Running '%s' on %s", command, unit)
+        result = await async_run_on_unit(
+            unit_name=unit, command=command, model_name=self.model_name
+        )
+        if str(result["Code"]) == "0":
+            logger.debug(result["Stdout"])
+        else:
+            logger.error(
+                "Error upgrading package on %s: %s",
+                unit,
+                result["Stderr"],
+            )
+            raise PackageUpgradeError()
+
+    async def _upgrade_packages(self) -> None:
+        """Run package updates and upgrades on each unit of an Application."""
+        status = await async_get_status()
+        app_status = status.applications.get(self.name)
+        for unit in app_status.units.keys():
+            update_command = "sudo apt update"
+            await self._run_package_upgrade_command(unit=unit, command=update_command)
+
+            dpkg_opts = "-o Dpkg::Options::=--force-confnew -o Dpkg::Options::=--force-confdef"
+            upgrade_command = f"sudo apt full-upgrade {dpkg_opts} -y"
+            await self._run_package_upgrade_command(unit=unit, command=upgrade_command)
+
+            autoremove_command = "sudo apt autoremove"
+            await self._run_package_upgrade_command(unit=unit, command=autoremove_command)
+
     def pre_upgrade_plan(self, target: OpenStackRelease) -> list[Optional[UpgradeStep]]:
         """Pre Upgrade planning.
 
@@ -350,7 +391,10 @@ class OpenStackApplication:
         :return: Plan that will add pre upgrade as sub steps.
         :rtype: list[Optional[UpgradeStep]]
         """
-        return [self._get_refresh_charm_plan(target)]
+        return [
+            self._get_upgrade_current_release_packages_plan(),
+            self._get_refresh_charm_plan(target),
+        ]
 
     def upgrade_plan(self, target: OpenStackRelease) -> list[Optional[UpgradeStep]]:
         """Upgrade planning.
@@ -413,6 +457,23 @@ class OpenStackApplication:
             if step:
                 upgrade_steps.add_step(step)
         return upgrade_steps
+
+    def _get_upgrade_current_release_packages_plan(self, parallel: bool = False) -> UpgradeStep:
+        """Get Plan for upgrading software packages to the latest of the current release.
+
+        :param parallel: Parallel running, defaults to False
+        :type parallel: bool, optional
+        :return plan: Plan for upgrading software packages to the latest of the current release.
+        :type plan: UpgradeStep
+        """
+        return UpgradeStep(
+            description=(
+                f"Upgrade software packages of '{self.name}' to the latest "
+                f"in '{self.current_os_release}' release"
+            ),
+            parallel=parallel,
+            function=self._upgrade_packages,
+        )
 
     def _get_refresh_charm_plan(
         self, target: OpenStackRelease, parallel: bool = False

--- a/cou/exceptions.py
+++ b/cou/exceptions.py
@@ -36,10 +36,6 @@ class UnitNotFound(Exception):
     """Exception raised when a unit is not found in the model."""
 
 
-class JujuError(Exception):
-    """Exception raised when libjuju does something unexpected."""
-
-
 class MismatchedOpenStackVersions(Exception):
     """Exception raised when more than one OpenStack version is found in the Application."""
 

--- a/cou/exceptions.py
+++ b/cou/exceptions.py
@@ -18,7 +18,7 @@ from juju.action import Action
 
 
 class CommandRunFailed(Exception):
-    """Command failed to run."""
+    """Exception raised when a command fails to run."""
 
     def __init__(self, cmd: str, code: str, output: str, err: str):
         """Create Command run failed exception.
@@ -33,19 +33,19 @@ class CommandRunFailed(Exception):
 
 
 class UnitNotFound(Exception):
-    """Unit not found in actual dict."""
+    """Exception raised when unit not found in the actual dict."""
 
 
 class JujuError(Exception):
-    """Exception when libjuju does something unexpected."""
+    """Exception raised when libjuju does something unexpected."""
 
 
 class MismatchedOpenStackVersions(Exception):
-    """Exception when more than one OpenStack version are found in the Application."""
+    """Exception raised when more than one OpenStack version are found in the Application."""
 
 
 class NoTargetError(Exception):
-    """Exception when there is no target to upgrade."""
+    """Exception raised when there is no target to upgrade."""
 
 
 class HaltUpgradePlanGeneration(Exception):
@@ -53,11 +53,11 @@ class HaltUpgradePlanGeneration(Exception):
 
 
 class ApplicationError(Exception):
-    """Exception when Application does something unexpected."""
+    """Exception raised when Application does something unexpected."""
 
 
 class PackageUpgradeError(Exception):
-    """Exception when pacakge upgrade fails."""
+    """Exception raised when a pacakge upgrade fails."""
 
 
 class ActionFailed(Exception):

--- a/cou/exceptions.py
+++ b/cou/exceptions.py
@@ -33,7 +33,7 @@ class CommandRunFailed(Exception):
 
 
 class UnitNotFound(Exception):
-    """Exception raised when unit not found in the actual dict."""
+    """Exception raised when a unit is not found in the model."""
 
 
 class JujuError(Exception):
@@ -41,7 +41,7 @@ class JujuError(Exception):
 
 
 class MismatchedOpenStackVersions(Exception):
-    """Exception raised when more than one OpenStack version are found in the Application."""
+    """Exception raised when more than one OpenStack version is found in the Application."""
 
 
 class NoTargetError(Exception):
@@ -57,7 +57,7 @@ class ApplicationError(Exception):
 
 
 class PackageUpgradeError(Exception):
-    """Exception raised when a pacakge upgrade fails."""
+    """Exception raised when a package upgrade fails."""
 
 
 class ActionFailed(Exception):

--- a/cou/exceptions.py
+++ b/cou/exceptions.py
@@ -56,6 +56,10 @@ class ApplicationError(Exception):
     """Exception when Application does something unexpected."""
 
 
+class PackageUpgradeError(Exception):
+    """Exception when pacakge upgrade fails."""
+
+
 class ActionFailed(Exception):
     # pylint: disable=consider-using-f-string
     """Exception raised when action fails."""

--- a/cou/utils/app_utils.py
+++ b/cou/utils/app_utils.py
@@ -1,0 +1,52 @@
+# Copyright 2023 Canonical Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Application utilities."""
+import logging
+from collections.abc import Iterable
+
+from cou.exceptions import PackageUpgradeError
+from cou.utils.juju_utils import async_run_on_unit
+
+logger = logging.getLogger(__name__)
+
+
+async def upgrade_packages(units: Iterable[str], model_name: str) -> None:
+    """Run package updates and upgrades on each unit of an Application.
+
+    :param units: The list of unit names where the package upgrade runs on.
+    :type Iterable[str]
+    :param model_name: The name of the model that the applcation belongs to.
+    :type str
+    :raises PackageUpgradeError: When the upgrade command execution resulted in error.
+    """
+    for unit in units:
+        dpkg_opts = "-o Dpkg::Options::=--force-confnew -o Dpkg::Options::=--force-confdef"
+        command = (
+            "sudo apt-get update && "
+            f"sudo apt-get dist-upgrade {dpkg_opts} -y && "
+            "sudo apt-get autoremove -y"
+        )
+
+        logger.info("Running '%s' on '%s'", command, unit)
+        result = await async_run_on_unit(unit_name=unit, command=command, model_name=model_name)
+        if str(result["Code"]) == "0":
+            logger.debug(result["Stdout"])
+        else:
+            logger.error(
+                "Error upgrading package on %s: %s",
+                unit,
+                result["Stderr"],
+            )
+            raise PackageUpgradeError()

--- a/cou/utils/app_utils.py
+++ b/cou/utils/app_utils.py
@@ -46,8 +46,8 @@ async def upgrade_packages(units: Iterable[str], model_name: str) -> None:
             if str(result["Code"]) == "0":
                 logger.debug(result["Stdout"])
             else:
-                logger.error("Error upgrading package on %s: %s", unit, result["Stderr"])
+                logger.error("Error upgrading packages on %s: %s", unit, result["Stderr"])
                 raise PackageUpgradeError()
         except JujuError as exc:
-            logger.error("Failed running package upgrade on %s: %s", unit, exc)
+            logger.error("Failed running package upgrades on %s: %s", unit, exc)
             raise PackageUpgradeError() from exc

--- a/cou/utils/app_utils.py
+++ b/cou/utils/app_utils.py
@@ -27,18 +27,14 @@ async def upgrade_packages(units: Iterable[str], model_name: str) -> None:
 
     :param units: The list of unit names where the package upgrade runs on.
     :type Iterable[str]
-    :param model_name: The name of the model that the applcation belongs to.
+    :param model_name: The name of the model that the application belongs to.
     :type str
     :raises PackageUpgradeError: When the upgrade command execution resulted in error.
     """
-    for unit in units:
-        dpkg_opts = "-o Dpkg::Options::=--force-confnew -o Dpkg::Options::=--force-confdef"
-        command = (
-            "sudo apt-get update && "
-            f"sudo apt-get dist-upgrade {dpkg_opts} -y && "
-            "sudo apt-get autoremove -y"
-        )
+    dpkg_opts = "-o Dpkg::Options::=--force-confnew -o Dpkg::Options::=--force-confdef"
+    command = f"apt-get update && apt-get dist-upgrade {dpkg_opts} -y && apt-get autoremove -y"
 
+    for unit in units:
         logger.info("Running '%s' on '%s'", command, unit)
         result = await async_run_on_unit(unit_name=unit, command=command, model_name=model_name)
         if str(result["Code"]) == "0":

--- a/tests/unit/apps/test_app.py
+++ b/tests/unit/apps/test_app.py
@@ -288,7 +288,7 @@ def test_upgrade_plan_ussuri_to_victoria(status, config):
     app = OpenStackApplication("my_keystone", app_status, app_config, "my_model", "keystone")
     upgrade_plan = app.generate_upgrade_plan(target)
     steps_description = [
-        "Upgrade software packages of 'my_keystone' to the latest in 'ussuri' release",
+        "Upgrade software packages of 'my_keystone' to the latest 'ussuri' release",
         "Refresh 'my_keystone' to the latest revision of 'ussuri/stable'",
         "Change charm config of 'my_keystone' 'action-managed-upgrade' to False.",
         "Upgrade 'my_keystone' to the new channel: 'victoria/stable'",
@@ -306,7 +306,7 @@ def test_upgrade_plan_ussuri_to_victoria_ch_migration(status, config):
     app = OpenStackApplication("my_keystone", app_status, app_config, "my_model", "keystone")
     upgrade_plan = app.generate_upgrade_plan(target)
     steps_description = [
-        "Upgrade software packages of 'my_keystone' to the latest in 'ussuri' release",
+        "Upgrade software packages of 'my_keystone' to the latest 'ussuri' release",
         "Migration of 'my_keystone' from charmstore to charmhub",
         "Change charm config of 'my_keystone' 'action-managed-upgrade' to False.",
         "Upgrade 'my_keystone' to the new channel: 'victoria/stable'",
@@ -329,7 +329,7 @@ def test_upgrade_plan_change_current_channel(mocker, status, config):
     upgrade_plan = app.generate_upgrade_plan(target)
 
     steps_description = [
-        "Upgrade software packages of 'my_keystone' to the latest in 'ussuri' release",
+        "Upgrade software packages of 'my_keystone' to the latest 'ussuri' release",
         "Changing 'my_keystone' channel from: 'foo/stable' to: 'ussuri/stable'",
         "Change charm config of 'my_keystone' 'action-managed-upgrade' to False.",
         "Upgrade 'my_keystone' to the new channel: 'victoria/stable'",
@@ -356,7 +356,7 @@ def test_upgrade_plan_channel_on_next_os_release(status, config, mocker):
 
     # no sub-step for refresh current channel or next channel
     steps_description = [
-        "Upgrade software packages of 'my_keystone' to the latest in 'ussuri' release",
+        "Upgrade software packages of 'my_keystone' to the latest 'ussuri' release",
         "Change charm config of 'my_keystone' 'action-managed-upgrade' to False.",
         "Change charm config of 'my_keystone' 'openstack-origin' to 'cloud:focal-victoria'",
         "Check if the workload of 'my_keystone' has been upgraded",
@@ -384,7 +384,7 @@ def test_upgrade_plan_origin_already_on_next_openstack_release(status, config, m
     app = OpenStackApplication("my_keystone", app_status, app_config, "my_model", "keystone")
     upgrade_plan = app.generate_upgrade_plan(target)
     steps_description = [
-        "Upgrade software packages of 'my_keystone' to the latest in 'ussuri' release",
+        "Upgrade software packages of 'my_keystone' to the latest 'ussuri' release",
         "Refresh 'my_keystone' to the latest revision of 'ussuri/stable'",
         "Change charm config of 'my_keystone' 'action-managed-upgrade' to False.",
         "Upgrade 'my_keystone' to the new channel: 'victoria/stable'",
@@ -433,7 +433,7 @@ def test_upgrade_plan_application_already_disable_action_managed(status, config)
     )
     upgrade_plan = app.generate_upgrade_plan(target)
     steps_description = [
-        "Upgrade software packages of 'my_keystone' to the latest in 'ussuri' release",
+        "Upgrade software packages of 'my_keystone' to the latest 'ussuri' release",
         "Refresh 'my_keystone' to the latest revision of 'ussuri/stable'",
         "Upgrade 'my_keystone' to the new channel: 'victoria/stable'",
         "Change charm config of 'my_keystone' 'openstack-origin' to 'cloud:focal-victoria'",

--- a/tests/unit/steps/test_steps_plan.py
+++ b/tests/unit/steps/test_steps_plan.py
@@ -99,6 +99,8 @@ async def test_generate_plan_raise_Exception(mocker):
 def generate_expected_upgrade_plan_description(charm, target):
     target_version = OpenStackRelease(target)
     return [
+        f"Upgrade software packages of '{charm.name}' to the latest "
+        f"in '{charm.current_os_release}' release",
         f"Refresh '{charm.name}' to the latest revision of '{charm.expected_current_channel}'",
         f"Change charm config of '{charm.name}' 'action-managed-upgrade' to False.",
         f"Upgrade '{charm.name}' to the new channel: '{charm.target_channel(target_version)}'",

--- a/tests/unit/steps/test_steps_plan.py
+++ b/tests/unit/steps/test_steps_plan.py
@@ -100,7 +100,7 @@ def generate_expected_upgrade_plan_description(charm, target):
     target_version = OpenStackRelease(target)
     return [
         f"Upgrade software packages of '{charm.name}' to the latest "
-        f"in '{charm.current_os_release}' release",
+        f"'{charm.current_os_release}' release",
         f"Refresh '{charm.name}' to the latest revision of '{charm.expected_current_channel}'",
         f"Change charm config of '{charm.name}' 'action-managed-upgrade' to False.",
         f"Upgrade '{charm.name}' to the new channel: '{charm.target_channel(target_version)}'",

--- a/tests/unit/test_exceptions.py
+++ b/tests/unit/test_exceptions.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 import pytest
 
-from cou.exceptions import ActionFailed, CommandRunFailed, JujuError, UnitNotFound
+from cou.exceptions import ActionFailed, CommandRunFailed, UnitNotFound
 
 
 def test_command_run_failed():
@@ -24,11 +24,6 @@ def test_command_run_failed():
 def test_unit_not_found():
     with pytest.raises(UnitNotFound):
         raise UnitNotFound()
-
-
-def test_juju_error():
-    with pytest.raises(JujuError):
-        raise JujuError()
 
 
 def test_action_failed():

--- a/tests/unit/utils/test_app_utils.py
+++ b/tests/unit/utils/test_app_utils.py
@@ -1,0 +1,79 @@
+#  Copyright 2023 Canonical Limited
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+from unittest.mock import call
+
+import pytest
+
+from cou.exceptions import PackageUpgradeError
+from cou.utils import app_utils
+
+
+@pytest.mark.asyncio
+async def test_application_upgrade_packages(mocker):
+    mock_logger = mocker.patch("cou.utils.app_utils.logger")
+
+    success_result = {"Code": "0", "Stdout": "Success"}
+    mock_async_run_on_unit = mocker.patch.object(
+        app_utils, "async_run_on_unit", return_value=success_result
+    )
+    await app_utils.upgrade_packages(units=["keystone/0", "keystone/1"], model_name="my_model")
+
+    dpkg_opts = "-o Dpkg::Options::=--force-confnew -o Dpkg::Options::=--force-confdef"
+    expected_calls = [
+        call(
+            unit_name="keystone/0",
+            command="sudo apt-get update && "
+            f"sudo apt-get dist-upgrade {dpkg_opts} -y && "
+            "sudo apt-get autoremove -y",
+            model_name="my_model",
+        ),
+        call(
+            unit_name="keystone/1",
+            command="sudo apt-get update && "
+            f"sudo apt-get dist-upgrade {dpkg_opts} -y && "
+            "sudo apt-get autoremove -y",
+            model_name="my_model",
+        ),
+    ]
+
+    mock_async_run_on_unit.assert_has_calls(
+        expected_calls,
+    )
+    assert len(mock_logger.debug.mock_calls) == 2
+
+
+@pytest.mark.asyncio
+async def test_application_upgrade_packages_failed(mocker):
+    mock_logger = mocker.patch("cou.utils.app_utils.logger")
+
+    failed_result = {"Code": "non-zero", "Stderr": "unexpected error"}
+    mock_async_run_on_unit = mocker.patch.object(
+        app_utils, "async_run_on_unit", return_value=failed_result
+    )
+
+    with pytest.raises(PackageUpgradeError):
+        await app_utils.upgrade_packages(units=["keystone/0", "keystone/1"], model_name="my_model")
+
+    dpkg_opts = "-o Dpkg::Options::=--force-confnew -o Dpkg::Options::=--force-confdef"
+    mock_async_run_on_unit.assert_called_once_with(
+        unit_name="keystone/0",
+        command="sudo apt-get update && "
+        f"sudo apt-get dist-upgrade {dpkg_opts} -y && "
+        "sudo apt-get autoremove -y",
+        model_name="my_model",
+    )
+    mock_logger.error.assert_called_once_with(
+        "Error upgrading package on %s: %s", "keystone/0", "unexpected error"
+    )

--- a/tests/unit/utils/test_app_utils.py
+++ b/tests/unit/utils/test_app_utils.py
@@ -34,16 +34,16 @@ async def test_application_upgrade_packages(mocker):
     expected_calls = [
         call(
             unit_name="keystone/0",
-            command="sudo apt-get update && "
-            f"sudo apt-get dist-upgrade {dpkg_opts} -y && "
-            "sudo apt-get autoremove -y",
+            command="apt-get update && "
+            f"apt-get dist-upgrade {dpkg_opts} -y && "
+            "apt-get autoremove -y",
             model_name="my_model",
         ),
         call(
             unit_name="keystone/1",
-            command="sudo apt-get update && "
-            f"sudo apt-get dist-upgrade {dpkg_opts} -y && "
-            "sudo apt-get autoremove -y",
+            command="apt-get update && "
+            f"apt-get dist-upgrade {dpkg_opts} -y && "
+            "apt-get autoremove -y",
             model_name="my_model",
         ),
     ]
@@ -69,9 +69,9 @@ async def test_application_upgrade_packages_failed(mocker):
     dpkg_opts = "-o Dpkg::Options::=--force-confnew -o Dpkg::Options::=--force-confdef"
     mock_async_run_on_unit.assert_called_once_with(
         unit_name="keystone/0",
-        command="sudo apt-get update && "
-        f"sudo apt-get dist-upgrade {dpkg_opts} -y && "
-        "sudo apt-get autoremove -y",
+        command="apt-get update && "
+        f"apt-get dist-upgrade {dpkg_opts} -y && "
+        "apt-get autoremove -y",
         model_name="my_model",
     )
     mock_logger.error.assert_called_once_with(


### PR DESCRIPTION
A pre-upgrade step that ensures all packages are at their current latest version. The step is at the moment implemented at the Application level as we are currently only dealing with control plane components.

In addition to the commands recommended in the charm upgrade documentation, we also included the following changes:
1. add dpkg options as used in the latest charm upgrade functions (e.g. [charm-nova-compute](https://opendev.org/openstack/charm-nova-compute/src/commit/f6892d228c6e6eff72bbfc700a4d5a4a9a4d92e7/hooks/nova_compute_utils.py#L769))
2. autoremvoe old, dangling dependency packages.

This PR should be merged after https://github.com/canonical/charmed-openstack-upgrader/pull/21
