### PR TITLE
increase waiting time

### DIFF
--- a/cou/apps/auxiliary.py
+++ b/cou/apps/auxiliary.py
@@ -128,7 +128,7 @@ class RabbitMQServer(OpenStackAuxiliaryApplication):
     RabbitMQ must wait for the entire model to be idle before declaring the upgrade complete.
     """
 
-    wait_timeout = 300
+    wait_timeout = 30 * 60  # 30 min
     wait_for_model = True
 
 
@@ -136,7 +136,7 @@ class RabbitMQServer(OpenStackAuxiliaryApplication):
 class CephMonApplication(OpenStackAuxiliaryApplication):
     """Application for Ceph Monitor charm."""
 
-    wait_timeout = 300
+    wait_timeout = 30 * 60  # 30 min
     wait_for_model = True
 
     def pre_upgrade_plan(self, target: OpenStackRelease) -> list[UpgradeStep]:
@@ -192,6 +192,7 @@ class MysqlInnodbClusterApplication(OpenStackAuxiliaryApplication):
     # NOTE(agileshaw): holding 'mysql-server-core-8.0' package prevents undesired
     # mysqld processes from restarting, which lead to outages
     packages_to_hold: Optional[list] = ["mysql-server-core-8.0"]
+    wait_timeout = 30 * 60  # 30 min
 
 
 # NOTE (gabrielcocenza): Although CephOSD class is empty now, it will be

--- a/cou/apps/base.py
+++ b/cou/apps/base.py
@@ -40,7 +40,7 @@ from cou.utils.openstack import (
 
 logger = logging.getLogger(__name__)
 
-DEFAULT_WAITING_TIMEOUT = 120
+DEFAULT_WAITING_TIMEOUT = 5 * 60  # 5 min
 
 
 @dataclass

--- a/cou/apps/base.py
+++ b/cou/apps/base.py
@@ -683,13 +683,11 @@ class OpenStackApplication:
         """
         if self.wait_for_model:
             description = (
-                f"Wait {self.wait_timeout} s for model {self.model.name} to reach the idle state."
+                f"Wait {self.wait_timeout}s for model {self.model.name} to reach the idle state."
             )
             apps = None
         else:
