### PR TITLE
Better logging for mismatched applications

### DIFF
--- a/cou/apps/core.py
+++ b/cou/apps/core.py
@@ -16,6 +16,7 @@
 from __future__ import annotations
 
 import logging
+from collections import defaultdict
 from dataclasses import dataclass, field
 from io import StringIO
 from typing import Any, Optional
@@ -239,15 +240,22 @@ class OpenStackApplication:
         :return: OpenStackRelease object
         :rtype: OpenStackRelease
         """
-        os_versions = {unit.os_version for unit in self.units}
+        os_versions = defaultdict(list)
+        for unit in self.units:
+            os_versions[unit.os_version].append(unit.name)
 
-        if len(os_versions) == 1:
-            return os_versions.pop()
+        if len(os_versions.keys()) == 1:
+            return next(iter(os_versions))
+
         # NOTE (gabrielcocenza) on applications that use single-unit or paused-single-unit
         # upgrade methods, more than one version can be found.
+        mismatched_repr = [
+            f"'{openstack_release.codename}': {os_versions[openstack_release]}"
+            for openstack_release in os_versions
+        ]
         raise MismatchedOpenStackVersions(
             f"Units of application {self.name} are running mismatched OpenStack versions: "
-            f"{os_versions}. This is not currently handled."
+            f"{', '.join(mismatched_repr)}. This is not currently handled."
         )
 
     @property

--- a/cou/apps/core.py
+++ b/cou/apps/core.py
@@ -250,8 +250,8 @@ class OpenStackApplication:
         # NOTE (gabrielcocenza) on applications that use single-unit or paused-single-unit
         # upgrade methods, more than one version can be found.
         mismatched_repr = [
-            f"'{openstack_release.codename}': {apps}"
-            for openstack_release, apps in os_versions.items()
+            f"'{openstack_release.codename}': {units}"
+            for openstack_release, units in os_versions.items()
         ]
         raise MismatchedOpenStackVersions(
             f"Units of application {self.name} are running mismatched OpenStack versions: "

--- a/cou/apps/core.py
+++ b/cou/apps/core.py
@@ -250,8 +250,8 @@ class OpenStackApplication:
         # NOTE (gabrielcocenza) on applications that use single-unit or paused-single-unit
         # upgrade methods, more than one version can be found.
         mismatched_repr = [
-            f"'{openstack_release.codename}': {os_versions[openstack_release]}"
-            for openstack_release in os_versions
+            f"'{openstack_release.codename}': {apps}"
+            for openstack_release, apps in os_versions.items()
         ]
         raise MismatchedOpenStackVersions(
             f"Units of application {self.name} are running mismatched OpenStack versions: "

--- a/tests/unit/apps/test_core.py
+++ b/tests/unit/apps/test_core.py
@@ -11,7 +11,6 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-import re
 from unittest.mock import AsyncMock
 
 import pytest
@@ -135,9 +134,9 @@ def test_application_ussuri(status, config, units, model):
 
 def test_application_different_wl(status, config, model):
     """Different OpenStack Version on units if workload version is different."""
-    exp_error_msg = re.compile(
+    exp_error_msg = (
         "Units of application my_keystone are running mismatched OpenStack versions: "
-        r"{OpenStackRelease(?:<victoria>|<ussuri>), OpenStackRelease(?:<victoria>|<ussuri>)}. "
+        r"'ussuri': \['keystone\/0', 'keystone\/1'\], 'victoria': \['keystone\/2'\]. "
         "This is not currently handled."
     )
     app_status = status["keystone_ussuri_victoria"]


### PR DESCRIPTION
- Currently the logging does not include the unit, so it's harder to the user to know which unit didn't get upgrade.