### PR TITLE
Warn if data plane needs to upgrade manually

### DIFF
--- a/cou/apps/auxiliary.py
+++ b/cou/apps/auxiliary.py
@@ -179,6 +179,10 @@ class MysqlInnodbClusterApplication(OpenStackAuxiliaryApplication):
     packages_to_hold: Optional[list] = ["mysql-server-core-8.0"]
 
 
+# NOTE (gabrielcocenza): Although CephOSD class is empty now, it will be
+# necessary to add post upgrade plan to set require-osd-release. Registering on
+# OpenStackAuxiliaryApplication can be easily forgot and ceph-osd can't be instantiated
+# as a normal OpenStackApplication.
 @AppFactory.register_application(["ceph-osd"])
 class CephOSD(OpenStackAuxiliaryApplication):
     """Application for ceph-osd."""

--- a/cou/apps/auxiliary.py
+++ b/cou/apps/auxiliary.py
@@ -177,3 +177,8 @@ class MysqlInnodbClusterApplication(OpenStackAuxiliaryApplication):
     # NOTE(agileshaw): holding 'mysql-server-core-8.0' package prevents undesired
     # mysqld processes from restarting, which lead to outages
     packages_to_hold: Optional[list] = ["mysql-server-core-8.0"]
+
+
+@AppFactory.register_application(["ceph-osd"])
+class CephOSD(OpenStackAuxiliaryApplication):
+    """Application for ceph-osd."""

--- a/cou/cli.py
+++ b/cou/cli.py
@@ -27,7 +27,7 @@ from cou.logging import setup_logging
 from cou.steps import UpgradeStep
 from cou.steps.analyze import Analysis
 from cou.steps.execute import apply_plan
-from cou.steps.plan import generate_plan
+from cou.steps.plan import generate_plan, manually_upgrade_data_plane
 from cou.utils.juju_utils import COUModel
 
 AVAILABLE_OPTIONS = "cas"
@@ -115,7 +115,7 @@ async def get_upgrade_plan(model_name: Optional[str] = None) -> None:
     analysis_result, upgrade_plan = await analyze_and_plan(model_name)
     logger.info(upgrade_plan)
     print(upgrade_plan)  # print plan to console even in quiet mode
