### PR TITLE
remove data plane charm support.

### DIFF
--- a/cou/utils/openstack.py
+++ b/cou/utils/openstack.py
@@ -417,13 +417,15 @@ class OpenStackCodenameLookup:
 def is_charm_supported(charm: str) -> bool:
     """Check if a charm upgrade is supported.
 
+    Currently data plane apps are not supported.
     :param charm: Name of the charm.
     :type charm: str
     :return: True if supported, else False
     :rtype: bool
     """
     return (
-        bool(OpenStackCodenameLookup.lookup(charm))
+        charm not in DATA_PLANE_CHARMS
+        and bool(OpenStackCodenameLookup.lookup(charm))
         or charm in SUBORDINATES + AUXILIARY_SUBORDINATES
     )
 

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -282,6 +282,8 @@ def full_status(status, model):
             ("cinder", status["cinder_ussuri"]),
             ("rabbitmq-server", status["rabbitmq_server"]),
             ("my_app", status["unknown_app"]),
+            ("nova-compute", status["unknown_app"]),
+            ("ceph-osd", status["unknown_app"]),
         ]
     )
     return mock_full_status

--- a/tests/unit/steps/test_steps_analyze.py
+++ b/tests/unit/steps/test_steps_analyze.py
@@ -87,9 +87,10 @@ async def test_populate_model(full_status, config, model):
     model.get_status = AsyncMock(return_value=full_status)
     model.get_application_config = AsyncMock(return_value=config["openstack_ussuri"])
 
-    # Initially, 6 applications are in the status: keystone, cinder, rabbitmq-serve, my-app,
+    # Initially, 6 applications are in the status: keystone, cinder, rabbitmq-server, my-app,
     # ceph-osd and nova-compute. my-app it's not on the lookup table, ceph-osd and nova-compute
-    # are data plane (not supported yet) and because of that they won't be instantiated.
+    # are data plane applications (not supported yet) and because of that they won't
+    # be instantiated.
     assert len(full_status.applications) == 6
     apps = await Analysis._populate(model)
     assert len(apps) == 3

--- a/tests/unit/steps/test_steps_analyze.py
+++ b/tests/unit/steps/test_steps_analyze.py
@@ -87,9 +87,10 @@ async def test_populate_model(full_status, config, model):
     model.get_status = AsyncMock(return_value=full_status)
     model.get_application_config = AsyncMock(return_value=config["openstack_ussuri"])
 
-    # Initially, 4 applications are in the status: keystone, cinder, rabbitmq-server and my-app
-    # my-app it's not on the lookup and won't be instantiated.
-    assert len(full_status.applications) == 4
+    # Initially, 6 applications are in the status: keystone, cinder, rabbitmq-serve, my-app,
+    # ceph-osd and nova-compute. my-app it's not on the lookup table, ceph-osd and nova-compute
+    # are data plane (not supported yet) and because of that they won't be instantiated.
+    assert len(full_status.applications) == 6
     apps = await Analysis._populate(model)
     assert len(apps) == 3
     # apps are on the UPGRADE_ORDER sequence

--- a/tests/unit/utils/test_openstack.py
+++ b/tests/unit/utils/test_openstack.py
@@ -19,6 +19,7 @@ from cou.utils.openstack import (
     OpenStackCodenameLookup,
     OpenStackRelease,
     VersionRange,
+    is_charm_supported,
 )
 
 
@@ -458,3 +459,19 @@ def test_openstack_to_track(charm, series, os_release, exp_result):
 )
 def test_track_to_openstack(charm, series, track, exp_result):
     assert TRACK_TO_OPENSTACK_MAPPING.get((charm, series, track)) == exp_result
+
+
+@pytest.mark.parametrize(
+    "charm, exp_result",
+    [
+        ("keystone", True),
+        ("ceph-mon", True),
+        ("ceph-osd", False),
+        ("nova-compute", False),
+        ("my-charm", False),
+        ("barbican-vault", True),
+        ("hacluster", True),
+    ],
+)
+def test_is_charm_supported(charm, exp_result):
+    assert is_charm_supported(charm) is exp_result


### PR DESCRIPTION
- with this removal, data-plane charms won't be instantiated as OpenStack applications.