### PR TITLE
drop parallel for `cou plan`

### DIFF
--- a/completions/bash/cou_bash_completion
+++ b/completions/bash/cou_bash_completion
@@ -2,7 +2,7 @@ _subcommand_args() {
     local cmd=$1
     case "${cmd}" in
         plan)
-            opts="--help --quiet --verbose --parallel --model"
+            opts="--help --quiet --verbose --model"
             child_commands=""
             ;;
         run)

--- a/cou/commands.py
+++ b/cou/commands.py
@@ -86,12 +86,6 @@ def get_subcommand_common_opts_parser() -> argparse.ArgumentParser:
         "  2 - Environment variable MODEL_NAME,"
         "  3 - Current active juju model",
     )
-    subcommand_common_opts_parser.add_argument(
-        "--parallel",
-        help="Run upgrade steps in parallel where possible.",
-        default=False,
-        action="store_true",
-    )
 
     # quiet and verbose options are mutually exclusive
     group = subcommand_common_opts_parser.add_mutually_exclusive_group()
@@ -235,6 +229,12 @@ def create_run_subparser(
         help="Run upgrade with prompt.",
         action=argparse.BooleanOptionalAction,
         default=True,
+    )
+    subcommand_common_opts_parser.add_argument(
+        "--parallel",
+        help="Run upgrade steps in parallel where possible.",
+        default=False,
+        action="store_true",
     )
     run_parser = subparsers.add_parser(
         "run",

--- a/tests/unit/test_commands.py
+++ b/tests/unit/test_commands.py
@@ -69,7 +69,6 @@ def test_parse_args_quiet_verbose_exclusive(args):
             Namespace(
                 command="plan",
                 model_name=None,
-                parallel=False,
                 verbosity=0,
                 quiet=False,
                 **{"upgrade-group": None}
@@ -80,7 +79,6 @@ def test_parse_args_quiet_verbose_exclusive(args):
             Namespace(
                 command="plan",
                 model_name="model_name",
-                parallel=False,
                 verbosity=0,
                 quiet=False,
                 **{"upgrade-group": None}
@@ -91,7 +89,6 @@ def test_parse_args_quiet_verbose_exclusive(args):
             Namespace(
                 command="plan",
                 model_name=None,
-                parallel=False,
                 verbosity=0,
                 quiet=False,
                 **{"upgrade-group": "control-plane"}
@@ -102,7 +99,6 @@ def test_parse_args_quiet_verbose_exclusive(args):
             Namespace(
                 command="plan",
                 model_name=None,
-                parallel=False,
                 verbosity=0,
                 quiet=False,
                 machines=None,
@@ -116,7 +112,6 @@ def test_parse_args_quiet_verbose_exclusive(args):
             Namespace(
                 command="plan",
                 model_name=None,
-                parallel=False,
                 verbosity=1,
                 quiet=False,
                 **{"upgrade-group": "control-plane"}
@@ -127,7 +122,6 @@ def test_parse_args_quiet_verbose_exclusive(args):
             Namespace(
                 command="plan",
                 model_name=None,
-                parallel=False,
                 verbosity=0,
                 quiet=False,
                 machines=["1", "2,3"],
@@ -141,7 +135,6 @@ def test_parse_args_quiet_verbose_exclusive(args):
             Namespace(
                 command="plan",
                 model_name=None,
-                parallel=False,
                 verbosity=0,
                 quiet=True,
                 machines=None,
@@ -151,11 +144,10 @@ def test_parse_args_quiet_verbose_exclusive(args):
             ),
         ),
         (
-            ["plan", "data-plane", "--parallel", "--hostname=1", "-n=2,3"],
+            ["plan", "data-plane", "--hostname=1", "-n=2,3"],
             Namespace(
                 command="plan",
                 model_name=None,
-                parallel=True,
                 verbosity=0,
                 quiet=False,
                 machines=None,


### PR DESCRIPTION
Dropping option `parallel` for `plan` command.

Fixes: #110