-            description = (
-                f"Wait {self.wait_timeout} s for app {self.name} to reach the idle state."
-            )
+            description = f"Wait {self.wait_timeout}s for app {self.name} to reach the idle state."
             apps = [self.name]
 
         return UpgradeStep(

--- a/cou/apps/core.py
+++ b/cou/apps/core.py
@@ -28,5 +28,15 @@ class Keystone(OpenStackApplication):
     Keystone must wait for the entire model to be idle before declaring the upgrade complete.
     """
 
-    wait_timeout = 300
+    wait_timeout = 30 * 60  # 30 min
     wait_for_model = True
+
+
+@AppFactory.register_application(["octavia"])
+class Octavia(OpenStackApplication):
+    """Octavia application.
+
+    Octavia required more time to settle before COU can continue.
+    """
+
+    wait_timeout = 30 * 60  # 30 min

--- a/cou/steps/plan.py
+++ b/cou/steps/plan.py
@@ -32,7 +32,7 @@ from cou.apps.auxiliary_subordinate import (  # noqa: F401
 )
 from cou.apps.base import OpenStackApplication
 from cou.apps.channel_based import OpenStackChannelBasedApplication  # noqa: F401
-from cou.apps.core import Keystone  # noqa: F401
+from cou.apps.core import Keystone, Octavia  # noqa: F401
 from cou.apps.subordinate import (  # noqa: F401
     OpenStackSubordinateApplication,
     SubordinateBaseClass,

--- a/tests/unit/apps/test_auxiliary.py
+++ b/tests/unit/apps/test_auxiliary.py
@@ -130,7 +130,7 @@ def test_auxiliary_upgrade_plan_ussuri_to_victoria_change_channel(status, config
             ),
         ),
         UpgradeStep(
-            description=f"Wait 1800 s for model {model.name} to reach the idle state.",
+            description=f"Wait 1800s for model {model.name} to reach the idle state.",
             parallel=False,
             coro=model.wait_for_idle(1800, None),
         ),
@@ -189,7 +189,7 @@ def test_auxiliary_upgrade_plan_ussuri_to_victoria(status, config, model):
             ),
         ),
         UpgradeStep(
-            description=f"Wait 1800 s for model {model.name} to reach the idle state.",
+            description=f"Wait 1800s for model {model.name} to reach the idle state.",
             parallel=False,
             coro=model.wait_for_idle(1800, None),
         ),
@@ -251,7 +251,7 @@ def test_auxiliary_upgrade_plan_ussuri_to_victoria_ch_migration(status, config, 
             ),
         ),
         UpgradeStep(
-            description=f"Wait 1800 s for model {model.name} to reach the idle state.",
+            description=f"Wait 1800s for model {model.name} to reach the idle state.",
             parallel=False,
             coro=model.wait_for_idle(1800, None),
         ),
@@ -431,7 +431,7 @@ def test_ceph_mon_upgrade_plan_xena_to_yoga(
             ),
         ),
         UpgradeStep(
-            description=f"Wait 1800 s for model {model.name} to reach the idle state.",
+            description=f"Wait 1800s for model {model.name} to reach the idle state.",
             parallel=False,
             coro=model.wait_for_idle(1800, None),
         ),
@@ -494,7 +494,7 @@ def test_ceph_mon_upgrade_plan_ussuri_to_victoria(
             ),
         ),
         UpgradeStep(
-            description=f"Wait 1800 s for model {model.name} to reach the idle state.",
+            description=f"Wait 1800s for model {model.name} to reach the idle state.",
             parallel=False,
             coro=model.wait_for_idle(1800, None),
         ),
@@ -601,7 +601,7 @@ def test_ovn_principal_upgrade_plan(status, config, model):
             ),
         ),
         UpgradeStep(
-            description=f"Wait 300 s for app {app.name} to reach the idle state.",
+            description=f"Wait 300s for app {app.name} to reach the idle state.",
             parallel=False,
             coro=model.wait_for_idle(300, [app.name]),
         ),
@@ -657,7 +657,7 @@ def test_mysql_innodb_cluster_upgrade(status, config, model):
             ),
         ),
         UpgradeStep(
-            description=f"Wait 1800 s for app {app.name} to reach the idle state.",
+            description=f"Wait 1800s for app {app.name} to reach the idle state.",
             parallel=False,
             coro=model.wait_for_idle(1800, [app.name]),
         ),

--- a/tests/unit/apps/test_auxiliary.py
+++ b/tests/unit/apps/test_auxiliary.py
@@ -130,9 +130,9 @@ def test_auxiliary_upgrade_plan_ussuri_to_victoria_change_channel(status, config
             ),
         ),
         UpgradeStep(
-            description=f"Wait 300 s for model {model.name} to reach the idle state.",
+            description=f"Wait 1800 s for model {model.name} to reach the idle state.",
             parallel=False,
-            coro=model.wait_for_idle(300, None),
+            coro=model.wait_for_idle(1800, None),
         ),
         UpgradeStep(
             description=f"Check if the workload of '{app.name}' has been upgraded",
@@ -189,9 +189,9 @@ def test_auxiliary_upgrade_plan_ussuri_to_victoria(status, config, model):
             ),
         ),
         UpgradeStep(
-            description=f"Wait 300 s for model {model.name} to reach the idle state.",
+            description=f"Wait 1800 s for model {model.name} to reach the idle state.",
             parallel=False,
-            coro=model.wait_for_idle(300, None),
+            coro=model.wait_for_idle(1800, None),
         ),
         UpgradeStep(
             description=f"Check if the workload of '{app.name}' has been upgraded",
@@ -251,9 +251,9 @@ def test_auxiliary_upgrade_plan_ussuri_to_victoria_ch_migration(status, config, 
             ),
         ),
         UpgradeStep(
-            description=f"Wait 300 s for model {model.name} to reach the idle state.",
+            description=f"Wait 1800 s for model {model.name} to reach the idle state.",
             parallel=False,
-            coro=model.wait_for_idle(300, None),
+            coro=model.wait_for_idle(1800, None),
         ),
         UpgradeStep(
             description=f"Check if the workload of '{app.name}' has been upgraded",
@@ -431,9 +431,9 @@ def test_ceph_mon_upgrade_plan_xena_to_yoga(
             ),
         ),
         UpgradeStep(
-            description=f"Wait 300 s for model {model.name} to reach the idle state.",
+            description=f"Wait 1800 s for model {model.name} to reach the idle state.",
             parallel=False,
-            coro=model.wait_for_idle(300, None),
+            coro=model.wait_for_idle(1800, None),
         ),
         UpgradeStep(
             description=f"Check if the workload of '{app.name}' has been upgraded",
@@ -494,9 +494,9 @@ def test_ceph_mon_upgrade_plan_ussuri_to_victoria(
             ),
         ),
         UpgradeStep(
-            description=f"Wait 300 s for model {model.name} to reach the idle state.",
+            description=f"Wait 1800 s for model {model.name} to reach the idle state.",
             parallel=False,
-            coro=model.wait_for_idle(300, None),
+            coro=model.wait_for_idle(1800, None),
         ),
         UpgradeStep(
             description=f"Check if the workload of '{app.name}' has been upgraded",
@@ -601,9 +601,9 @@ def test_ovn_principal_upgrade_plan(status, config, model):
             ),
         ),
         UpgradeStep(
-            description=f"Wait 120 s for app {app.name} to reach the idle state.",
+            description=f"Wait 300 s for app {app.name} to reach the idle state.",
             parallel=False,
-            coro=model.wait_for_idle(120, [app.name]),
+            coro=model.wait_for_idle(300, [app.name]),
         ),
         UpgradeStep(
             description=f"Check if the workload of '{app.name}' has been upgraded",
@@ -657,9 +657,9 @@ def test_mysql_innodb_cluster_upgrade(status, config, model):
             ),
         ),
         UpgradeStep(
-            description=f"Wait 120 s for app {app.name} to reach the idle state.",
+            description=f"Wait 1800 s for app {app.name} to reach the idle state.",
             parallel=False,
-            coro=model.wait_for_idle(120, [app.name]),
+            coro=model.wait_for_idle(1800, [app.name]),
         ),
         UpgradeStep(
             description=f"Check if the workload of '{app.name}' has been upgraded",

--- a/tests/unit/apps/test_channel_based.py
+++ b/tests/unit/apps/test_channel_based.py
@@ -177,7 +177,7 @@ def test_application_gnocchi_upgrade_plan_ussuri_to_victoria(status, config, mod
             ),
         ),
         UpgradeStep(
-            description=f"Wait 300 s for app {app.name} to reach the idle state.",
+            description=f"Wait 300s for app {app.name} to reach the idle state.",
             parallel=False,
             coro=model.wait_for_idle(300, [app.name]),
         ),
@@ -242,7 +242,7 @@ def test_application_designate_bind_upgrade_plan_ussuri_to_victoria(status, conf
             ),
         ),
         UpgradeStep(
-            description=f"Wait 300 s for app {app.name} to reach the idle state.",
+            description=f"Wait 300s for app {app.name} to reach the idle state.",
             parallel=False,
             coro=model.wait_for_idle(300, [app.name]),
         ),

--- a/tests/unit/apps/test_channel_based.py
+++ b/tests/unit/apps/test_channel_based.py
@@ -177,9 +177,9 @@ def test_application_gnocchi_upgrade_plan_ussuri_to_victoria(status, config, mod
             ),
         ),
         UpgradeStep(
-            description=f"Wait 120 s for app {app.name} to reach the idle state.",
+            description=f"Wait 300 s for app {app.name} to reach the idle state.",
             parallel=False,
-            coro=model.wait_for_idle(120, [app.name]),
+            coro=model.wait_for_idle(300, [app.name]),
         ),
         UpgradeStep(
             description=f"Check if the workload of '{app.name}' has been upgraded",
@@ -242,9 +242,9 @@ def test_application_designate_bind_upgrade_plan_ussuri_to_victoria(status, conf
             ),
         ),
         UpgradeStep(
-            description=f"Wait 120 s for app {app.name} to reach the idle state.",
+            description=f"Wait 300 s for app {app.name} to reach the idle state.",
             parallel=False,
-            coro=model.wait_for_idle(120, [app.name]),
+            coro=model.wait_for_idle(300, [app.name]),
         ),
         UpgradeStep(
             description=f"Check if the workload of '{app.name}' has been upgraded",

--- a/tests/unit/apps/test_core.py
+++ b/tests/unit/apps/test_core.py
@@ -358,7 +358,7 @@ def test_upgrade_plan_ussuri_to_victoria(status, config, model):
             ),
         ),
         UpgradeStep(
-            description=f"Wait 1800 s for model {model.name} to reach the idle state.",
+            description=f"Wait 1800s for model {model.name} to reach the idle state.",
             parallel=False,
             coro=model.wait_for_idle(1800, None),
         ),
@@ -414,7 +414,7 @@ def test_upgrade_plan_ussuri_to_victoria_ch_migration(status, config, model):
             ),
         ),
         UpgradeStep(
-            description=f"Wait 1800 s for model {model.name} to reach the idle state.",
+            description=f"Wait 1800s for model {model.name} to reach the idle state.",
             parallel=False,
             coro=model.wait_for_idle(1800, None),
         ),
@@ -466,7 +466,7 @@ def test_upgrade_plan_channel_on_next_os_release(status, config, model):
             ),
         ),
         UpgradeStep(
-            description=f"Wait 1800 s for model {model.name} to reach the idle state.",
+            description=f"Wait 1800s for model {model.name} to reach the idle state.",
             parallel=False,
             coro=model.wait_for_idle(1800, None),
         ),
@@ -517,7 +517,7 @@ def test_upgrade_plan_origin_already_on_next_openstack_release(status, config, m
             coro=model.upgrade_charm(app.name, "victoria/stable"),
         ),
         UpgradeStep(
-            description=f"Wait 1800 s for model {model.name} to reach the idle state.",
+            description=f"Wait 1800s for model {model.name} to reach the idle state.",
             parallel=False,
             coro=model.wait_for_idle(1800, None),
         ),
@@ -592,7 +592,7 @@ def test_upgrade_plan_application_already_disable_action_managed(status, config,
             ),
         ),
         UpgradeStep(
-            description=f"Wait 1800 s for model {model.name} to reach the idle state.",
+            description=f"Wait 1800s for model {model.name} to reach the idle state.",
             parallel=False,
             coro=model.wait_for_idle(1800, None),
         ),

--- a/tests/unit/apps/test_core.py
+++ b/tests/unit/apps/test_core.py
@@ -358,9 +358,9 @@ def test_upgrade_plan_ussuri_to_victoria(status, config, model):
             ),
         ),
         UpgradeStep(
-            description=f"Wait 300 s for model {model.name} to reach the idle state.",
+            description=f"Wait 1800 s for model {model.name} to reach the idle state.",
             parallel=False,
-            coro=model.wait_for_idle(300, None),
+            coro=model.wait_for_idle(1800, None),
         ),
         UpgradeStep(
             description=f"Check if the workload of '{app.name}' has been upgraded",
@@ -414,9 +414,9 @@ def test_upgrade_plan_ussuri_to_victoria_ch_migration(status, config, model):
             ),
         ),
         UpgradeStep(
-            description=f"Wait 300 s for model {model.name} to reach the idle state.",
+            description=f"Wait 1800 s for model {model.name} to reach the idle state.",
             parallel=False,
-            coro=model.wait_for_idle(300, None),
+            coro=model.wait_for_idle(1800, None),
         ),
         UpgradeStep(
             description=f"Check if the workload of '{app.name}' has been upgraded",
@@ -466,9 +466,9 @@ def test_upgrade_plan_channel_on_next_os_release(status, config, model):
             ),
         ),
         UpgradeStep(
-            description=f"Wait 300 s for model {model.name} to reach the idle state.",
+            description=f"Wait 1800 s for model {model.name} to reach the idle state.",
             parallel=False,
-            coro=model.wait_for_idle(300, None),
+            coro=model.wait_for_idle(1800, None),
         ),
         UpgradeStep(
             description=f"Check if the workload of '{app.name}' has been upgraded",
@@ -517,9 +517,9 @@ def test_upgrade_plan_origin_already_on_next_openstack_release(status, config, m
             coro=model.upgrade_charm(app.name, "victoria/stable"),
         ),
         UpgradeStep(
-            description=f"Wait 300 s for model {model.name} to reach the idle state.",
+            description=f"Wait 1800 s for model {model.name} to reach the idle state.",
             parallel=False,
-            coro=model.wait_for_idle(300, None),
+            coro=model.wait_for_idle(1800, None),
         ),
         UpgradeStep(
             description=f"Check if the workload of '{app.name}' has been upgraded",
@@ -592,9 +592,9 @@ def test_upgrade_plan_application_already_disable_action_managed(status, config,
             ),
         ),
         UpgradeStep(
-            description=f"Wait 300 s for model {model.name} to reach the idle state.",
+            description=f"Wait 1800 s for model {model.name} to reach the idle state.",
             parallel=False,
-            coro=model.wait_for_idle(300, None),
+            coro=model.wait_for_idle(1800, None),
         ),
         UpgradeStep(
             description=f"Check if the workload of '{app.name}' has been upgraded",

--- a/tests/unit/steps/test_steps_plan.py
+++ b/tests/unit/steps/test_steps_plan.py
@@ -44,15 +44,15 @@ def generate_expected_upgrade_plan_principal(app, target, model):
     if app.charm in ["rabbitmq-server", "ceph-mon", "keystone"]:
         # apps waiting for whole model
         wait_step = UpgradeStep(
-            description=f"Wait 300 s for model {model.name} to reach the idle state.",
+            description=f"Wait 1800 s for model {model.name} to reach the idle state.",
             parallel=False,
-            coro=model.wait_for_idle(300, None),
+            coro=model.wait_for_idle(1800, None),
         )
     else:
         wait_step = UpgradeStep(
-            description=f"Wait 120 s for app {app.name} to reach the idle state.",
+            description=f"Wait 300 s for app {app.name} to reach the idle state.",
             parallel=False,
-            coro=model.wait_for_idle(120, [app.name]),
+            coro=model.wait_for_idle(300, [app.name]),
         )
 
     upgrade_steps = [

--- a/tests/unit/steps/test_steps_plan.py
+++ b/tests/unit/steps/test_steps_plan.py
@@ -44,13 +44,13 @@ def generate_expected_upgrade_plan_principal(app, target, model):
     if app.charm in ["rabbitmq-server", "ceph-mon", "keystone"]:
         # apps waiting for whole model
         wait_step = UpgradeStep(
-            description=f"Wait 1800 s for model {model.name} to reach the idle state.",
+            description=f"Wait 1800s for model {model.name} to reach the idle state.",
             parallel=False,
             coro=model.wait_for_idle(1800, None),
         )
     else:
         wait_step = UpgradeStep(
-            description=f"Wait 300 s for app {app.name} to reach the idle state.",
+            description=f"Wait 300s for app {app.name} to reach the idle state.",
             parallel=False,
             coro=model.wait_for_idle(300, [app.name]),
         )


### PR DESCRIPTION
During testing of OpenStack cloud upgrade with COU, we found out that current waiting times are not enough. I increases all of times, since we raise an exception if any app and up in error state it's safe to have longer wait time, where most of that time will not be used.

fixes: #155