### PR TITLE
Add pylint docparams extension to check docstrings.

### DIFF
--- a/cou/apps/app.py
+++ b/cou/apps/app.py
@@ -108,7 +108,9 @@ class AppFactory:
         :rtype: Callable[[type[OpenStackApplication]], type[OpenStackApplication]]
         """
 
-        def decorator(application: type[OpenStackApplication]) -> type[OpenStackApplication]:
+        def decorator(  # pylint: disable=W9011
+            application: type[OpenStackApplication],
+        ) -> type[OpenStackApplication]:
             for charm in charms:
                 cls.charms[charm] = application
             return application

--- a/cou/commands.py
+++ b/cou/commands.py
@@ -167,7 +167,7 @@ def create_plan_subparser(
 
     :param subparsers: subparsers that plan subparser belongs to
     :type subparsers: argparse.ArgumentParser
-    :param subcommand_common_opts_parser parser groups options commonly shared by subcommands
+    :param subcommand_common_opts_parser: parser groups options commonly shared by subcommands
     :type subcommand_common_opts_parser: argparse.ArgumentParser
     :param dp_parser: a parser groups options specific to data-plane
     :type dp_parser: argparse.ArgumentParser
@@ -223,7 +223,7 @@ def create_run_subparser(
 
     :param subparsers: subparsers that plan subparser belongs to
     :type subparsers: argparse.ArgumentParser
-    :param subcommand_common_opts_parser parser groups options commonly shared by subcommands
+    :param subcommand_common_opts_parser: parser groups options commonly shared by subcommands
     :type subcommand_common_opts_parser: argparse.ArgumentParser
     :param dp_parser: a parser groups options specific to data-plane
     :type dp_parser: argparse.ArgumentParser
@@ -284,10 +284,10 @@ def create_run_subparser(
 def create_subparsers(parser: argparse.ArgumentParser) -> argparse._SubParsersAction:
     """Create and configure subparsers.
 
-    :param parsers: the top level parser to create subparsers for,
-    :type parsers: argparse.ArgumentParser
-    :return subparsers: configured subparsers
-    :type subparsers: argparse.ArgumentParser
+    :param parser: the top level parser to create subparsers for,
+    :type parser: argparse.ArgumentParser
+    :return: configured subparsers
+    :rtype: argparse._SubParsersAction
     """
     # Configure subcommand parser
     subparsers = parser.add_subparsers(
@@ -321,9 +321,9 @@ def create_subparsers(parser: argparse.ArgumentParser) -> argparse._SubParsersAc
 def parse_args(args: Any) -> argparse.Namespace:  # pylint: disable=inconsistent-return-statements
     """Parse cli arguments.
 
-    :return: Arguments parser.
-    :rtype: argparse.ArgumentParser
-    :return: Parsed arguments.
+    :param args: Arguments parser.
+    :type args: Any
+    :return: argparse.Namespace
     :rtype: argparse.Namespace
     :raises argparse.ArgumentError: Unexpected arguments input.
     """

--- a/cou/logging.py
+++ b/cou/logging.py
@@ -30,6 +30,8 @@ class TracebackInfoFilter(logging.Filter):  # pylint: disable=too-few-public-met
     def filter(self, record: logging.LogRecord) -> bool:
         """Filter function that sets exception info and cache to None.
 
+        :param record: An event being logged.
+        :type record: logging.LogRecord
         :return: Whether the specified record is to be logged.
         :rtype: bool
         """
@@ -38,7 +40,11 @@ class TracebackInfoFilter(logging.Filter):  # pylint: disable=too-few-public-met
 
 
 def setup_logging(log_level: str = "INFO") -> None:
-    """Do setup for logging."""
+    """Do setup for logging.
+
+    :param log_level: Logging level, defaults to "INFO"
+    :type log_level: str, optional
+    """
     log_formatter_file = logging.Formatter(
         fmt="%(asctime)s [%(name)s] [%(levelname)s] %(message)s", datefmt="%Y-%m-%d %H:%M:%S"
     )

--- a/cou/steps/backup.py
+++ b/cou/steps/backup.py
@@ -77,6 +77,7 @@ async def get_database_app_unit_name(model: COUModel) -> str:
 
     :param model: COUModel object
     :type model: COUModel
+    :raises UnitNotFound: When cannot find a valid unit for 'mysql-innodb-cluster
     :returns: Name of the mysql-innodb-cluster application name
     :rtype: ApplicationStatus
     """

--- a/cou/steps/execute.py
+++ b/cou/steps/execute.py
@@ -37,9 +37,23 @@ def prompt(parameter: str) -> str:
     """
 
     def bold(text: str) -> str:
+        """Transform the text in bold format.
+
+        :param text: text to format.
+        :type text: str
+        :return: text formatted.
+        :rtype: str
+        """
         return Style.RESET_ALL + Fore.RED + Style.BRIGHT + text + Style.RESET_ALL
 
     def normal(text: str) -> str:
+        """Transform the text in normal format.
+
+        :param text: text to format.
+        :type text: str
+        :return: text formatted.
+        :rtype: str
+        """
         return Style.RESET_ALL + Fore.RED + text + Style.RESET_ALL
 
     return (

--- a/cou/steps/plan.py
+++ b/cou/steps/plan.py
@@ -37,6 +37,7 @@ async def generate_plan(analysis_result: Analysis) -> UpgradeStep:
 
     :param analysis_result: Analysis result.
     :type analysis_result: Analysis
+    :raises NoTargetError: When cannot find target to upgrade.
     :return: Plan with all upgrade steps necessary based on the Analysis.
     :rtype: UpgradeStep
     """
