### PR TITLE
Refactor cloud os release analysis

### DIFF
--- a/cou/apps/app.py
+++ b/cou/apps/app.py
@@ -455,7 +455,7 @@ class OpenStackApplication:
         """
         return [self._get_reached_expected_target_plan(target)]
 
-    def generate_upgrade_plan(self, target: str) -> UpgradeStep:
+    def generate_upgrade_plan(self, target: OpenStackRelease) -> UpgradeStep:
         """Generate full upgrade plan for an Application.
 
         :param target: OpenStack codename to upgrade.
@@ -463,16 +463,15 @@ class OpenStackApplication:
         :return: Full upgrade plan if the Application is able to generate it.
         :rtype: UpgradeStep
         """
-        target_version = OpenStackRelease(target)
         upgrade_steps = UpgradeStep(
             description=f"Upgrade plan for '{self.name}' to {target}",
             parallel=False,
             function=None,
         )
         all_steps = (
-            self.pre_upgrade_plan(target_version)
-            + self.upgrade_plan(target_version)
-            + self.post_upgrade_plan(target_version)
+            self.pre_upgrade_plan(target)
+            + self.upgrade_plan(target)
+            + self.post_upgrade_plan(target)
         )
         for step in all_steps:
             if step:

--- a/cou/steps/analyze.py
+++ b/cou/steps/analyze.py
@@ -156,8 +156,6 @@ class Analysis:
     def current_cloud_os_release(self) -> Optional[OpenStackRelease]:
         """Shows the current OpenStack release codename.
 
-        This property just consider OpenStack charms as those that have
-        openstack-origin or source on the charm configuration (app.os_origin).
         :return: OpenStack release codename
         :rtype: Optional[OpenStackRelease]
         """
@@ -170,8 +168,6 @@ class Analysis:
     def next_cloud_os_release(self) -> Optional[OpenStackRelease]:
         """Shows the next OpenStack release codename.
 
-        This property just consider OpenStack charms as those that have
-        openstack-origin or source on the charm configuration (app.os_origin).
         :return: OpenStack release codename
         :rtype: Optional[OpenStackRelease]
         """

--- a/cou/steps/analyze.py
+++ b/cou/steps/analyze.py
@@ -148,6 +148,8 @@ class Analysis:
             + "\n".join([str(app) for app in self.apps_control_plane])
             + "Data Plane:\n"
             + "\n".join([str(app) for app in self.apps_data_plane])
+            + f"\nCurrent Cloud OpenStack Release: {self.current_cloud_os_release}\n"
+            + f"Next Cloud OpenStack Release: {self.next_cloud_os_release}\n"
         )
 
     @property
@@ -157,9 +159,22 @@ class Analysis:
         This property just consider OpenStack charms as those that have
         openstack-origin or source on the charm configuration (app.os_origin).
         :return: OpenStack release codename
-        :rtype: OpenStackRelease
+        :rtype: Optional[OpenStackRelease]
         """
         return min(
             (app.current_os_release for app in self.apps_control_plane + self.apps_data_plane),
             default=None,
+        )
+
+    @property
+    def next_cloud_os_release(self) -> Optional[OpenStackRelease]:
+        """Shows the next OpenStack release codename.
+
+        This property just consider OpenStack charms as those that have
+        openstack-origin or source on the charm configuration (app.os_origin).
+        :return: OpenStack release codename
+        :rtype: Optional[OpenStackRelease]
+        """
+        return (
+            self.current_cloud_os_release.next_release if self.current_cloud_os_release else None
         )

--- a/cou/steps/plan.py
+++ b/cou/steps/plan.py
@@ -39,6 +39,7 @@ from cou.exceptions import HaltUpgradePlanGeneration, NoTargetError
 from cou.steps import UpgradeStep
 from cou.steps.analyze import Analysis
 from cou.steps.backup import backup
+from cou.utils.openstack import OpenStackRelease
 
 logger = logging.getLogger(__name__)
 
