### PR TITLE
Fix openstack subordinates using 'cs:'.

### DIFF
--- a/cou/apps/subordinate.py
+++ b/cou/apps/subordinate.py
@@ -25,6 +25,8 @@ logger = logging.getLogger(__name__)
 class OpenStackSubordinateApplication(OpenStackApplication):
     """Subordinate application class."""
 
+    _default_used = False
+
     @property
     def current_os_release(self) -> OpenStackRelease:
         """Infer the OpenStack release from subordinate charm's channel.

--- a/tests/unit/apps/test_subordinate.py
+++ b/tests/unit/apps/test_subordinate.py
@@ -98,3 +98,12 @@ def test_channel_setter_invalid(status, channel):
     app.channel = channel
     assert app.channel == "ussuri/stable"
     assert app._default_used
+
+
+def test_channel_default_used(status):
+    app_status = status["keystone-ldap"]
+    app = OpenStackSubordinateApplication(
+        "my_keystone_ldap", app_status, {}, "my_model", "keystone-ldap"
+    )
+
+    assert not app._default_used

--- a/tests/unit/apps/test_subordinate.py
+++ b/tests/unit/apps/test_subordinate.py
@@ -17,7 +17,6 @@ import logging
 import pytest
 
 from cou.apps.subordinate import OpenStackSubordinateApplication
-from cou.exceptions import ApplicationError
 from cou.utils.openstack import OpenStackRelease
 
 logger = logging.getLogger(__name__)
@@ -78,6 +77,7 @@ def test_channel_setter_valid(status, channel):
 
     app.channel = channel
     assert app.channel == channel
+    assert not app._default_used
 
 
 @pytest.mark.parametrize(
@@ -95,5 +95,6 @@ def test_channel_setter_invalid(status, channel):
         "my_keystone_ldap", app_status, {}, "my_model", "keystone-ldap"
     )
 
-    with pytest.raises(ApplicationError):
-        app.channel = channel
+    app.channel = channel
+    assert app.channel == "ussuri/stable"
+    assert app._default_used


### PR DESCRIPTION
If subordinate charm does not have channels this means it is either before focal, or using cs:

In any case assuming it ussuri/stable will not break the code because and openstack
- if the principal is not (ussuri/victoria/..)/stable we will not try to upgrade it
- principals thus the subordinate binaries already upgraded to whatever version we are trying to upgrade

basically if subordinate is cs:charm stable principal is ussuri/stable we will first upgrade principal to victoria than upgrade subordinate to victoria. We will not refresh charm it its origin is unidentified.