@@ -88,6 +89,7 @@ async def create_upgrade_group(
     :type description: str
     :param filter_function: Function to filter applications.
     :type filter_function: Callable[[OpenStackApplication], bool]
+    :raises Exception: When cannot generate upgrade plan.
     :return: Upgrade group.
     :rtype: UpgradeStep
     """

--- a/cou/utils/app_utils.py
+++ b/cou/utils/app_utils.py
@@ -28,7 +28,7 @@ async def upgrade_packages(units: Iterable[str], model: COUModel) -> None:
     """Run package updates and upgrades on each unit of an Application.
 
     :param units: The list of unit names where the package upgrade runs on.
-    :type Iterable[str]
+    :type units: Iterable[str]
     :param model: COUModel object
     :type model: COUModel
     :raises PackageUpgradeError: When the package upgrade fails.

--- a/cou/utils/juju_utils.py
+++ b/cou/utils/juju_utils.py
@@ -98,7 +98,7 @@ def retry(
 
     def _wrapper(func: Callable) -> Callable:
         @wraps(func)
-        async def wrapper(*args: Any, **kwargs: Any) -> Any:
+        async def wrapper(*args: Any, **kwargs: Any) -> Any:  # pylint: disable=W9011
             attempt: int = 0
             start_time = datetime.now()
             while (datetime.now() - start_time).seconds <= timeout:
@@ -137,7 +137,13 @@ class COUModel:
 
     @staticmethod
     async def create(name: Optional[str]) -> "COUModel":
-        """Create COUModel object and connect it to model."""
+        """Create COUModel object and connect it to model.
+
+        :param name: Name of the model.
+        :type name: Optional[str]
+        :return: COUModel object.
+        :rtype: COUModel
+        """
         model = COUModel(name)
         await model._connect()  # pylint: disable=protected-access
         return model
@@ -225,10 +231,9 @@ class COUModel:
 
         :param application_name: Name of application
         :type application_name: str
+        :raises ApplicationError: if charm_name is None
         :return: Charm name
         :rtype: str
-        :raises: ApplicationNotFound
-        :raises: ApplicationError if charm_name is None
         """
         app = await self._get_application(application_name)
         if app.charm_name is None:
@@ -258,14 +263,13 @@ class COUModel:
         :type unit_name: str
         :param action_name: Name of action to run
         :type action_name: str
-        :param action_params: Dictionary of config options for action
-        :type action_params: Optional[Dict]
+        :param action_params: Dictionary of config options for action, defaults to None
+        :type action_params: Optional[Dict], optional
         :param raise_on_failure: Raise ActionFailed exception on failure, defaults to False
-        :type raise_on_failure: bool
-        :returns: Action object
-        :rtype: juju.action.Action
-        :raises: UnitNotFound
-        :raises: ActionFailed
+        :type raise_on_failure: bool, optional
+        :raises ActionFailed: _description_
+        :return: When status is different from "completed"
+        :rtype: Action
         """
         action_params = action_params or {}
         unit = await self._get_unit(unit_name)
@@ -286,7 +290,7 @@ class COUModel:
         """Juju run on unit.
 
         :param unit_name: Name of unit to match
-        :type unit: str
+        :type unit_name: str
         :param command: Command to execute
         :type command: str
         :param timeout: How long in seconds to wait for command to complete
@@ -388,7 +392,13 @@ class COUModel:
         )
 
     async def wait_for_idle(self, timeout: int, apps: Optional[list[str]] = None) -> None:
-        """Wait for model to reach an idle state."""
+        """Wait for model to reach an idle state.
+
+        :param timeout: Timeout in seconds.
+        :type timeout: int
+        :param apps: Applications to wait, defaults to None
+        :type apps: Optional[list[str]], optional
+        """
         model = await self._get_model()
         await model.wait_for_idle(
             apps=apps, timeout=timeout, idle_period=DEFAULT_MODEL_IDLE_PERIOD

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ skip_glob = [
 
 [tool.pylint]
 max-line-length = 99
+load-plugins = "pylint.extensions.docparams"
 ignore-paths = [
     ".eggs",
     ".git",
@@ -46,6 +47,11 @@ ignore-paths = [
     "report",
     "tests"
 ]
+default-docstring-type = "sphinx"
+accept-no-param-doc = false
+accept-no-raise-doc = false
+accept-no-return-doc = false
+accept-no-yields-doc = false
 
 [tool.mypy]
 warn_unused_ignores = true

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,11 @@ from setuptools import setup
 
 
 def find_version() -> str:
-    """Parse charmed-openstack-upgrader version based on the git tag."""
+    """Parse charmed-openstack-upgrader version based on the git tag.
+
+    :return: Version of the package.
+    :rtype: str
+    """
     try:
         cmd: List[str] = ["git", "describe", "--tags", "--always", "HEAD"]
         gitversion: str = subprocess.check_output(cmd, stderr=subprocess.DEVNULL).decode().strip()


### PR DESCRIPTION
Docstrings are hard to maintaining and review and can be easily outdated.
This PR adds docparams extension to be more strict with those checks and also fix the problems found in the project.
Documentation of the plugin can be found [here](https://pylint.pycqa.org/en/latest/user_guide/checkers/extensions.html#parameter-documentation-checker)