### PR TITLE
fix broken lint because of docstrings.

### DIFF
--- a/cou/apps/app.py
+++ b/cou/apps/app.py
@@ -497,6 +497,7 @@ class OpenStackApplication:
         :type target: OpenStackRelease
         :param parallel: Parallel running, defaults to False
         :type parallel: bool, optional
+        :raises ApplicationError: When application has unexpected channel.
         :return: Plan for refreshing the charm.
         :rtype: Optional[UpgradeStep]
         """

--- a/cou/apps/ceph.py
+++ b/cou/apps/ceph.py
@@ -64,7 +64,7 @@ class CephMonApplication(OpenStackAuxiliaryApplication):
         https://docs.openstack.org/charm-guide/latest/project/issues/upgrade-issues.html#ceph-require-osd-release
 
         :param channel: The channel to get ceph track from.
-        :type str
+        :type channel: str
         :param parallel: Parallel running, defaults to False
         :type parallel: bool, optional
         :return: Plan to check and set correct value for require-osd-release


### PR DESCRIPTION
Currently lint is broken because merges happened without rebasing #85 