### PR TITLE
Add support to designate-bind and gnocchi

### DIFF
--- a/cou/utils/openstack.py
+++ b/cou/utils/openstack.py
@@ -45,6 +45,10 @@ CHARM_FAMILIES = {
 
 DATA_PLANE_CHARMS = ["nova-compute", "ceph-osd"]
 
+# designate-bind and gnocchi can have more than one compatible OpenStack release
+# for a workload version
+OPENSTACK_CHANNEL_BASED_CHARMS = ["designate-bind", "gnocchi"]
+
 # https://docs.openstack.org/charm-guide/latest/admin/upgrades/openstack.html#list-the-upgrade-order
 UPGRADE_ORDER = [
     "rabbitmq-server",

--- a/tests/unit/apps/test_base.py
+++ b/tests/unit/apps/test_base.py
@@ -1,0 +1,240 @@
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+from cou.apps.base import OpenStackApplication
+from cou.steps import UpgradeStep
+from cou.utils import app_utils
+from cou.utils.openstack import OpenStackRelease
+from tests.unit.apps.utils import add_steps
+
+
+def test_application_gnocchi_ussuri(status, config, model):
+    app_config = config["openstack_ussuri"]
+    app_config["action-managed-upgrade"] = {"value": False}
+    app = OpenStackApplication(
+        "gnocchi",
+        status["gnocchi_ussuri"],
+        app_config,
+        model,
+        "gnocchi",
+    )
+    assert app.is_os_channel_based is True
+    assert app.current_os_release == "ussuri"
+
+
+def test_application_designate_bind_ussuri(status, config, model):
+    app_config = config["openstack_ussuri"]
+    app_config["action-managed-upgrade"] = {"value": False}
+    app = OpenStackApplication(
+        "designate-bind",
+        status["designate_bind_ussuri"],
+        app_config,
+        model,
+        "designate-bind",
+    )
+    assert app.is_os_channel_based is True
+    assert app.current_os_release == "ussuri"
+
+
+def test_application_gnocchi_upgrade_plan_ussuri_to_victoria(status, config, model):
+    target = OpenStackRelease("victoria")
+    app_config = config["openstack_ussuri"]
+    app_config["action-managed-upgrade"] = {"value": False}
+    app = OpenStackApplication(
+        "gnocchi",
+        status["gnocchi_ussuri"],
+        app_config,
+        model,
+        "gnocchi",
+    )
+
+    upgrade_plan = app.generate_upgrade_plan(target)
+
+    expected_plan = UpgradeStep(
+        description=f"Upgrade plan for '{app.name}' to {target}",
+        parallel=False,
+    )
+
+    upgrade_steps = [
+        UpgradeStep(
+            description=(
+                f"Upgrade software packages of '{app.name}' from the current APT repositories"
+            ),
+            parallel=False,
+            coro=app_utils.upgrade_packages(app.status.units.keys(), model, None),
+        ),
+        UpgradeStep(
+            description=f"Refresh '{app.name}' to the latest revision of 'ussuri/stable'",
+            parallel=False,
+            coro=model.upgrade_charm(app.name, "ussuri/stable", switch=None),
+        ),
+        UpgradeStep(
+            description=f"Upgrade '{app.name}' to the new channel: 'victoria/stable'",
+            parallel=False,
+            coro=model.upgrade_charm(app.name, "victoria/stable"),
+        ),
+        UpgradeStep(
+            description=(
+                f"Change charm config of '{app.name}' "
+                f"'{app.origin_setting}' to 'cloud:focal-victoria'"
+            ),
+            parallel=False,
+            coro=model.set_application_config(
+                app.name,
+                {f"{app.origin_setting}": "cloud:focal-victoria"},
+            ),
+        ),
+        UpgradeStep(
+            description=f"Wait 120 s for app {app.name} to reach the idle state.",
+            parallel=False,
+            coro=model.wait_for_idle(120, [app.name]),
+        ),
+        UpgradeStep(
+            description=f"Check if the workload of '{app.name}' has been upgraded",
+            parallel=False,
+            coro=app._check_upgrade(target),
+        ),
+    ]
+
+    add_steps(expected_plan, upgrade_steps)
+
+    assert upgrade_plan == expected_plan
+
+
+def test_application_gnocchi_upgrade_plan_xena_to_yoga(status, config, model):
+    target = OpenStackRelease("yoga")
+    app_config = config["openstack_xena"]
+    app_config["action-managed-upgrade"] = {"value": False}
+    app = OpenStackApplication(
+        "gnocchi",
+        status["gnocchi_xena"],
+        app_config,
+        model,
+        "gnocchi",
+    )
+
+    upgrade_plan = app.generate_upgrade_plan(target)
+
+    expected_plan = UpgradeStep(
+        description=f"Upgrade plan for '{app.name}' to {target}",
+        parallel=False,
+    )
+
+    upgrade_steps = [
+        UpgradeStep(
+            description=(
+                f"Upgrade software packages of '{app.name}' from the current APT repositories"
+            ),
+            parallel=False,
+            coro=app_utils.upgrade_packages(app.status.units.keys(), model, None),
+        ),
+        UpgradeStep(
+            description=f"Refresh '{app.name}' to the latest revision of 'xena/stable'",
+            parallel=False,
+            coro=model.upgrade_charm(app.name, "xena/stable", switch=None),
+        ),
+        UpgradeStep(
+            description=f"Upgrade '{app.name}' to the new channel: 'yoga/stable'",
+            parallel=False,
+            coro=model.upgrade_charm(app.name, "yoga/stable"),
+        ),
+        UpgradeStep(
+            description=(
+                f"Change charm config of '{app.name}' "
+                f"'{app.origin_setting}' to 'cloud:focal-yoga'"
+            ),
+            parallel=False,
+            coro=model.set_application_config(
+                app.name,
+                {f"{app.origin_setting}": "cloud:focal-yoga"},
+            ),
+        ),
+        UpgradeStep(
+            description=f"Wait 120 s for app {app.name} to reach the idle state.",
+            parallel=False,
+            coro=model.wait_for_idle(120, [app.name]),
+        ),
+        UpgradeStep(
+            description=f"Check if the workload of '{app.name}' has been upgraded",
+            parallel=False,
+            coro=app._check_upgrade(target),
+        ),
+    ]
+
+    add_steps(expected_plan, upgrade_steps)
+
+    assert upgrade_plan == expected_plan
+
+
+def test_application_designate_bind_upgrade_plan_ussuri_to_victoria(status, config, model):
+    target = OpenStackRelease("victoria")
+    app_config = config["openstack_ussuri"]
+    app_config["action-managed-upgrade"] = {"value": False}
+    app = OpenStackApplication(
+        "designate-bind",
+        status["designate_bind_ussuri"],
+        app_config,
+        model,
+        "designate-bind",
+    )
+
+    upgrade_plan = app.generate_upgrade_plan(target)
+
+    expected_plan = UpgradeStep(
+        description=f"Upgrade plan for '{app.name}' to {target}",
+        parallel=False,
+    )
+
+    upgrade_steps = [
+        UpgradeStep(
+            description=(
+                f"Upgrade software packages of '{app.name}' from the current APT repositories"
+            ),
+            parallel=False,
+            coro=app_utils.upgrade_packages(app.status.units.keys(), model, None),
+        ),
+        UpgradeStep(
+            description=f"Refresh '{app.name}' to the latest revision of 'ussuri/stable'",
+            parallel=False,
+            coro=model.upgrade_charm(app.name, "ussuri/stable", switch=None),
+        ),
+        UpgradeStep(
+            description=f"Upgrade '{app.name}' to the new channel: 'victoria/stable'",
+            parallel=False,
+            coro=model.upgrade_charm(app.name, "victoria/stable"),
+        ),
+        UpgradeStep(
+            description=(
+                f"Change charm config of '{app.name}' "
+                f"'{app.origin_setting}' to 'cloud:focal-victoria'"
+            ),
+            parallel=False,
+            coro=model.set_application_config(
+                app.name,
+                {f"{app.origin_setting}": "cloud:focal-victoria"},
+            ),
+        ),
+        UpgradeStep(
+            description=f"Wait 120 s for app {app.name} to reach the idle state.",
+            parallel=False,
+            coro=model.wait_for_idle(120, [app.name]),
+        ),
+        UpgradeStep(
+            description=f"Check if the workload of '{app.name}' has been upgraded",
+            parallel=False,
+            coro=app._check_upgrade(target),
+        ),
+    ]
+
+    add_steps(expected_plan, upgrade_steps)
+
+    assert upgrade_plan == expected_plan

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -128,6 +128,47 @@ def status():
         ]
     )
 
