### PR TITLE
Remove invalid model arguments

### DIFF
--- a/cou/apps/app.py
+++ b/cou/apps/app.py
@@ -514,7 +514,6 @@ class OpenStackApplication:
             function=self.model.upgrade_charm,
             application_name=self.name,
             channel=self.expected_current_channel,
-            model=self.model,
             switch=switch,
         )
 
@@ -539,7 +538,6 @@ class OpenStackApplication:
                 function=self.model.upgrade_charm,
                 application_name=self.name,
                 channel=self.target_channel(target),
-                model=self.model,
             )
         return None
 
@@ -562,7 +560,6 @@ class OpenStackApplication:
                 function=self.model.set_application_config,
                 application_name=self.name,
                 configuration={"action-managed-upgrade": False},
-                model=self.model,
             )
         return None
 
@@ -588,7 +585,6 @@ class OpenStackApplication:
                 function=self.model.set_application_config,
                 application_name=self.name,
                 configuration={self.origin_setting: self.new_origin(target)},
-                model=self.model,
             )
         logger.warning(
             "Not triggering the workload upgrade of app %s: %s already set to %s",


### PR DESCRIPTION
Currently we are passing `model` as an argument to some COUModel methods, which is not correct and causes `unexpected keyword argument` error. Removed the argument to fix this issue.