@@ -52,7 +53,7 @@ async def generate_plan(analysis_result: Analysis) -> UpgradeStep:
     :return: Plan with all upgrade steps necessary based on the Analysis.
     :rtype: UpgradeStep
     """
-    target = getattr(analysis_result.current_cloud_os_release, "next_release", None)
+    target = analysis_result.next_cloud_os_release
     if not target:
         raise NoTargetError("Cannot find target to upgrade.")
 
@@ -87,7 +88,7 @@ async def generate_plan(analysis_result: Analysis) -> UpgradeStep:
 
 async def create_upgrade_group(
     apps: list[OpenStackApplication],
-    target: str,
+    target: OpenStackRelease,
     description: str,
     filter_function: Callable[[OpenStackApplication], bool],
 ) -> UpgradeStep:
@@ -95,8 +96,8 @@ async def create_upgrade_group(
 
     :param apps: Result of the analysis.
     :type apps: list[OpenStackApplication]
-    :param target: Target OpenStack version.
-    :type target: str
+    :param target: Target OpenStack release.
+    :type target: OpenStackRelease
     :param description: Description of the upgrade step.
     :type description: str
     :param filter_function: Function to filter applications.

--- a/cou/utils/openstack.py
+++ b/cou/utils/openstack.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 """Lookup utils to determine compatible OpenStack codenames for a given component."""
+from __future__ import annotations
 
 import csv
 import encodings
@@ -240,7 +241,7 @@ class OpenStackRelease:
             raise ValueError(f"OpenStack '{value}' is not in '{self.openstack_codenames}'")
 
     @property
-    def next_release(self) -> Optional["OpenStackRelease"]:
+    def next_release(self) -> Optional[OpenStackRelease]:
         """Return the next OpenStack release codename.
 
         :return: OpenStack release codename.
@@ -253,7 +254,7 @@ class OpenStackRelease:
             return None
 
     @property
-    def previous_release(self) -> Optional["OpenStackRelease"]:
+    def previous_release(self) -> Optional[OpenStackRelease]:
         """Return the previous OpenStack release codename.
 
         :return: OpenStack release codename.

--- a/cou/utils/openstack.py
+++ b/cou/utils/openstack.py
@@ -240,20 +240,20 @@ class OpenStackRelease:
             raise ValueError(f"OpenStack '{value}' is not in '{self.openstack_codenames}'")
 
     @property
-    def next_release(self) -> Optional[str]:
+    def next_release(self) -> Optional["OpenStackRelease"]:
         """Return the next OpenStack release codename.
 
         :return: OpenStack release codename.
         :rtype: Optional[str]
         """
         try:
-            return self.openstack_codenames[self.index + 1]
+            return OpenStackRelease(self.openstack_codenames[self.index + 1])
         except IndexError:
             logger.warning("Cannot find an OpenStack release after %s", self.codename)
             return None
 
     @property
-    def previous_release(self) -> Optional[str]:
+    def previous_release(self) -> Optional["OpenStackRelease"]:
         """Return the previous OpenStack release codename.
 
         :return: OpenStack release codename.
@@ -263,7 +263,7 @@ class OpenStackRelease:
             logger.warning("Cannot find an OpenStack release before %s", self.codename)
             return None
 
-        return self.openstack_codenames[self.index - 1]
+        return OpenStackRelease(self.openstack_codenames[self.index - 1])
 
     @property
     def date(self) -> str:

--- a/cou/utils/openstack.py
+++ b/cou/utils/openstack.py
@@ -245,7 +245,7 @@ class OpenStackRelease:
         """Return the next OpenStack release codename.
 
         :return: OpenStack release codename.
-        :rtype: Optional[str]
+        :rtype: Optional[OpenStackRelease]
         """
         try:
             return OpenStackRelease(self.openstack_codenames[self.index + 1])
@@ -258,7 +258,7 @@ class OpenStackRelease:
         """Return the previous OpenStack release codename.
 
         :return: OpenStack release codename.
-        :rtype: Optional[str]
+        :rtype: Optional[OpenStackRelease]
         """
         if self.index == 0:
             logger.warning("Cannot find an OpenStack release before %s", self.codename)

--- a/tests/unit/apps/test_app.py
+++ b/tests/unit/apps/test_app.py
@@ -72,7 +72,6 @@ def assert_application(
     exp_channel_codename,
     target,
 ):
-    target_version = OpenStackRelease(target)
     assert app.name == exp_name
     assert app.series == exp_series
     assert app.status == exp_status