+    # gnocchi on ussuri
+    mock_gnocchi_ussuri = MagicMock(spec_set=ApplicationStatus())
+    mock_gnocchi_ussuri.series = "focal"
+    mock_gnocchi_ussuri.charm_channel = "ussuri/stable"
+    mock_gnocchi_ussuri.charm = "ch:amd64/focal/gnocchi-638"
+    mock_gnocchi_ussuri.subordinate_to = []
+    mock_gnocchi_ussuri.units = OrderedDict(
+        [
+            ("gnocchi/0", generate_unit("4.3.4", "3/lxd/6")),
+            ("gnocchi/1", generate_unit("4.3.4", "4/lxd/6")),
+            ("gnocchi/2", generate_unit("4.3.4", "5/lxd/5")),
+        ]
+    )
+
+    # gnocchi on xena
+    mock_gnocchi_xena = MagicMock(spec_set=ApplicationStatus())
+    mock_gnocchi_xena.series = "focal"
+    mock_gnocchi_xena.charm_channel = "xena/stable"
+    mock_gnocchi_xena.charm = "ch:amd64/focal/gnocchi-638"
+    mock_gnocchi_xena.subordinate_to = []
+    mock_gnocchi_xena.units = OrderedDict(
+        [
+            ("gnocchi/0", generate_unit("4.4.1", "3/lxd/6")),
+            ("gnocchi/1", generate_unit("4.4.1", "4/lxd/6")),
+            ("gnocchi/2", generate_unit("4.4.1", "5/lxd/5")),
+        ]
+    )
+
+    # designate-bind on ussuri
+    mock_designate_bind_ussuri = MagicMock(spec_set=ApplicationStatus())
+    mock_designate_bind_ussuri.series = "focal"
+    mock_designate_bind_ussuri.charm_channel = "ussuri/stable"
+    mock_designate_bind_ussuri.charm = "ch:amd64/focal/designate-bind-737"
+    mock_designate_bind_ussuri.subordinate_to = []
+    mock_designate_bind_ussuri.units = OrderedDict(
+        [
+            ("gnocchi/0", generate_unit("9.16.1", "1/lxd/6")),
+            ("gnocchi/1", generate_unit("9.16.1", "2/lxd/6")),
+        ]
+    )
+
     mock_nova_ussuri = MagicMock(spec_set=ApplicationStatus())
     mock_nova_ussuri.series = "focal"
     mock_nova_ussuri.charm_channel = "ussuri/stable"
