### PR TITLE
clean up usage of environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,9 +23,11 @@ Then you can use ```cou```
 
 ## Environment Variables
 
-- `COU_DATA`: Main directory for Charmed Openstack Upgrader configuration files. Currently only log files are kept under
-  COU_DATA/logs.
-- `JUJU_MODEL`: Active juju model to operate on.
+- `COU_DATA` - sets the main cou directory where logs and backups are stored. Defaults to ~/.local/share/cou
+- `JUJU_DATA` - sets the path containing Juju configuration files (e.g. credentials.yaml). Defaults to ~/.local/share/juju
+- `COU_TIMEOUT` - define timeout for cou retry policy. Default value is 10 seconds.
+- `COU_MODEL_RETRIES` - define how many times to retry the connection to Juju model before giving up. Default value is 5 times.
+- `COU_MODEL_RETRY_BACKOFF` - define number of seconds to increase the wait between connection to the Juju model retry attempts. Default value is 2 seconds.
 
 ## Supported Upgrade Paths
 

--- a/cou/commands.py
+++ b/cou/commands.py
@@ -80,10 +80,8 @@ def get_subcommand_common_opts_parser() -> argparse.ArgumentParser:
         default=None,
         dest="model_name",
         type=str,
-        help="Set the model to operate on.\nIf unset, the model name will be determined by "
-        "inspecting the environment as follows:\n"
-        "  1 - Environment variable JUJU_MODEL,"
-        "  2 - Current active juju model",
+        help="Set the model to operate on.\nIf not set, the currently active Juju model will "
+        "be used.",
     )
 
     # quiet and verbose options are mutually exclusive

--- a/cou/commands.py
+++ b/cou/commands.py
@@ -83,8 +83,7 @@ def get_subcommand_common_opts_parser() -> argparse.ArgumentParser:
         help="Set the model to operate on.\nIf unset, the model name will be determined by "
         "inspecting the environment as follows:\n"
         "  1 - Environment variable JUJU_MODEL,"
-        "  2 - Environment variable MODEL_NAME,"
-        "  3 - Current active juju model",
+        "  2 - Current active juju model",
     )
 
     # quiet and verbose options are mutually exclusive

--- a/cou/logging.py
+++ b/cou/logging.py
@@ -15,11 +15,12 @@
 """Set up both global logger for logfile and console'."""
 import logging
 import logging.handlers
-import os
 import pathlib
 from datetime import datetime
 
-COU_DIR_LOG = pathlib.Path(os.getenv("COU_DATA", ""), "log")
+from cou.utils import COU_DATA
+
+COU_DIR_LOG = COU_DATA / "log"
 
 logger = logging.getLogger(__name__)
 

--- a/cou/steps/backup.py
+++ b/cou/steps/backup.py
@@ -18,6 +18,7 @@ import os
 from pathlib import Path
 
 from cou.exceptions import UnitNotFound
+from cou.utils import COU_DATA
 from cou.utils.juju_utils import COUModel
 
 logger = logging.getLogger(__name__)
@@ -42,7 +43,7 @@ async def backup(model: COUModel) -> Path:
     logger.info("Set permissions to read mysql-innodb-cluster:%s ...", basedir)
     await model.run_on_unit(unit_name, f"chmod o+rx {basedir}")
 
-    local_file = Path(os.getenv("COU_DATA", ""), os.path.basename(remote_file))
+    local_file = COU_DATA / os.path.basename(remote_file)
     logger.info("SCP from  mysql-innodb-cluster:%s to %s ...", remote_file, local_file)
     await model.scp_from_unit(unit_name, remote_file, str(local_file))
 

--- a/cou/utils/__init__.py
+++ b/cou/utils/__init__.py
@@ -13,3 +13,9 @@
 # limitations under the License.
 
 """Utilities for charmed-openstack-upgrader."""
+
+
+import os
+from pathlib import Path
+
+COU_DATA = Path(os.getenv("COU_DATA", "."))


### PR DESCRIPTION
The COU_DATA was defined in two places, so I moved it only to single place. Remove mention of `MODEL_NAME` from CLI.

fixes: #149 #151 