-    analysis_result.manually_upgrade_data_plane()
+    manually_upgrade_data_plane(analysis_result)
 
 
 async def run_upgrade(
@@ -143,7 +143,7 @@ async def run_upgrade(
         progress_indicator.succeed()
     else:
         await apply_plan(upgrade_plan, interactive)
-    analysis_result.manually_upgrade_data_plane()
+    manually_upgrade_data_plane(analysis_result)
     print("Upgrade completed.")
 
 

--- a/cou/steps/analyze.py
+++ b/cou/steps/analyze.py
@@ -167,10 +167,7 @@ class Analysis:
         :return: OpenStack release.
         :rtype: Optional[OpenStackRelease]
         """
-        return min(
-            (app.current_os_release for app in apps),
-            default=None,
-        )
+        return min((app.current_os_release for app in apps), default=None)
 
     @property
     def current_cloud_os_release(self) -> Optional[OpenStackRelease]:

--- a/cou/steps/analyze.py
+++ b/cou/steps/analyze.py
@@ -42,6 +42,13 @@ class Analysis:
     model: juju_utils.COUModel
     apps_control_plane: list[OpenStackApplication]
     apps_data_plane: list[OpenStackApplication]
+    min_os_version_control_plane: Optional[OpenStackRelease] = None
+    min_os_version_data_plane: Optional[OpenStackRelease] = None
+
+    def __post_init__(self) -> None:
+        """Initialize the Analysis dataclass."""
+        self.min_os_version_control_plane = self.min_os_release_apps(self.apps_control_plane)
+        self.min_os_version_data_plane = self.min_os_release_apps(self.apps_data_plane)
 
     @staticmethod
     def _split_apps(
@@ -151,6 +158,20 @@ class Analysis:
             + "\n".join([str(app) for app in self.apps_data_plane])
         )
 
+    @staticmethod
+    def min_os_release_apps(apps: list[OpenStackApplication]) -> Optional[OpenStackRelease]:
+        """Get the minimal OpenStack release from a list of applications.
+
+        :param apps: Applications.
+        :type apps: list[OpenStackApplication]
+        :return: OpenStack release.
+        :rtype: Optional[OpenStackRelease]
+        """
+        return min(
+            (app.current_os_release for app in apps),
+            default=None,
+        )
+
     @property
     def current_cloud_os_release(self) -> Optional[OpenStackRelease]:
         """Shows the current OpenStack release codename.
@@ -160,7 +181,15 @@ class Analysis:
         :return: OpenStack release codename
         :rtype: OpenStackRelease
         """
-        return min(
-            (app.current_os_release for app in self.apps_control_plane + self.apps_data_plane),
-            default=None,
+        control_plane = (
+            [self.min_os_version_control_plane] if self.min_os_version_control_plane else []
         )
+        data_plane = [self.min_os_version_data_plane] if self.min_os_version_data_plane else []
+        return min(control_plane + data_plane, default=None)
+
+    def manually_upgrade_data_plane(self) -> None:
+        """Warning message to upgrade data plane charms if necessary."""
+        if self.min_os_version_control_plane and self.min_os_version_data_plane:
+            if self.min_os_version_control_plane > self.min_os_version_data_plane:
+                data_plane_apps = ", ".join([app.name for app in self.apps_data_plane])
+                print(f"WARNING: Please upgrade manually the data plane apps: {data_plane_apps}")

--- a/cou/steps/analyze.py
+++ b/cou/steps/analyze.py
@@ -186,10 +186,3 @@ class Analysis:
         )
         data_plane = [self.min_os_version_data_plane] if self.min_os_version_data_plane else []
         return min(control_plane + data_plane, default=None)
-
-    def manually_upgrade_data_plane(self) -> None:
-        """Warning message to upgrade data plane charms if necessary."""
-        if self.min_os_version_control_plane and self.min_os_version_data_plane:
-            if self.min_os_version_control_plane > self.min_os_version_data_plane:
-                data_plane_apps = ", ".join([app.name for app in self.apps_data_plane])
-                print(f"WARNING: Please upgrade manually the data plane apps: {data_plane_apps}")

--- a/cou/steps/plan.py
+++ b/cou/steps/plan.py
@@ -122,6 +122,8 @@ async def create_upgrade_group(
 def manually_upgrade_data_plane(analysis_result: Analysis) -> None:
     """Warning message to upgrade data plane charms if necessary.
 
+    NOTE(gabrielcocenza) This function should be removed when cou starts
+    supporting data plan upgrades.
     :param analysis_result: Analysis result.
     :type analysis_result: Analysis
     """

--- a/cou/steps/plan.py
+++ b/cou/steps/plan.py
@@ -125,10 +125,13 @@ def manually_upgrade_data_plane(analysis_result: Analysis) -> None:
     :param analysis_result: Analysis result.
     :type analysis_result: Analysis
     """
-    if analysis_result.min_os_version_control_plane and analysis_result.min_os_version_data_plane:
-        if (
+    if (
+        analysis_result.min_os_version_control_plane
+        and analysis_result.min_os_version_data_plane
+        and (
             analysis_result.min_os_version_control_plane
             > analysis_result.min_os_version_data_plane
-        ):
-            data_plane_apps = ", ".join([app.name for app in analysis_result.apps_data_plane])
-            print(f"WARNING: Please upgrade manually the data plane apps: {data_plane_apps}")
+        )
+    ):
+        data_plane_apps = ", ".join([app.name for app in analysis_result.apps_data_plane])
+        print(f"WARNING: Please upgrade manually the data plane apps: {data_plane_apps}")

--- a/cou/steps/plan.py
+++ b/cou/steps/plan.py
@@ -117,3 +117,18 @@ async def create_upgrade_group(
             raise
 
     return group_upgrade_plan
+
+
+def manually_upgrade_data_plane(analysis_result: Analysis) -> None:
+    """Warning message to upgrade data plane charms if necessary.
+
+    :param analysis_result: Analysis result.
+    :type analysis_result: Analysis
+    """
+    if analysis_result.min_os_version_control_plane and analysis_result.min_os_version_data_plane:
+        if (
+            analysis_result.min_os_version_control_plane
+            > analysis_result.min_os_version_data_plane
+        ):
+            data_plane_apps = ", ".join([app.name for app in analysis_result.apps_data_plane])
+            print(f"WARNING: Please upgrade manually the data plane apps: {data_plane_apps}")

--- a/cou/utils/openstack.py
+++ b/cou/utils/openstack.py
@@ -424,8 +424,7 @@ def is_charm_supported(charm: str) -> bool:
     :rtype: bool
     """
     return (
-        charm not in DATA_PLANE_CHARMS
-        and bool(OpenStackCodenameLookup.lookup(charm))
+        bool(OpenStackCodenameLookup.lookup(charm))
         or charm in SUBORDINATES + AUXILIARY_SUBORDINATES
     )
 

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -127,6 +127,19 @@ def status():
         ]
     )
 
+    mock_nova_ussuri = MagicMock(spec_set=ApplicationStatus())
+    mock_nova_ussuri.series = "focal"
+    mock_nova_ussuri.charm_channel = "ussuri/stable"
+    mock_nova_ussuri.charm = "ch:amd64/focal/nova-compute-638"
+    mock_nova_ussuri.subordinate_to = []
+    mock_nova_ussuri.units = OrderedDict(
+        [
+            ("nova-compute/0", generate_unit("21.0.0", "0")),
+            ("nova-compute/1", generate_unit("21.0.0", "1")),
+            ("nova-compute/2", generate_unit("21.0.0", "2")),
+        ]
+    )
+
     mock_nova_wallaby = MagicMock(spec_set=ApplicationStatus())
     mock_nova_wallaby.series = "focal"
     mock_nova_wallaby.charm_channel = "wallaby/stable"
@@ -207,6 +220,14 @@ def status():
     mock_ceph_mon_xena.subordinate_to = []
     mock_ceph_mon_xena.units = OrderedDict([("ceph-mon/0", generate_unit("16.2.0", "7"))])
 
+    # ceph-osd application on ussuri
+    mock_ceph_osd_ussuri = MagicMock(spec_set=ApplicationStatus())
+    mock_ceph_osd_ussuri.series = "focal"
+    mock_ceph_osd_ussuri.charm_channel = "octopus/stable"
+    mock_ceph_osd_ussuri.charm = "ch:amd64/focal/ceph-osd-177"
+    mock_ceph_osd_ussuri.subordinate_to = []
+    mock_ceph_osd_ussuri.units = OrderedDict([("ceph-osd/0", generate_unit("15.2.0", "6"))])
+
     # mysql-innodb-cluster application on ussuri using 8.0
     mock_mysql_innodb_cluster_ussuri = MagicMock(spec_set=ApplicationStatus())
     mock_mysql_innodb_cluster_ussuri.series = "focal"
@@ -270,9 +291,11 @@ def status():
         "vault": mock_vault,
         "keystone-ldap": mock_keystone_ldap,
         "keystone-ldap-cs": mock_keystone_ldap_cs,
+        "nova_ussuri": mock_nova_ussuri,
         "nova_wallaby": mock_nova_wallaby,
         "ceph-mon_ussuri": mock_ceph_mon_ussuri,
         "ceph-mon_xena": mock_ceph_mon_xena,
+        "ceph_osd_ussuri": mock_ceph_osd_ussuri,
         "cinder_ussuri_on_nova": mock_cinder_on_nova,
         "mysql-innodb-cluster": mock_mysql_innodb_cluster_ussuri,
         "ovn_central_ussuri_22": mock_ovn_central_ussuri_22,
@@ -293,8 +316,8 @@ def full_status(status, model):
             ("cinder", status["cinder_ussuri"]),
             ("rabbitmq-server", status["rabbitmq_server"]),
             ("my_app", status["unknown_app"]),
-            ("nova-compute", status["unknown_app"]),
-            ("ceph-osd", status["unknown_app"]),
+            ("nova-compute", status["nova_ussuri"]),
+            ("ceph-osd", status["ceph_osd_ussuri"]),
         ]
     )
     return mock_full_status
@@ -410,7 +433,6 @@ def apps(status, config, model):
     cinder_ussuri_status = status["cinder_ussuri"]
     rmq_status = status["rabbitmq_server"]
     keystone_ldap_status = status["keystone-ldap"]
-    nova_wallaby_status = status["nova_wallaby"]
 
     keystone_ussuri = OpenStackApplication(
         "keystone", keystone_ussuri_status, config["openstack_ussuri"], model, "keystone"
@@ -433,9 +455,8 @@ def apps(status, config, model):
     keystone_mysql_router = OpenStackAuxiliarySubordinateApplication(
         "keystone-mysql-router", status["mysql_router"], {}, model, "mysql-router"
     )
-
-    nova_wallaby = OpenStackSubordinateApplication(
-        "nova-compute", nova_wallaby_status, {}, model, "nova-compute"
+    nova_ussuri = OpenStackApplication(
+        "nova-compute", status["nova_ussuri"], config["openstack_ussuri"], model, "nova-compute"
     )
     return {
         "keystone_ussuri": keystone_ussuri,
@@ -444,6 +465,6 @@ def apps(status, config, model):
         "rmq_ussuri": rmq_ussuri,
         "rmq_wallaby": rmq_wallaby,
         "keystone_ldap": keystone_ldap,
-        "nova_wallaby": nova_wallaby,
+        "nova_ussuri": nova_ussuri,
         "keystone_mysql_router": keystone_mysql_router,
     }

--- a/tests/unit/steps/test_steps_analyze.py
+++ b/tests/unit/steps/test_steps_analyze.py
@@ -141,30 +141,6 @@ async def test_analysis_detect_current_cloud_os_release_same_release(apps, model
     assert result.current_cloud_os_release == "ussuri"
 
 
-@patch("builtins.print")
-def test_analysis_print_warn_manually_upgrade(mock_print, model, apps):
-    result = analyze.Analysis(
-        model=model,
-        apps_control_plane=[apps["keystone_wallaby"]],
-        apps_data_plane=[apps["nova_ussuri"]],
-    )
-    result.manually_upgrade_data_plane()
-    mock_print.assert_called_with(
-        "WARNING: Please upgrade manually the data plane apps: nova-compute"
-    )
-
-
-@patch("builtins.print")
-def test_analysis_not_print_warn_manually_upgrade(mock_print, model, apps):
-    result = analyze.Analysis(
-        model=model,
-        apps_control_plane=[apps["keystone_ussuri"]],
-        apps_data_plane=[apps["nova_ussuri"]],
-    )
-    result.manually_upgrade_data_plane()
-    mock_print.assert_not_called()
-
-
 def _app(name, units):
     app = MagicMock(spec_set=OpenStackApplication).return_value
     app.charm = name

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import argparse
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -84,12 +84,14 @@ async def test_get_upgrade_plan(mock_logger, mock_analyze_and_plan):
     """Test get_upgrade_plan function."""
     plan = UpgradeStep(description="Top level plan", parallel=False)
     plan.add_step(UpgradeStep(description="backup mysql databases", parallel=False))
+    mock_analysis_result = MagicMock()
 
-    mock_analyze_and_plan.return_value = plan
+    mock_analyze_and_plan.return_value = (mock_analysis_result, plan)
     await cli.get_upgrade_plan()
 
     mock_analyze_and_plan.assert_awaited_once()
     mock_logger.info.assert_called_once_with(plan)
+    mock_analysis_result.manually_upgrade_data_plane.assert_called_once()
 
 
 @pytest.mark.asyncio
@@ -110,7 +112,8 @@ async def test_run_upgrade_quiet(
     """Test get_upgrade_plan function in either quiet or non-quiet mode."""
     plan = UpgradeStep(description="Top level plan", parallel=False)
     plan.add_step(UpgradeStep(description="backup mysql databases", parallel=False))
-    mock_analyze_and_plan.return_value = plan
+    mock_analysis_result = MagicMock()
+    mock_analyze_and_plan.return_value = (mock_analysis_result, plan)
 
     await cli.run_upgrade(quiet=quiet)
 
@@ -143,7 +146,8 @@ async def test_run_upgrade_interactive(
     """Test get_upgrade_plan function in either interactive or non-interactive mode."""
     plan = UpgradeStep(description="Top level plan", parallel=False)
     plan.add_step(UpgradeStep(description="backup mysql databases", parallel=False))
-    mock_analyze_and_plan.return_value = plan
+    mock_analysis_result = MagicMock()
+    mock_analyze_and_plan.return_value = (mock_analysis_result, plan)
 
     await cli.run_upgrade(interactive=interactive)
 

--- a/tests/unit/utils/test_openstack.py
+++ b/tests/unit/utils/test_openstack.py
@@ -466,8 +466,8 @@ def test_track_to_openstack(charm, series, track, exp_result):
     [
         ("keystone", True),
         ("ceph-mon", True),
-        ("ceph-osd", False),
-        ("nova-compute", False),
+        ("ceph-osd", True),
+        ("nova-compute", True),
         ("my-charm", False),
         ("barbican-vault", True),
         ("hacluster", True),


### PR DESCRIPTION
- back to instantiate data-plane charms
- ceph-osd class
- separate min OpenStack release from data and control plane apps

Closes #105 