@@ -299,6 +340,9 @@ def status():
         "keystone_wallaby": mock_keystone_wallaby,
         "keystone_ussuri_victoria": mock_keystone_ussuri_victoria,
         "cinder_ussuri": mock_cinder_ussuri,
+        "gnocchi_ussuri": mock_gnocchi_ussuri,
+        "gnocchi_xena": mock_gnocchi_xena,
+        "designate_bind_ussuri": mock_designate_bind_ussuri,
         "rabbitmq_server": mock_rmq,
         "unknown_rabbitmq_server": mock_rmq_unknown,
         "keystone_ussuri_cs": mock_keystone_ussuri_cs,
@@ -405,6 +449,7 @@ def config():
             "action-managed-upgrade": {"value": True},
         },
         "openstack_wallaby": {"openstack-origin": {"value": "cloud:focal-wallaby"}},
+        "openstack_xena": {"openstack-origin": {"value": "cloud:focal-xena"}},
         "auxiliary_ussuri": {"source": {"value": "distro"}},
         "auxiliary_wallaby": {"source": {"value": "cloud:focal-wallaby"}},
         "auxiliary_xena": {"source": {"value": "cloud:focal-xena"}},


### PR DESCRIPTION
- Those charms can be compatible with more than one OpenStack release for a workload version, so they should be channel based.

Closes: #106 #94