@@ -85,14 +84,14 @@ def assert_application(
     assert app.channel == exp_channel
     assert app.current_os_release == exp_current_os_release
     assert app.possible_current_channels == exp_possible_current_channels
-    assert app.target_channel(target_version) == exp_target_channel
-    assert app.new_origin(target_version) == exp_new_origin
+    assert app.target_channel(target) == exp_target_channel
+    assert app.new_origin(target) == exp_new_origin
     assert app.apt_source_codename == exp_apt_source_codename
     assert app.channel_codename == exp_channel_codename
 
 
 def test_application_ussuri(status, config, units, model):
-    target = "victoria"
+    target = OpenStackRelease("victoria")
     app_status = status["keystone_ussuri"]
     app_config = config["openstack_ussuri"]
     exp_charm_origin = "ch"
@@ -147,7 +146,7 @@ def test_application_different_wl(status, config, model):
 
 def test_application_cs(status, config, units, model):
     """Test when application is from charm store."""
-    target = "victoria"
+    target = OpenStackRelease("victoria")
     app_status = status["keystone_ussuri_cs"]
     app_config = config["openstack_ussuri"]
     exp_os_origin = "distro"
@@ -186,7 +185,7 @@ def test_application_cs(status, config, units, model):
 
 
 def test_application_wallaby(status, config, units, model):
-    target = "xena"
+    target = OpenStackRelease("xena")
     exp_units = units["units_wallaby"]
     exp_charm_origin = "ch"
     app_config = config["openstack_wallaby"]
@@ -310,7 +309,7 @@ async def test_application_check_upgrade_fail(status, config, model):
 
 
 def test_upgrade_plan_ussuri_to_victoria(status, config, model):
-    target = "victoria"
+    target = OpenStackRelease("victoria")
     app_status = status["keystone_ussuri"]
     app_config = config["openstack_ussuri"]
     app = OpenStackApplication("my_keystone", app_status, app_config, model, "keystone")
@@ -366,7 +365,7 @@ def test_upgrade_plan_ussuri_to_victoria(status, config, model):
             description=f"Check if the workload of '{app.name}' has been upgraded",
             parallel=False,
             function=app._check_upgrade,
-            target=OpenStackRelease(target),
+            target=target,
         ),
     ]
     add_steps(expected_plan, upgrade_steps)
@@ -375,7 +374,7 @@ def test_upgrade_plan_ussuri_to_victoria(status, config, model):
 
 
 def test_upgrade_plan_ussuri_to_victoria_ch_migration(status, config, model):
-    target = "victoria"
+    target = OpenStackRelease("victoria")
     app_status = status["keystone_ussuri_cs"]
     app_config = config["openstack_ussuri"]
     app = OpenStackApplication("my_keystone", app_status, app_config, model, "keystone")
@@ -431,7 +430,7 @@ def test_upgrade_plan_ussuri_to_victoria_ch_migration(status, config, model):
             description=f"Check if the workload of '{app.name}' has been upgraded",
             parallel=False,
             function=app._check_upgrade,
-            target=OpenStackRelease(target),
+            target=target,
         ),
     ]
     add_steps(expected_plan, upgrade_steps)
@@ -440,7 +439,7 @@ def test_upgrade_plan_ussuri_to_victoria_ch_migration(status, config, model):
 
 
 def test_upgrade_plan_channel_on_next_os_release(status, config, model):
-    target = "victoria"
+    target = OpenStackRelease("victoria")
     app_status = status["keystone_ussuri"]
     app_config = config["openstack_ussuri"]
     # channel it's already on next OpenStack release
@@ -485,7 +484,7 @@ def test_upgrade_plan_channel_on_next_os_release(status, config, model):
             description=f"Check if the workload of '{app.name}' has been upgraded",
             parallel=False,
             function=app._check_upgrade,
-            target=OpenStackRelease(target),
+            target=target,
         ),
     ]
     add_steps(expected_plan, upgrade_steps)
@@ -494,7 +493,7 @@ def test_upgrade_plan_channel_on_next_os_release(status, config, model):
 
 
 def test_upgrade_plan_origin_already_on_next_openstack_release(status, config, model):
-    target = "victoria"
+    target = OpenStackRelease("victoria")
     app_status = status["keystone_ussuri"]
     app_config = config["openstack_ussuri"]
     # openstack-origin already configured for next OpenStack release
@@ -542,7 +541,7 @@ def test_upgrade_plan_origin_already_on_next_openstack_release(status, config, m
             description=f"Check if the workload of '{app.name}' has been upgraded",
             parallel=False,
             function=app._check_upgrade,
-            target=OpenStackRelease(target),
+            target=target,
         ),
     ]
     add_steps(expected_plan, upgrade_steps)
