### PR TITLE
Add codespell in lint check to prevent common misspellings

### DIFF
--- a/cou/steps/analyze.py
+++ b/cou/steps/analyze.py
@@ -115,7 +115,7 @@ class Analysis:
             apps_to_upgrade_in_order,
             key=lambda app: UPGRADE_ORDER.index(app.charm),  # type: ignore
         )
-        # order by charm name to have a predicable upgrade sequence of others o7k charms.
+        # order by charm name to have a predictable upgrade sequence of others o7k charms.
         other_o7k_apps_sorted_by_name = sorted(
             other_o7k_apps, key=lambda app: app.charm  # type: ignore
         )

--- a/cou/utils/juju_utils.py
+++ b/cou/utils/juju_utils.py
@@ -370,7 +370,7 @@ class COUModel:
         :type force_series: bool
         :param force_units: Upgrade all units immediately, even if in error state
         :type force_units: bool
-        :param path: Uprade to a charm located at path
+        :param path: Upgrade to a charm located at path
         :type path: str
         :param resources: Dictionary of resource name/filepath pairs
         :type resources: dict

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,3 +86,8 @@ directory = "tests/unit/report/html"
 
 [tool.coverage.xml]
 output = "tests/unit/report/coverage.xml"
+
+[tool.codespell]
+skip = ".eggs,.tox,.git,.venv,venv,build,.build,lib,report"
+quiet-level = 3
+check-filenames = true

--- a/setup.cfg
+++ b/setup.cfg
@@ -46,6 +46,7 @@ lint =
     pylint
     mypy
     types-PyYAML
+    codespell
 
 unittests =
     pytest

--- a/tox.ini
+++ b/tox.ini
@@ -33,6 +33,7 @@ commands =
     mypy --install-types --non-interactive .
     black --check --diff --color .
     isort --check --diff --color .
+    codespell
 deps =
     .[lint]
     {[testenv:unit]deps}


### PR DESCRIPTION
Misspellings are common and hard to catch in code reviews. Adding `codespell` check in lint test would help us reduce those typos.