### PR TITLE
Add private methods on docstring checks.

### DIFF
--- a/cou/apps/app.py
+++ b/cou/apps/app.py
@@ -461,8 +461,8 @@ class OpenStackApplication:
 
         :param parallel: Parallel running, defaults to False
         :type parallel: bool, optional
-        :return plan: Plan for upgrading software packages to the latest of the current release.
-        :type plan: UpgradeStep
+        :return: Plan for upgrading software packages to the latest of the current release.
+        :rtype: UpgradeStep
         """
         return UpgradeStep(
             description=(

--- a/cou/steps/execute.py
+++ b/cou/steps/execute.py
@@ -70,9 +70,9 @@ def prompt(parameter: str) -> str:
 async def _run_step(step: UpgradeStep, interactive: bool) -> None:
     """Run step and all sub-steps.
 
-    :param plan: Plan to be executed on steps.
-    :type plan: UpgradeStep
-    :param interactive:
+    :param step: Plan to be executed on steps.
+    :type step: UpgradeStep
+    :param interactive: Interactive mode or not.
     :type interactive: bool
     """
     logger.debug("running step %s", step)

--- a/cou/utils/juju_utils.py
+++ b/cou/utils/juju_utils.py
@@ -96,7 +96,7 @@ def retry(
     :rtype: Callable
     """
 
-    def _wrapper(func: Callable) -> Callable:
+    def _wrapper(func: Callable) -> Callable:  # pylint: disable=W9011
         @wraps(func)
         async def wrapper(*args: Any, **kwargs: Any) -> Any:  # pylint: disable=W9011
             attempt: int = 0
@@ -180,9 +180,9 @@ class COUModel:
 
         :param name: Name of application
         :type name: str
+        :raises ApplicationNotFound: When cannot find Application in the model.
         :return: Application
         :rtype: Application
-        :raises: ApplicationNotFound
         """
         model = await self._get_model()
         app = model.applications.get(name)
@@ -192,7 +192,11 @@ class COUModel:
         return app
 
     async def _get_model(self) -> Model:
-        """Get juju.model.Model and make sure that it is connected."""
+        """Get juju.model.Model and make sure that it is connected.
+
+        :return: Model
+        :rtype: Model
+        """
         if not self.connected:
             await self._connect()
 
@@ -203,9 +207,9 @@ class COUModel:
 
         :param name: Name of unit
         :type name: str
+        :raises UnitNotFound: When cannot find unit in the model.
         :return: Unit
         :rtype: Unit
-        :raises: UnitNotFound
         """
         model = await self._get_model()
         unit = model.units.get(name)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ ignore-paths = [
     "report",
     "tests"
 ]
+no-docstring-rgx = "__.*__"
 default-docstring-type = "sphinx"
 accept-no-param-doc = false
 accept-no-raise-doc = false


### PR DESCRIPTION
[pylint]((https://pylint.pycqa.org/en/latest/user_guide/configuration/all-options.html#no-docstring-rgx) for standard doesn't consider private methods to be checked for docstrings. This PR changes this behavior to not check just the magic methods.