@@ -555,7 +554,7 @@ def test_upgrade_plan_application_already_upgraded(status, config, model):
         "Application 'my_keystone' already configured for release equal or greater "
         "than victoria. Ignoring."
     )
-    target = "victoria"
+    target = OpenStackRelease("victoria")
     app_status = status["keystone_wallaby"]
     app_config = config["openstack_wallaby"]
     app = OpenStackApplication("my_keystone", app_status, app_config, model, "keystone")
@@ -565,7 +564,7 @@ def test_upgrade_plan_application_already_upgraded(status, config, model):
 
 
 def test_upgrade_plan_application_already_disable_action_managed(status, config, model):
-    target = "victoria"
+    target = OpenStackRelease("victoria")
     app_status = status["keystone_ussuri"]
     app_config = config["openstack_ussuri"]
     app_config["action-managed-upgrade"]["value"] = False
@@ -621,7 +620,7 @@ def test_upgrade_plan_application_already_disable_action_managed(status, config,
             description=f"Check if the workload of '{app.name}' has been upgraded",
             parallel=False,
             function=app._check_upgrade,
-            target=OpenStackRelease(target),
+            target=target,
         ),
     ]
     add_steps(expected_plan, upgrade_steps)

--- a/tests/unit/apps/test_auxiliary.py
+++ b/tests/unit/apps/test_auxiliary.py
@@ -49,7 +49,7 @@ def test_auxiliary_app(status, config, model):
 
 
 def test_auxiliary_upgrade_plan_ussuri_to_victoria_change_channel(status, config, model):
-    target = "victoria"
+    target = OpenStackRelease("victoria")
     app = OpenStackAuxiliaryApplication(
         "rabbitmq-server",
         status["rabbitmq_server"],
@@ -104,7 +104,7 @@ def test_auxiliary_upgrade_plan_ussuri_to_victoria_change_channel(status, config
             description=f"Check if the workload of '{app.name}' has been upgraded",
             parallel=False,
             function=app._check_upgrade,
-            target=OpenStackRelease(target),
+            target=target,
         ),
     ]
     add_steps(expected_plan, upgrade_steps)
@@ -113,7 +113,7 @@ def test_auxiliary_upgrade_plan_ussuri_to_victoria_change_channel(status, config
 
 
 def test_auxiliary_upgrade_plan_ussuri_to_victoria(status, config, model):
-    target = "victoria"
+    target = OpenStackRelease("victoria")
     rmq_status = status["rabbitmq_server"]
     # rabbitmq already on channel 3.9 on ussuri
     rmq_status.charm_channel = "3.9/stable"
@@ -164,7 +164,7 @@ def test_auxiliary_upgrade_plan_ussuri_to_victoria(status, config, model):
             description=f"Check if the workload of '{app.name}' has been upgraded",
             parallel=False,
             function=app._check_upgrade,
-            target=OpenStackRelease(target),
+            target=target,
         ),
     ]
     add_steps(expected_plan, upgrade_steps)
@@ -173,7 +173,7 @@ def test_auxiliary_upgrade_plan_ussuri_to_victoria(status, config, model):
 
 
 def test_auxiliary_upgrade_plan_ussuri_to_victoria_ch_migration(status, config, model):
-    target = "victoria"
+    target = OpenStackRelease("victoria")
     rmq_status = status["rabbitmq_server"]
     rmq_status.charm = "cs:amd64/focal/rabbitmq-server-638"
     rmq_status.charm_channel = "stable"
@@ -229,7 +229,7 @@ def test_auxiliary_upgrade_plan_ussuri_to_victoria_ch_migration(status, config, 
             description=f"Check if the workload of '{app.name}' has been upgraded",
             parallel=False,
             function=app._check_upgrade,
-            target=OpenStackRelease(target),
+            target=target,
         ),
     ]
     add_steps(expected_plan, upgrade_steps)
