### PR TITLE
Changed plug name for publish

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ sudo snap remove charmed-openstack-upgrader --purge
 make build
 sudo snap install ./charmed-openstack-upgrader.snap --dangerous
 sudo snap connect charmed-openstack-upgrader:juju-client-observe snapd
-sudo snap connect charmed-openstack-upgrader:dot-local-cou snapd
+sudo snap connect charmed-openstack-upgrader:dot-local-share-cou snapd
 sudo snap alias charmed-openstack-upgrader.cou cou
 ```
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -18,7 +18,7 @@ apps:
       - juju-client-observe
       - network
       - network-bind
-      - dot-local-cou
+      - dot-local-share-cou
 
 parts:
   cou-wrapper:
@@ -52,7 +52,7 @@ parts:
       craftctl set version=${VERSION}
 
 plugs:
-  dot-local-cou:
+  dot-local-share-cou:
     interface: personal-files
     write:
       - $HOME/.local/share/cou


### PR DESCRIPTION
Change plug name from `dot-local-cou` to `dot-local-share-cou` as requested by [snapcraft team](https://forum.snapcraft.io/t/manual-review-for-charmed-openstack-upgrader-auto-connect-for-juju-client-observe-and-personal-files/36910/3)