@@ -238,7 +238,7 @@ def test_auxiliary_upgrade_plan_ussuri_to_victoria_ch_migration(status, config, 
 
 
 def test_auxiliary_upgrade_plan_unknown_track(status, config, model):
-    target = "victoria"
+    target = OpenStackRelease("victoria")
     rmq_status = status["rabbitmq_server"]
     # 2.0 is an unknown track
     rmq_status.charm_channel = "2.0/stable"
@@ -283,7 +283,7 @@ def test_auxiliary_raise_error_unknown_track(status, config, model):
 
 
 def test_auxiliary_raise_halt_upgrade(status, config, model):
-    target = "victoria"
+    target = OpenStackRelease("victoria")
     # source is already configured to wallaby, so the plan halt with target victoria
     app = OpenStackAuxiliaryApplication(
         "rabbitmq-server",

--- a/tests/unit/apps/test_auxiliary_subordinate.py
+++ b/tests/unit/apps/test_auxiliary_subordinate.py
@@ -14,6 +14,7 @@
 """Tests of the Auxiliary Subordinate application class."""
 
 from cou.steps import UpgradeStep
+from cou.utils.openstack import OpenStackRelease
 
 
 def test_auxiliary_subordinate(apps):
@@ -27,7 +28,7 @@ def test_auxiliary_subordinate(apps):
 
 
 def test_auxiliary_subordinate_upgrade_plan_to_victoria(apps, model):
-    target = "victoria"
+    target = OpenStackRelease("victoria")
     app = apps["keystone_mysql_router"]
 
     upgrade_plan = app.generate_upgrade_plan(target)

--- a/tests/unit/apps/test_ceph.py
+++ b/tests/unit/apps/test_ceph.py
@@ -44,13 +44,13 @@ def test_ceph_mon_app(status, config, model):
     assert app.channel_codename == "xena"
 
 
-def test_test_ceph_mon_upgrade_plan_xena_to_yoga(
+def test_ceph_mon_upgrade_plan_xena_to_yoga(
     status,
     config,
     model,
 ):
     """Test when ceph version changes between os releases."""
-    target = "yoga"
+    target = OpenStackRelease("yoga")
     app = CephMonApplication(
         "ceph-mon",
         status["ceph-mon_xena"],
@@ -115,7 +115,7 @@ def test_test_ceph_mon_upgrade_plan_xena_to_yoga(
             description=f"Check if the workload of '{app.name}' has been upgraded",
             parallel=False,
             function=app._check_upgrade,
-            target=OpenStackRelease(target),
+            target=target,
         ),
         UpgradeStep(
             description=(
@@ -139,7 +139,7 @@ def test_ceph_mon_upgrade_plan_ussuri_to_victoria(
     model,
 ):
     """Test when ceph version remains the same between os releases."""
-    target = "victoria"
+    target = OpenStackRelease("victoria")
     app = CephMonApplication(
         "ceph-mon",
         status["ceph-mon_ussuri"],
@@ -196,7 +196,7 @@ def test_ceph_mon_upgrade_plan_ussuri_to_victoria(
             description=f"Check if the workload of '{app.name}' has been upgraded",
             parallel=False,
             function=app._check_upgrade,
-            target=OpenStackRelease(target),
+            target=target,
         ),
         UpgradeStep(
             description=(

--- a/tests/unit/apps/test_ovn.py
+++ b/tests/unit/apps/test_ovn.py
@@ -54,7 +54,7 @@ def test_ovn_subordinate(status, model):
 
 
 def test_ovn_workload_ver_lower_than_22_principal(status, config, model):
-    target = "victoria"
+    target = OpenStackRelease("victoria")
 
     exp_error_msg_ovn_upgrade = (
         "OVN versions lower than 22.03 are not supported. It's necessary to upgrade "
@@ -76,7 +76,7 @@ def test_ovn_workload_ver_lower_than_22_principal(status, config, model):
 
 
 def test_ovn_workload_ver_lower_than_22_subordinate(status, model):
-    target = "victoria"
+    target = OpenStackRelease("victoria")
 
     exp_error_msg_ovn_upgrade = (
         "OVN versions lower than 22.03 are not supported. It's necessary to upgrade "
@@ -119,7 +119,7 @@ def test_ovn_no_compatible_os_release(status, config, model, channel):
 
 
 def test_ovn_principal_upgrade_plan(status, config, model):
-    target = "victoria"
+    target = OpenStackRelease("victoria")
     app = OvnPrincipalApplication(
         "ovn-central",
         status["ovn_central_ussuri_22"],
@@ -168,7 +168,7 @@ def test_ovn_principal_upgrade_plan(status, config, model):
             description=f"Check if the workload of '{app.name}' has been upgraded",
             parallel=False,
             function=app._check_upgrade,
-            target=OpenStackRelease(target),
+            target=target,
         ),
     ]
     add_steps(expected_plan, upgrade_steps)
@@ -177,7 +177,7 @@ def test_ovn_principal_upgrade_plan(status, config, model):
 
 
 def test_ovn_subordinate_upgrade_plan(status, model):
-    target = "victoria"
+    target = OpenStackRelease("victoria")
     app = OvnSubordinateApplication(
         "ovn-chassis",
         status["ovn_chassis_ussuri_22"],

--- a/tests/unit/apps/test_subordinate.py
+++ b/tests/unit/apps/test_subordinate.py
@@ -43,7 +43,7 @@ def test_current_os_release(status, model):
 
 
 def test_generate_upgrade_plan(status, model):
-    target = "victoria"
+    target = OpenStackRelease("victoria")
     app_status = status["keystone-ldap"]
     app = OpenStackSubordinateApplication(
         "my_keystone_ldap", app_status, {}, model, "keystone-ldap"
@@ -126,7 +126,7 @@ def test_channel_setter_invalid(status, model, channel):
     ],
 )
 def test_generate_plan_ch_migration(status, model, channel):
-    target = "wallaby"
+    target = OpenStackRelease("wallaby")
     app_status = status["keystone-ldap-cs"]
     app = OpenStackSubordinateApplication(
         "my_keystone_ldap", app_status, {}, model, "keystone-ldap"
@@ -178,10 +178,11 @@ def test_generate_plan_from_to(status, model, from_os, to_os):
     )
 
     app.channel = f"{from_os}/stable"
-    upgrade_plan = app.generate_upgrade_plan(to_os)
+    target = OpenStackRelease(to_os)
+    upgrade_plan = app.generate_upgrade_plan(target)
 
     expected_plan = UpgradeStep(
-        description=f"Upgrade plan for '{app.name}' to {to_os}",
+        description=f"Upgrade plan for '{app.name}' to {target}",
         parallel=False,
         function=None,
     )
@@ -195,11 +196,11 @@ def test_generate_plan_from_to(status, model, from_os, to_os):
             switch=None,
         ),
         UpgradeStep(
-            description=f"Upgrade '{app.name}' to the new channel: '{to_os}/stable'",
+            description=f"Upgrade '{app.name}' to the new channel: '{target}/stable'",
             parallel=False,
             function=model.upgrade_charm,
             application_name=app.name,
-            channel=f"{to_os}/stable",
+            channel=f"{target}/stable",
         ),
     ]
     add_steps(expected_plan, upgrade_steps)
@@ -224,9 +225,10 @@ def test_generate_plan_in_same_version(status, model, from_to):
     )
 
     app.channel = f"{from_to}/stable"
-    upgrade_plan = app.generate_upgrade_plan(from_to)
+    from_to_release = OpenStackRelease(from_to)
+    upgrade_plan = app.generate_upgrade_plan(from_to_release)
     expected_plan = UpgradeStep(
-        description=f"Upgrade plan for '{app.name}' to {from_to}",
+        description=f"Upgrade plan for '{app.name}' to {from_to_release}",
         parallel=False,
         function=None,
     )

--- a/tests/unit/steps/test_steps_analyze.py
+++ b/tests/unit/steps/test_steps_analyze.py
@@ -69,6 +69,8 @@ def test_analysis_dump(apps, model):
         "      workload_version: '3.8'\n"
         "      os_version: yoga\n"
         "Data Plane:\n"
+        "\nCurrent Cloud OpenStack Release: ussuri\n"
+        "Next Cloud OpenStack Release: victoria\n"
     )
     result = analyze.Analysis(
         model=model,
@@ -112,7 +114,7 @@ async def test_analysis_create(mock_populate, apps, model):
 
 
 @pytest.mark.asyncio
-async def test_analysis_detect_current_cloud_os_release_different_releases(apps, model):
+async def test_analysis_detect_current_and_next_cloud_os_release_different_releases(apps, model):
     result = analyze.Analysis(
         model=model,
         apps_control_plane=[apps["rmq_ussuri"], apps["keystone_wallaby"], apps["cinder_ussuri"]],
@@ -121,10 +123,11 @@ async def test_analysis_detect_current_cloud_os_release_different_releases(apps,
 
     # current_cloud_os_release takes the minimum OpenStack version
     assert result.current_cloud_os_release == "ussuri"
+    assert result.next_cloud_os_release == "victoria"
 
 
 @pytest.mark.asyncio
-async def test_analysis_detect_current_cloud_os_release_same_release(apps, model):
+async def test_analysis_detect_current_and_next_cloud_os_release_same_release(apps, model):
     result = analyze.Analysis(
         model=model,
         apps_control_plane=[apps["cinder_ussuri"], apps["keystone_ussuri"]],
@@ -133,6 +136,19 @@ async def test_analysis_detect_current_cloud_os_release_same_release(apps, model
 
     # current_cloud_os_release takes the minimum OpenStack version
     assert result.current_cloud_os_release == "ussuri"
+    assert result.next_cloud_os_release == "victoria"
+
+
+@pytest.mark.asyncio
+async def test_analysis_detect_current_and_next_cloud_os_release_empty_cloud(model):
+    result = analyze.Analysis(
+        model=model,
+        apps_control_plane=[],
+        apps_data_plane=[],
+    )
+
+    assert result.current_cloud_os_release is None
+    assert result.next_cloud_os_release is None
 
 
 def _app(name, units):

--- a/tests/unit/utils/test_openstack.py
+++ b/tests/unit/utils/test_openstack.py
@@ -213,16 +213,16 @@ def test_compare_openstack_release_order():
 
 def test_openstack_release_setter():
     openstack_release = OpenStackRelease("wallaby")
-    assert openstack_release.next_release == "xena"
+    assert openstack_release.next_release == OpenStackRelease("xena")
     # change OpenStack release
     openstack_release.codename = "xena"
-    assert openstack_release.next_release == "yoga"
+    assert openstack_release.next_release == OpenStackRelease("yoga")
 
 
 def test_openstack_release_setter_by_date():
     openstack_release = OpenStackRelease("2023.1")
     assert openstack_release.codename == "antelope"
-    assert openstack_release.next_release == "bobcat"
+    assert openstack_release.next_release == OpenStackRelease("bobcat")
     assert openstack_release.date == "2023.1"
 
 
@@ -253,7 +253,10 @@ def test_compare_openstack_raises_error():
 )
 def test_determine_next_openstack_release(os_release, release_year, next_os_release):
     release = OpenStackRelease(os_release)
-    assert release.next_release == next_os_release
+    if next_os_release is None:
+        assert release.next_release is None
+    else:
+        assert release.next_release == OpenStackRelease(next_os_release)
     assert release.date == release_year
 
 
@@ -269,7 +272,10 @@ def test_determine_next_openstack_release(os_release, release_year, next_os_rele
 )
 def test_determine_previous_openstack_release(os_release, previous_os_release):
     release = OpenStackRelease(os_release)
-    assert release.previous_release == previous_os_release
+    if previous_os_release is None:
+        assert release.previous_release is None
+    else:
+        assert release.previous_release == OpenStackRelease(previous_os_release)
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/utils/test_openstack.py
+++ b/tests/unit/utils/test_openstack.py
@@ -253,10 +253,10 @@ def test_compare_openstack_raises_error():
 )
 def test_determine_next_openstack_release(os_release, release_year, next_os_release):
     release = OpenStackRelease(os_release)
-    if next_os_release is None:
-        assert release.next_release is None
-    else:
+    if next_os_release:
         assert release.next_release == OpenStackRelease(next_os_release)
+    else:
+        assert release.next_release is None
     assert release.date == release_year
 
 
@@ -272,10 +272,10 @@ def test_determine_next_openstack_release(os_release, release_year, next_os_rele
 )
 def test_determine_previous_openstack_release(os_release, previous_os_release):
     release = OpenStackRelease(os_release)
-    if previous_os_release is None:
-        assert release.previous_release is None
-    else:
+    if previous_os_release:
         assert release.previous_release == OpenStackRelease(previous_os_release)
+    else:
+        assert release.previous_release is None
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
- Delegate the responsibility of evaluating target cloud os release to the Analyze stage, alongside the existing current_cloud_os_release method
- Change the return type of `OpenStackRelease.next_release` and `OpenStackRelease.previous_release` from `str` to an `OpenStackRelease` object. This unifies the target release variable type across the project.