### PR TITLE
Create separate classes for different types of steps

### DIFF
--- a/cou/apps/auxiliary.py
+++ b/cou/apps/auxiliary.py
@@ -18,7 +18,7 @@ from typing import Optional
 from cou.apps.base import OpenStackApplication
 from cou.apps.factory import AppFactory
 from cou.exceptions import ApplicationError
-from cou.steps import PreUpgradeSubStep
+from cou.steps import PreUpgradeStep
 from cou.utils.app_utils import set_require_osd_release_option, validate_ovn_support
 from cou.utils.openstack import (
     OPENSTACK_TO_TRACK_MAPPING,
@@ -139,17 +139,17 @@ class CephMonApplication(OpenStackAuxiliaryApplication):
     wait_timeout = 300
     wait_for_model = True
 
-    def pre_upgrade_plan(self, target: OpenStackRelease) -> list[PreUpgradeSubStep]:
+    def pre_upgrade_plan(self, target: OpenStackRelease) -> list[PreUpgradeStep]:
         """Pre Upgrade planning.
 
         :param target: OpenStack release as target to upgrade.
         :type target: OpenStackRelease
         :return: Plan that will add pre upgrade as sub steps.
-        :rtype: list[PreUpgradeSubStep]
+        :rtype: list[PreUpgradeStep]
         """
         return super().pre_upgrade_plan(target) + [self._get_change_require_osd_release_plan()]
 
-    def _get_change_require_osd_release_plan(self, parallel: bool = False) -> PreUpgradeSubStep:
+    def _get_change_require_osd_release_plan(self, parallel: bool = False) -> PreUpgradeStep:
         """Get plan to set correct value for require-osd-release option on ceph-mon.
 
         This step is needed as a workaround for LP#1929254. Reference:
@@ -158,10 +158,10 @@ class CephMonApplication(OpenStackAuxiliaryApplication):
         :param parallel: Parallel running, defaults to False
         :type parallel: bool, optional
         :return: Plan to check and set correct value for require-osd-release
-        :rtype: PreUpgradeSubStep
+        :rtype: PreUpgradeStep
         """
         ceph_mon_unit, *_ = self.units
-        return PreUpgradeSubStep(
+        return PreUpgradeStep(
             description="Ensure require-osd-release option matches with ceph-osd version",
             parallel=parallel,
             coro=set_require_osd_release_option(ceph_mon_unit.name, self.model),
@@ -172,13 +172,13 @@ class CephMonApplication(OpenStackAuxiliaryApplication):
 class OvnPrincipalApplication(OpenStackAuxiliaryApplication):
     """Ovn principal application class."""
 
-    def pre_upgrade_plan(self, target: OpenStackRelease) -> list[PreUpgradeSubStep]:
+    def pre_upgrade_plan(self, target: OpenStackRelease) -> list[PreUpgradeStep]:
         """Pre Upgrade planning.
 
         :param target: OpenStack release as target to upgrade.
         :type target: OpenStackRelease
         :return: Plan that will add pre upgrade as sub steps.
-        :rtype: list[PreUpgradeSubStep]
+        :rtype: list[PreUpgradeStep]
         """
         for unit in self.units:
             validate_ovn_support(unit.workload_version)

--- a/cou/apps/auxiliary.py
+++ b/cou/apps/auxiliary.py
@@ -18,7 +18,7 @@ from typing import Optional
 from cou.apps.base import OpenStackApplication
 from cou.apps.factory import AppFactory
 from cou.exceptions import ApplicationError
-from cou.steps import UpgradeStep
+from cou.steps import PreUpgradeSubStep
 from cou.utils.app_utils import set_require_osd_release_option, validate_ovn_support
 from cou.utils.openstack import (
     OPENSTACK_TO_TRACK_MAPPING,
@@ -139,17 +139,17 @@ class CephMonApplication(OpenStackAuxiliaryApplication):
     wait_timeout = 300
     wait_for_model = True
 
-    def pre_upgrade_plan(self, target: OpenStackRelease) -> list[UpgradeStep]:
+    def pre_upgrade_plan(self, target: OpenStackRelease) -> list[PreUpgradeSubStep]:
         """Pre Upgrade planning.
 
         :param target: OpenStack release as target to upgrade.
         :type target: OpenStackRelease
         :return: Plan that will add pre upgrade as sub steps.
-        :rtype: list[UpgradeStep]
+        :rtype: list[PreUpgradeSubStep]
         """
         return super().pre_upgrade_plan(target) + [self._get_change_require_osd_release_plan()]
 
-    def _get_change_require_osd_release_plan(self, parallel: bool = False) -> UpgradeStep:
+    def _get_change_require_osd_release_plan(self, parallel: bool = False) -> PreUpgradeSubStep:
         """Get plan to set correct value for require-osd-release option on ceph-mon.
 
         This step is needed as a workaround for LP#1929254. Reference:
@@ -158,10 +158,10 @@ class CephMonApplication(OpenStackAuxiliaryApplication):
         :param parallel: Parallel running, defaults to False
         :type parallel: bool, optional
         :return: Plan to check and set correct value for require-osd-release
-        :rtype: UpgradeStep
+        :rtype: PreUpgradeSubStep
         """
         ceph_mon_unit, *_ = self.units
-        return UpgradeStep(
+        return PreUpgradeSubStep(
             description="Ensure require-osd-release option matches with ceph-osd version",
             parallel=parallel,
             coro=set_require_osd_release_option(ceph_mon_unit.name, self.model),
@@ -172,13 +172,13 @@ class CephMonApplication(OpenStackAuxiliaryApplication):
 class OvnPrincipalApplication(OpenStackAuxiliaryApplication):
     """Ovn principal application class."""
 
-    def pre_upgrade_plan(self, target: OpenStackRelease) -> list[UpgradeStep]:
+    def pre_upgrade_plan(self, target: OpenStackRelease) -> list[PreUpgradeSubStep]:
         """Pre Upgrade planning.
 
         :param target: OpenStack release as target to upgrade.
         :type target: OpenStackRelease
         :return: Plan that will add pre upgrade as sub steps.
-        :rtype: list[UpgradeStep]
+        :rtype: list[PreUpgradeSubStep]
         """
         for unit in self.units:
             validate_ovn_support(unit.workload_version)

--- a/cou/apps/auxiliary_subordinate.py
+++ b/cou/apps/auxiliary_subordinate.py
@@ -15,7 +15,7 @@
 from cou.apps.auxiliary import OpenStackAuxiliaryApplication
 from cou.apps.factory import AppFactory
 from cou.apps.subordinate import SubordinateBaseClass
-from cou.steps import UpgradeStep
+from cou.steps import PreUpgradeSubStep
 from cou.utils.app_utils import validate_ovn_support
 from cou.utils.openstack import AUXILIARY_SUBORDINATES, OpenStackRelease
 
@@ -42,13 +42,13 @@ class OpenStackAuxiliarySubordinateApplication(
 class OvnSubordinateApplication(OpenStackAuxiliarySubordinateApplication):
     """Ovn subordinate application class."""
 
-    def pre_upgrade_plan(self, target: OpenStackRelease) -> list[UpgradeStep]:
+    def pre_upgrade_plan(self, target: OpenStackRelease) -> list[PreUpgradeSubStep]:
         """Pre Upgrade planning.
 
         :param target: OpenStack release as target to upgrade.
         :type target: OpenStackRelease
         :return: Plan that will add pre upgrade as sub steps.
-        :rtype: list[UpgradeStep]
+        :rtype: list[PreUpgradeSubStep]
         """
         validate_ovn_support(self.status.workload_version)
         return super().pre_upgrade_plan(target)

--- a/cou/apps/auxiliary_subordinate.py
+++ b/cou/apps/auxiliary_subordinate.py
@@ -15,7 +15,7 @@
 from cou.apps.auxiliary import OpenStackAuxiliaryApplication
 from cou.apps.factory import AppFactory
 from cou.apps.subordinate import SubordinateBaseClass
-from cou.steps import PreUpgradeSubStep
+from cou.steps import PreUpgradeStep
 from cou.utils.app_utils import validate_ovn_support
 from cou.utils.openstack import AUXILIARY_SUBORDINATES, OpenStackRelease
 
@@ -42,13 +42,13 @@ class OpenStackAuxiliarySubordinateApplication(
 class OvnSubordinateApplication(OpenStackAuxiliarySubordinateApplication):
     """Ovn subordinate application class."""
 
-    def pre_upgrade_plan(self, target: OpenStackRelease) -> list[PreUpgradeSubStep]:
+    def pre_upgrade_plan(self, target: OpenStackRelease) -> list[PreUpgradeStep]:
         """Pre Upgrade planning.
 
         :param target: OpenStack release as target to upgrade.
         :type target: OpenStackRelease
         :return: Plan that will add pre upgrade as sub steps.
-        :rtype: list[PreUpgradeSubStep]
+        :rtype: list[PreUpgradeStep]
         """
         validate_ovn_support(self.status.workload_version)
         return super().pre_upgrade_plan(target)

--- a/cou/apps/channel_based.py
+++ b/cou/apps/channel_based.py
@@ -18,7 +18,7 @@ from juju.client._definitions import UnitStatus
 
 from cou.apps.base import OpenStackApplication
 from cou.apps.factory import AppFactory
-from cou.steps import UpgradeStep
+from cou.steps import PostUpgradeSubStep
 from cou.utils.openstack import CHANNEL_BASED_CHARMS, OpenStackRelease
 
 logger = logging.getLogger(__name__)
@@ -60,7 +60,7 @@ class OpenStackChannelBasedApplication(OpenStackApplication):
         """
         return not all(unit.workload_version for unit in self.status.units.values())
 
-    def post_upgrade_plan(self, target: OpenStackRelease) -> list[UpgradeStep]:
+    def post_upgrade_plan(self, target: OpenStackRelease) -> list[PostUpgradeSubStep]:
         """Post Upgrade planning.
 
         Wait until the application reaches the idle state and then check the target workload.
@@ -68,7 +68,7 @@ class OpenStackChannelBasedApplication(OpenStackApplication):
         :param target: OpenStack release as target to upgrade.
         :type target: OpenStackRelease
         :return: Plan that will add post upgrade as sub steps.
-        :rtype: list[UpgradeStep]
+        :rtype: list[PostUpgradeSubStep]
         """
         if self.is_versionless:
             return []

--- a/cou/apps/channel_based.py
+++ b/cou/apps/channel_based.py
@@ -18,7 +18,7 @@ from juju.client._definitions import UnitStatus
 
 from cou.apps.base import OpenStackApplication
 from cou.apps.factory import AppFactory
-from cou.steps import PostUpgradeSubStep
+from cou.steps import PostUpgradeStep
 from cou.utils.openstack import CHANNEL_BASED_CHARMS, OpenStackRelease
 
 logger = logging.getLogger(__name__)
@@ -60,7 +60,7 @@ class OpenStackChannelBasedApplication(OpenStackApplication):
         """
         return not all(unit.workload_version for unit in self.status.units.values())
 
-    def post_upgrade_plan(self, target: OpenStackRelease) -> list[PostUpgradeSubStep]:
+    def post_upgrade_plan(self, target: OpenStackRelease) -> list[PostUpgradeStep]:
         """Post Upgrade planning.
 
         Wait until the application reaches the idle state and then check the target workload.
@@ -68,7 +68,7 @@ class OpenStackChannelBasedApplication(OpenStackApplication):
         :param target: OpenStack release as target to upgrade.
         :type target: OpenStackRelease
         :return: Plan that will add post upgrade as sub steps.
-        :rtype: list[PostUpgradeSubStep]
+        :rtype: list[PostUpgradeStep]
         """
         if self.is_versionless:
             return []

--- a/cou/apps/subordinate.py
+++ b/cou/apps/subordinate.py
@@ -16,7 +16,7 @@ import logging
 
 from cou.apps.base import OpenStackApplication
 from cou.apps.factory import AppFactory
-from cou.steps import UpgradeStep
+from cou.steps import PostUpgradeSubStep, PreUpgradeSubStep, UpgradeSubStep
 from cou.utils.openstack import SUBORDINATES, OpenStackRelease
 
 logger = logging.getLogger(__name__)
@@ -25,34 +25,34 @@ logger = logging.getLogger(__name__)
 class SubordinateBaseClass(OpenStackApplication):
     """Subordinate base class."""
 
-    def pre_upgrade_plan(self, target: OpenStackRelease) -> list[UpgradeStep]:
+    def pre_upgrade_plan(self, target: OpenStackRelease) -> list[PreUpgradeSubStep]:
         """Pre Upgrade planning.
 
         :param target: OpenStack release as target to upgrade.
         :type target: OpenStackRelease
         :return: Plan that will add pre upgrade as sub steps.
-        :rtype: list[UpgradeStep]
+        :rtype: list[PreUpgradeSubStep]
         """
         return [self._get_refresh_charm_plan(target)]
 
-    def upgrade_plan(self, target: OpenStackRelease) -> list[UpgradeStep]:
+    def upgrade_plan(self, target: OpenStackRelease) -> list[UpgradeSubStep]:
         """Upgrade planning.
 
         :param target: OpenStack release as target to upgrade.
         :type target: OpenStackRelease
         :raises HaltUpgradePlanGeneration: When the application halt the upgrade plan generation.
         :return: Plan that will add upgrade as sub steps.
-        :rtype: list[UpgradeStep]
+        :rtype: list[UpgradeSubStep]
         """
         return [self._get_upgrade_charm_plan(target)]
 
-    def post_upgrade_plan(self, target: OpenStackRelease) -> list[UpgradeStep]:
+    def post_upgrade_plan(self, target: OpenStackRelease) -> list[PostUpgradeSubStep]:
         """Post Upgrade planning.
 
         :param target: OpenStack release as target to upgrade.
         :type target: OpenStackRelease
         :return: Plan that will add post upgrade as sub steps.
-        :rtype: list[UpgradeStep]
+        :rtype: list[PostUpgradeSubStep]
         """
         return []
 

--- a/cou/apps/subordinate.py
+++ b/cou/apps/subordinate.py
@@ -16,7 +16,7 @@ import logging
 
 from cou.apps.base import OpenStackApplication
 from cou.apps.factory import AppFactory
-from cou.steps import PostUpgradeSubStep, PreUpgradeSubStep, UpgradeSubStep
+from cou.steps import PostUpgradeStep, PreUpgradeStep, UpgradeStep
 from cou.utils.openstack import SUBORDINATES, OpenStackRelease
 
 logger = logging.getLogger(__name__)
@@ -25,34 +25,34 @@ logger = logging.getLogger(__name__)
 class SubordinateBaseClass(OpenStackApplication):
     """Subordinate base class."""
 
-    def pre_upgrade_plan(self, target: OpenStackRelease) -> list[PreUpgradeSubStep]:
+    def pre_upgrade_plan(self, target: OpenStackRelease) -> list[PreUpgradeStep]:
         """Pre Upgrade planning.
 
         :param target: OpenStack release as target to upgrade.
         :type target: OpenStackRelease
         :return: Plan that will add pre upgrade as sub steps.
-        :rtype: list[PreUpgradeSubStep]
+        :rtype: list[PreUpgradeStep]
         """
         return [self._get_refresh_charm_plan(target)]
 
-    def upgrade_plan(self, target: OpenStackRelease) -> list[UpgradeSubStep]:
+    def upgrade_plan(self, target: OpenStackRelease) -> list[UpgradeStep]:
         """Upgrade planning.
 
         :param target: OpenStack release as target to upgrade.
         :type target: OpenStackRelease
         :raises HaltUpgradePlanGeneration: When the application halt the upgrade plan generation.
         :return: Plan that will add upgrade as sub steps.
-        :rtype: list[UpgradeSubStep]
+        :rtype: list[UpgradeStep]
         """
         return [self._get_upgrade_charm_plan(target)]
 
-    def post_upgrade_plan(self, target: OpenStackRelease) -> list[PostUpgradeSubStep]:
+    def post_upgrade_plan(self, target: OpenStackRelease) -> list[PostUpgradeStep]:
         """Post Upgrade planning.
 
         :param target: OpenStack release as target to upgrade.
         :type target: OpenStackRelease
         :return: Plan that will add post upgrade as sub steps.
-        :rtype: list[PostUpgradeSubStep]
+        :rtype: list[PostUpgradeStep]
         """
         return []
 

--- a/cou/cli.py
+++ b/cou/cli.py
@@ -25,7 +25,7 @@ from juju.errors import JujuError
 from cou.commands import parse_args
 from cou.exceptions import COUException, HighestReleaseAchieved, TimeoutException
 from cou.logging import setup_logging
-from cou.steps import BaseStep
+from cou.steps import UpgradePlan
 from cou.steps.analyze import Analysis
 from cou.steps.execute import apply_plan
 from cou.steps.plan import generate_plan, manually_upgrade_data_plane
@@ -86,7 +86,7 @@ def get_log_level(quiet: bool = False, verbosity: int = 0) -> str:
 
 async def analyze_and_plan(
     model_name: Optional[str], backup_database: bool
-) -> tuple[Analysis, BaseStep]:
+) -> tuple[Analysis, UpgradePlan]:
     """Analyze cloud and generate the upgrade plan with steps.
 
     :param model_name: Model name inputted by user.
@@ -94,7 +94,7 @@ async def analyze_and_plan(
     :param backup_database: Whether to create database backup before upgrade.
     :type backup_database: bool
     :return: Generated analyses and upgrade plan.
-    :rtype: tuple[Analysis, BaseStep]
+    :rtype: tuple[Analysis, UpgradePlan]
     """
     model = await COUModel.create(model_name)
     logger.info("Using model: %s", model.name)

--- a/cou/cli.py
+++ b/cou/cli.py
@@ -25,7 +25,7 @@ from juju.errors import JujuError
 from cou.commands import parse_args
 from cou.exceptions import COUException, HighestReleaseAchieved, TimeoutException
 from cou.logging import setup_logging
-from cou.steps import UpgradeStep
+from cou.steps import BaseStep
 from cou.steps.analyze import Analysis
 from cou.steps.execute import apply_plan
 from cou.steps.plan import generate_plan, manually_upgrade_data_plane
@@ -86,7 +86,7 @@ def get_log_level(quiet: bool = False, verbosity: int = 0) -> str:
 
 async def analyze_and_plan(
     model_name: Optional[str], backup_database: bool
-) -> tuple[Analysis, UpgradeStep]:
+) -> tuple[Analysis, BaseStep]:
     """Analyze cloud and generate the upgrade plan with steps.
 
     :param model_name: Model name inputted by user.
@@ -94,7 +94,7 @@ async def analyze_and_plan(
     :param backup_database: Whether to create database backup before upgrade.
     :type backup_database: bool
     :return: Generated analyses and upgrade plan.
-    :rtype: tuple[Analysis, UpgradeStep]
+    :rtype: tuple[Analysis, BaseStep]
     """
     model = await COUModel.create(model_name)
     logger.info("Using model: %s", model.name)

--- a/cou/exceptions.py
+++ b/cou/exceptions.py
@@ -106,7 +106,7 @@ class TimeoutException(COUException):
     """COU timeout exception."""
 
 
-class CanceledUpgradeStep(COUException):
+class CanceledStep(COUException):
     """COU exception when executing canceled step."""
 
 

--- a/cou/steps/__init__.py
+++ b/cou/steps/__init__.py
@@ -240,7 +240,7 @@ class UpgradePlan(BaseStep):
     """Represents the upgrade plan.
 
     This class is intended to be used as a higher-level group for actual upgrade steps, therefore
-    doesn't accept corotine or parallel as inputs.
+    doesn't accept coroutine or parallel as inputs.
     """
 
     prompt: bool = False
@@ -260,17 +260,17 @@ class UpgradePlan(BaseStep):
     async def run(self) -> None:
         """Run UpgradePlan.
 
-        UpgradePlan should not have contain any corotine, so simply print a debug
+        UpgradePlan should not have contain any coroutine, so simply print a debug
         message to demonstrate the noop.
         """
-        logger.debug("No corotine to run for %s", repr(self))
+        logger.debug("No coroutine to run for %s", repr(self))
 
 
 class ApplicationUpgradePlan(UpgradePlan):
     """Represents the plan for application-level upgrade.
 
     This class is intended to be used as a group for application-level upgrade steps, therefore
-    doesn't accept corotine or parallel as inputs.
+    doesn't accept coroutine or parallel as inputs.
     """
 
     prompt: bool = True

--- a/cou/steps/__init__.py
+++ b/cou/steps/__init__.py
@@ -71,7 +71,6 @@ class BaseStep:
         description: str = "",
         parallel: bool = False,
         coro: Optional[Coroutine] = None,
-        prompt: Optional[bool] = None,
     ):
         """Initialize BaseStep.
 
@@ -96,10 +95,6 @@ class BaseStep:
         self.sub_steps: List[BaseStep] = []
         self._canceled: bool = False
         self._task: Optional[asyncio.Task] = None
-
-        # Use default prompt value unless explicitly provided
-        if prompt is not None:
-            self.prompt = prompt
 
     def __hash__(self) -> int:
         """Get hash for BaseStep."""
@@ -248,14 +243,13 @@ class UpgradePlan(BaseStep):
     def __init__(
         self,
         description: str = "",
-        prompt: bool = False,
     ):
         """Initialize upgrade plan.
 
         :param description: Description of the step.
         :type description: str
         """
-        super().__init__(description=description, parallel=False, coro=None, prompt=prompt)
+        super().__init__(description=description, parallel=False, coro=None)
 
     async def run(self) -> None:
         """Run UpgradePlan.
@@ -284,7 +278,7 @@ class UpgradeStep(BaseStep):
 
     @property
     def description(self) -> str:
-        """Get the description of the PreUpgradeStep.
+        """Get the description of the UpgradeStep.
 
         :return: description
         :rtype: str
@@ -293,7 +287,7 @@ class UpgradeStep(BaseStep):
 
     @description.setter
     def description(self, description: str) -> None:
-        """Set the description of the PreUpgradeStep.
+        """Set the description of the UpgradeStep.
 
         :param description: description
         :type description: str

--- a/cou/steps/__init__.py
+++ b/cou/steps/__init__.py
@@ -23,7 +23,7 @@ import os
 import warnings
 from typing import Any, Coroutine, List, Optional
 
-from cou.exceptions import CanceledUpgradeStep
+from cou.exceptions import CanceledStep
 
 logger = logging.getLogger(__name__)
 
@@ -50,10 +50,10 @@ def compare_step_coroutines(coro1: Optional[Coroutine], coro2: Optional[Coroutin
     )
 
 
-class UpgradeStep:
+class BaseStep:
     """Represents each upgrade step.
 
-    This UpgradeStep is used to define any step when performing an OpenStack upgrade.
+    This BaseStep is used to define any step when performing an OpenStack upgrade.
     And requires description, parallel and coroutine as arguments. The coroutine is expected by
     creating an asyncio.Task task instead of waiting directly, so that it is possible to cancel
     the task and at the same time simply find out which task is really running according to
@@ -84,23 +84,23 @@ class UpgradeStep:
         self._coro: Optional[Coroutine] = coro
         self.parallel = parallel
         self.description = description
-        self.sub_steps: List[UpgradeStep] = []
+        self.sub_steps: List[BaseStep] = []
         self._canceled: bool = False
         self._task: Optional[asyncio.Task] = None
 
     def __hash__(self) -> int:
-        """Get hash for UpgradeStep."""
+        """Get hash for BaseStep."""
         return hash((self.description, self.parallel, self._coro))
 
     def __eq__(self, other: Any) -> bool:
-        """Equal magic method for UpgradeStep.
+        """Equal magic method for BaseStep.
 
-        :param other: UpgradeStep object to compare.
+        :param other: BaseStep object to compare.
         :type other: Any
         :return: True if equal False if different.
         :rtype: bool
         """
-        if not isinstance(other, UpgradeStep):
+        if not isinstance(other, BaseStep):
             return NotImplemented
 
         return (
@@ -113,7 +113,7 @@ class UpgradeStep:
     def __str__(self) -> str:
         """Dump the plan for upgrade.
 
-        :return: String representation of UpgradeStep.
+        :return: String representation of BaseStep.
         :rtype: str
         """
         result = ""
@@ -127,17 +127,17 @@ class UpgradeStep:
         return result
 
     def __repr__(self) -> str:
-        """Representation of UpgradeStep.
+        """Representation of BaseStep.
 
-        :return: Representation of UpgradeStep.
+        :return: Representation of BaseStep.
         :rtype: str
         """
         return f"UpgradeStep({self.description})"
 
     def __bool__(self) -> bool:
-        """Boolean magic method for UpgradeStep.
+        """Boolean magic method for BaseStep.
 
-        :return: True if there is at least one coroutine in a UpgradeStep
+        :return: True if there is at least one coroutine in a BaseStep
         or in its sub steps.
         :rtype: bool
         """
@@ -145,7 +145,7 @@ class UpgradeStep:
 
     @property
     def description(self) -> str:
-        """Get the description of the UpgradeStep.
+        """Get the description of the BaseStep.
 
         :return: description
         :rtype: str
@@ -154,7 +154,7 @@ class UpgradeStep:
 
     @description.setter
     def description(self, description: str) -> None:
-        """Set the description of the UpgradeStep.
+        """Set the description of the BaseStep.
 
         :param description: description
         :type description: str
@@ -171,14 +171,23 @@ class UpgradeStep:
 
     @property
     def results(self) -> Any:
-        """Return result of UpgradeStep."""
+        """Return result of BaseStep."""
         return self._task.result() if self._task is not None else None
 
-    def add_step(self, step: UpgradeStep) -> None:
+    @property
+    def is_functionless(self) -> bool:
+        """Check if this is a functionless step.
+
+        :return: True if doesn't contain function. False otherwise.
+        :rtype: bool
+        """
+        return self._coro is None
+
+    def add_step(self, step: BaseStep) -> None:
         """Add a single step.
 
-        :param step: UpgradeStep to be added as sub step.
-        :type step: UpgradeStep
+        :param step: BaseStep to be added as sub step.
+        :type step: BaseStep
         """
         self.sub_steps.append(step)
 
@@ -202,16 +211,16 @@ class UpgradeStep:
         logger.debug("canceled: %s", self)
 
     async def run(self) -> Any:
-        """Run the UpgradeStep coroutine.
+        """Run the BaseStep coroutine.
 
         :return: Result of the coroutine.
         :rtype: Any
-        :raises CanceledUpgradeStep: If step has already been canceled.
+        :raises CanceledStep: If step has already been canceled.
         """
         logger.debug("running step: %s", repr(self))
 
         if self.canceled:
-            raise CanceledUpgradeStep(f"Could not run canceled step: {repr(self)}")
+            raise CanceledStep(f"Could not run canceled step: {repr(self)}")
 
         if self._coro is None:
             return  # do nothing if coro was not provided
@@ -221,3 +230,61 @@ class UpgradeStep:
             return await self._task  # wait until task is completed
         except asyncio.CancelledError:  # ignoring asyncio.CancelledError
             logger.warning("Task %s was stopped unsafely.", repr(self))
+
+
+class ApplicationUpgradeStep(BaseStep):
+    """Represents the step for application-level upgrade."""
+
+
+class UpgradeSubStep(BaseStep):
+    """Represents the sub-step of an application upgrade."""
+
+
+class PreUpgradeSubStep(UpgradeSubStep):
+    """Represents the pre-upgrade sub-step for an application upgrade."""
+
+    @property
+    def description(self) -> str:
+        """Get the description of the PreUpgradeSubStep.
+
+        :return: description
+        :rtype: str
+        """
+        return self._description
+
+    @description.setter
+    def description(self, description: str) -> None:
+        """Set the description of the PreUpgradeSubStep.
+
+        :param description: description
+        :type description: str
+        :raises ValueError: When a coroutine is passed without description.
+        """
+        if not description and self._coro:
+            raise ValueError("Every coroutine should have a description")
+        self._description = "[pre-upgrade] " + description
+
+
+class PostUpgradeSubStep(UpgradeSubStep):
+    """Represents the post-upgrade sub-step for an application upgrade."""
+
+    @property
+    def description(self) -> str:
+        """Get the description of the PostUpgradeSubStep.
+
+        :return: description
+        :rtype: str
+        """
+        return self._description
+
+    @description.setter
+    def description(self, description: str) -> None:
+        """Set the description of the PostUpgradeSubStep.
+
+        :param description: description
+        :type description: str
+        :raises ValueError: When a coroutine is passed without description.
+        """
+        if not description and self._coro:
+            raise ValueError("Every coroutine should have a description")
+        self._description = "[post-upgrade] " + description

--- a/cou/steps/__init__.py
+++ b/cou/steps/__init__.py
@@ -65,6 +65,7 @@ class BaseStep:
     # pylint: disable=too-many-instance-attributes
 
     prompt: bool = True  # whether to prompt for user input during execution
+    description_prefix: str = ""  # Common prefix for step description
 
     def __init__(
         self,
@@ -170,7 +171,7 @@ class BaseStep:
         """
         if not description and self._coro:
             raise ValueError("Every coroutine should have a description")
-        self._description = description
+        self._description = self.description_prefix + description
 
     @property
     def all_done(self) -> bool:
@@ -255,10 +256,7 @@ class UpgradePlan(BaseStep):
 
     prompt: bool = False
 
-    def __init__(
-        self,
-        description: str = "",
-    ):
+    def __init__(self, description: str):
         """Initialize upgrade plan.
 
         :param description: Description of the step.
@@ -288,38 +286,17 @@ class ApplicationUpgradePlan(UpgradePlan):
 class UpgradeStep(BaseStep):
     """Represents the upgrade step."""
 
-    sub_step_prefix = "[upgrade] "
     prompt: bool = False
-
-    @property
-    def description(self) -> str:
-        """Get the description of the UpgradeStep.
-
-        :return: description
-        :rtype: str
-        """
-        return self._description
-
-    @description.setter
-    def description(self, description: str) -> None:
-        """Set the description of the UpgradeStep.
-
-        :param description: description
-        :type description: str
-        :raises ValueError: When a coroutine is passed without description.
-        """
-        if not description and self._coro:
-            raise ValueError("Every coroutine should have a description")
-        self._description = self.sub_step_prefix + description
+    description_prefix = "[upgrade] "
 
 
 class PreUpgradeStep(UpgradeStep):
     """Represents the pre-upgrade step."""
 
-    sub_step_prefix = "[pre-upgrade] "
+    description_prefix = "[pre-upgrade] "
 
 
 class PostUpgradeStep(UpgradeStep):
     """Represents the post-upgrade step."""
 
-    sub_step_prefix = "[post-upgrade] "
+    description_prefix = "[post-upgrade] "

--- a/cou/steps/execute.py
+++ b/cou/steps/execute.py
@@ -20,7 +20,7 @@ import sys
 from aioconsole import ainput
 from colorama import Fore, Style
 
-from cou.steps import UpgradeStep
+from cou.steps import BaseStep
 
 AVAILABLE_OPTIONS = ["c", "a", "s"]
 
@@ -67,11 +67,11 @@ def prompt(parameter: str) -> str:
     )
 
 
-async def _run_step(step: UpgradeStep, interactive: bool) -> None:
+async def _run_step(step: BaseStep, interactive: bool) -> None:
     """Run step and all its sub-steps.
 
     :param step: Plan to be executed on steps.
-    :type step: UpgradeStep
+    :type step: BaseStep
     :param interactive: Whether to run upgrade step in interactive mode.
     :type interactive: bool
     """
@@ -89,11 +89,11 @@ async def _run_step(step: UpgradeStep, interactive: bool) -> None:
             await apply_plan(sub_step, interactive)
 
 
-async def apply_plan(plan: UpgradeStep, interactive: bool) -> None:
+async def apply_plan(plan: BaseStep, interactive: bool) -> None:
     """Apply the plan for upgrade.
 
     :param plan: Plan to be executed on steps.
-    :type plan: UpgradeStep
+    :type plan: BaseStep
     :param interactive:
     :type interactive: bool
     """

--- a/cou/steps/plan.py
+++ b/cou/steps/plan.py
@@ -71,9 +71,7 @@ async def generate_plan(analysis_result: Analysis, backup_database: bool) -> Upg
     )
 
     plan = UpgradePlan(
-        description=(
-            f"Upgrade cloud from '{analysis_result.current_cloud_os_release}' to '{target}'"
-        ),
+        f"Upgrade cloud from '{analysis_result.current_cloud_os_release}' to '{target}'"
     )
 
     if backup_database:
@@ -124,7 +122,7 @@ async def create_upgrade_group(
     :return: Upgrade group.
     :rtype: UpgradePlan
     """
-    group_upgrade_plan = UpgradePlan(description=description)
+    group_upgrade_plan = UpgradePlan(description)
     for app in filter(filter_function, apps):
         try:
             app_upgrade_plan = app.generate_upgrade_plan(target)

--- a/cou/steps/plan.py
+++ b/cou/steps/plan.py
@@ -43,7 +43,7 @@ from cou.exceptions import (
     NoTargetError,
     OutOfSupportRange,
 )
-from cou.steps import UpgradeStep
+from cou.steps import BaseStep
 from cou.steps.analyze import Analysis
 from cou.steps.backup import backup
 from cou.utils.openstack import LTS_TO_OS_RELEASE, OpenStackRelease
@@ -51,7 +51,7 @@ from cou.utils.openstack import LTS_TO_OS_RELEASE, OpenStackRelease
 logger = logging.getLogger(__name__)
 
 
-async def generate_plan(analysis_result: Analysis, backup_database: bool) -> UpgradeStep:
+async def generate_plan(analysis_result: Analysis, backup_database: bool) -> BaseStep:
     """Generate plan for upgrade.
 
     :param analysis_result: Analysis result.
@@ -64,18 +64,23 @@ async def generate_plan(analysis_result: Analysis, backup_database: bool) -> Upg
     :raises OutOfSupportRange: When the OpenStack release or Ubuntu series is out of the current
     supporting range.
     :return: Plan with all upgrade steps necessary based on the Analysis.
-    :rtype: UpgradeStep
+    :rtype: BaseStep
     """
     target = determine_upgrade_target(
         analysis_result.current_cloud_os_release, analysis_result.current_cloud_series
     )
-    print(f"Upgrading cloud from '{analysis_result.current_cloud_os_release}' to '{target}'\n.")
 
-    plan = UpgradeStep(description="Top level plan", parallel=False)
+    plan = BaseStep(
+        description=(
+            f"Upgrade cloud from '{analysis_result.current_cloud_os_release}' to '{target}'"
+        ),
+        parallel=False,
+    )
+
     if backup_database:
         plan.add_step(
-            UpgradeStep(
-                description="backup mysql databases",
+            BaseStep(
+                description="Backup mysql databases",
                 parallel=False,
                 coro=backup(analysis_result.model),
             )
@@ -105,7 +110,7 @@ async def create_upgrade_group(
     target: OpenStackRelease,
     description: str,
     filter_function: Callable[[OpenStackApplication], bool],
-) -> UpgradeStep:
+) -> BaseStep:
     """Create upgrade group.
 
     :param apps: Result of the analysis.
@@ -118,9 +123,9 @@ async def create_upgrade_group(
     :type filter_function: Callable[[OpenStackApplication], bool]
     :raises Exception: When cannot generate upgrade plan.
     :return: Upgrade group.
-    :rtype: UpgradeStep
+    :rtype: BaseStep
     """
-    group_upgrade_plan = UpgradeStep(description=description, parallel=False)
+    group_upgrade_plan = BaseStep(description=description, parallel=False)
     for app in filter(filter_function, apps):
         try:
             app_upgrade_plan = app.generate_upgrade_plan(target)

--- a/cou/steps/plan.py
+++ b/cou/steps/plan.py
@@ -80,7 +80,6 @@ async def generate_plan(analysis_result: Analysis, backup_database: bool) -> Upg
         plan.add_step(
             PreUpgradeStep(
                 description="Backup mysql databases",
-                prompt=True,
                 parallel=False,
                 coro=backup(analysis_result.model),
             )

--- a/cou/steps/plan.py
+++ b/cou/steps/plan.py
@@ -43,7 +43,7 @@ from cou.exceptions import (
     NoTargetError,
     OutOfSupportRange,
 )
-from cou.steps import BaseStep
+from cou.steps import PreUpgradeStep, UpgradePlan
 from cou.steps.analyze import Analysis
 from cou.steps.backup import backup
 from cou.utils.openstack import LTS_TO_OS_RELEASE, OpenStackRelease
@@ -51,7 +51,7 @@ from cou.utils.openstack import LTS_TO_OS_RELEASE, OpenStackRelease
 logger = logging.getLogger(__name__)
 
 
-async def generate_plan(analysis_result: Analysis, backup_database: bool) -> BaseStep:
+async def generate_plan(analysis_result: Analysis, backup_database: bool) -> UpgradePlan:
     """Generate plan for upgrade.
 
     :param analysis_result: Analysis result.
@@ -64,23 +64,23 @@ async def generate_plan(analysis_result: Analysis, backup_database: bool) -> Bas
     :raises OutOfSupportRange: When the OpenStack release or Ubuntu series is out of the current
     supporting range.
     :return: Plan with all upgrade steps necessary based on the Analysis.
-    :rtype: BaseStep
+    :rtype: UpgradePlan
     """
     target = determine_upgrade_target(
         analysis_result.current_cloud_os_release, analysis_result.current_cloud_series
     )
 
-    plan = BaseStep(
+    plan = UpgradePlan(
         description=(
             f"Upgrade cloud from '{analysis_result.current_cloud_os_release}' to '{target}'"
         ),
-        parallel=False,
     )
 
     if backup_database:
         plan.add_step(
-            BaseStep(
+            PreUpgradeStep(
                 description="Backup mysql databases",
+                prompt=True,
                 parallel=False,
                 coro=backup(analysis_result.model),
             )
@@ -110,7 +110,7 @@ async def create_upgrade_group(
     target: OpenStackRelease,
     description: str,
     filter_function: Callable[[OpenStackApplication], bool],
-) -> BaseStep:
+) -> UpgradePlan:
     """Create upgrade group.
 
     :param apps: Result of the analysis.
@@ -123,9 +123,9 @@ async def create_upgrade_group(
     :type filter_function: Callable[[OpenStackApplication], bool]
     :raises Exception: When cannot generate upgrade plan.
     :return: Upgrade group.
-    :rtype: BaseStep
+    :rtype: UpgradePlan
     """
-    group_upgrade_plan = BaseStep(description=description, parallel=False)
+    group_upgrade_plan = UpgradePlan(description=description)
     for app in filter(filter_function, apps):
         try:
             app_upgrade_plan = app.generate_upgrade_plan(target)

--- a/tests/unit/apps/test_auxiliary.py
+++ b/tests/unit/apps/test_auxiliary.py
@@ -23,10 +23,10 @@ from cou.apps.auxiliary import (
 from cou.apps.base import ApplicationUnit
 from cou.exceptions import ApplicationError, HaltUpgradePlanGeneration
 from cou.steps import (
-    ApplicationUpgradeStep,
-    PostUpgradeSubStep,
-    PreUpgradeSubStep,
-    UpgradeSubStep,
+    ApplicationUpgradePlan,
+    PostUpgradeStep,
+    PreUpgradeStep,
+    UpgradeStep,
 )
 from cou.utils import app_utils
 from cou.utils.openstack import OpenStackRelease
@@ -101,29 +101,28 @@ def test_auxiliary_upgrade_plan_ussuri_to_victoria_change_channel(status, config
 
     upgrade_plan = app.generate_upgrade_plan(target)
 
-    expected_plan = ApplicationUpgradeStep(
-        description=f"Upgrade plan for '{app.name}' to {target}",
-        parallel=False,
+    expected_plan = ApplicationUpgradePlan(
+        description=f"Upgrade plan for '{app.name}' to {target}"
     )
     upgrade_steps = [
-        PreUpgradeSubStep(
+        PreUpgradeStep(
             description=(
                 f"Upgrade software packages of '{app.name}' from the current APT repositories"
             ),
             parallel=False,
             coro=app_utils.upgrade_packages(app.status.units.keys(), model, None),
         ),
-        PreUpgradeSubStep(
+        PreUpgradeStep(
             description=f"Refresh '{app.name}' to the latest revision of '3.8/stable'",
             parallel=False,
             coro=model.upgrade_charm(app.name, "3.8/stable", switch=None),
         ),
-        UpgradeSubStep(
+        UpgradeStep(
             description=f"Upgrade '{app.name}' to the new channel: '3.9/stable'",
             parallel=False,
             coro=model.upgrade_charm(app.name, "3.9/stable"),
         ),
-        UpgradeSubStep(
+        UpgradeStep(
             description=(
                 f"Change charm config of '{app.name}' "
                 f"'{app.origin_setting}' to 'cloud:focal-victoria'"
@@ -134,12 +133,12 @@ def test_auxiliary_upgrade_plan_ussuri_to_victoria_change_channel(status, config
                 {f"{app.origin_setting}": "cloud:focal-victoria"},
             ),
         ),
-        PostUpgradeSubStep(
+        PostUpgradeStep(
             description=f"Wait 300 s for model {model.name} to reach the idle state.",
             parallel=False,
             coro=model.wait_for_idle(300, None),
         ),
-        PostUpgradeSubStep(
+        PostUpgradeStep(
             description=f"Check if the workload of '{app.name}' has been upgraded",
             parallel=False,
             coro=app._check_upgrade(target),
@@ -165,24 +164,23 @@ def test_auxiliary_upgrade_plan_ussuri_to_victoria(status, config, model):
 
     upgrade_plan = app.generate_upgrade_plan(target)
 
-    expected_plan = ApplicationUpgradeStep(
-        description=f"Upgrade plan for '{app.name}' to {target}",
-        parallel=False,
+    expected_plan = ApplicationUpgradePlan(
+        description=f"Upgrade plan for '{app.name}' to {target}"
     )
     upgrade_steps = [
-        PreUpgradeSubStep(
+        PreUpgradeStep(
             description=(
                 f"Upgrade software packages of '{app.name}' from the current APT repositories"
             ),
             parallel=False,
             coro=app_utils.upgrade_packages(app.status.units.keys(), model, None),
         ),
-        PreUpgradeSubStep(
+        PreUpgradeStep(
             description=f"Refresh '{app.name}' to the latest revision of '3.9/stable'",
             parallel=False,
             coro=model.upgrade_charm(app.name, "3.9/stable", switch=None),
         ),
-        UpgradeSubStep(
+        UpgradeStep(
             description=(
                 f"Change charm config of '{app.name}' "
                 f"'{app.origin_setting}' to 'cloud:focal-victoria'"
@@ -193,12 +191,12 @@ def test_auxiliary_upgrade_plan_ussuri_to_victoria(status, config, model):
                 {f"{app.origin_setting}": "cloud:focal-victoria"},
             ),
         ),
-        PostUpgradeSubStep(
+        PostUpgradeStep(
             description=f"Wait 300 s for model {model.name} to reach the idle state.",
             parallel=False,
             coro=model.wait_for_idle(300, None),
         ),
-        PostUpgradeSubStep(
+        PostUpgradeStep(
             description=f"Check if the workload of '{app.name}' has been upgraded",
             parallel=False,
             coro=app._check_upgrade(target),
@@ -222,29 +220,28 @@ def test_auxiliary_upgrade_plan_ussuri_to_victoria_ch_migration(status, config, 
         "rabbitmq-server",
     )
     upgrade_plan = app.generate_upgrade_plan(target)
-    expected_plan = ApplicationUpgradeStep(
+    expected_plan = ApplicationUpgradePlan(
         description=f"Upgrade plan for '{app.name}' to {target}",
-        parallel=False,
     )
     upgrade_steps = [
-        PreUpgradeSubStep(
+        PreUpgradeStep(
             description=(
                 f"Upgrade software packages of '{app.name}' from the current APT repositories"
             ),
             parallel=False,
             coro=app_utils.upgrade_packages(app.status.units.keys(), model, None),
         ),
-        PreUpgradeSubStep(
+        PreUpgradeStep(
             description=f"Migration of '{app.name}' from charmstore to charmhub",
             parallel=False,
             coro=model.upgrade_charm(app.name, "3.9/stable", switch="ch:rabbitmq-server"),
         ),
-        UpgradeSubStep(
+        UpgradeStep(
             description=f"Upgrade '{app.name}' to the new channel: '3.9/stable'",
             parallel=False,
             coro=model.upgrade_charm(app.name, "3.9/stable"),
         ),
-        UpgradeSubStep(
+        UpgradeStep(
             description=(
                 f"Change charm config of '{app.name}' "
                 f"'{app.origin_setting}' to 'cloud:focal-victoria'"
@@ -255,12 +252,12 @@ def test_auxiliary_upgrade_plan_ussuri_to_victoria_ch_migration(status, config, 
                 {f"{app.origin_setting}": "cloud:focal-victoria"},
             ),
         ),
-        PostUpgradeSubStep(
+        PostUpgradeStep(
             description=f"Wait 300 s for model {model.name} to reach the idle state.",
             parallel=False,
             coro=model.wait_for_idle(300, None),
         ),
-        PostUpgradeSubStep(
+        PostUpgradeStep(
             description=f"Check if the workload of '{app.name}' has been upgraded",
             parallel=False,
             coro=app._check_upgrade(target),
@@ -399,33 +396,33 @@ def test_ceph_mon_upgrade_plan_xena_to_yoga(
 
     upgrade_plan = app.generate_upgrade_plan(target)
 
-    expected_plan = ApplicationUpgradeStep(
-        description=f"Upgrade plan for '{app.name}' to {target}", parallel=False
+    expected_plan = ApplicationUpgradePlan(
+        description=f"Upgrade plan for '{app.name}' to {target}"
     )
     upgrade_steps = [
-        PreUpgradeSubStep(
+        PreUpgradeStep(
             description=(
                 f"Upgrade software packages of '{app.name}' from the current APT repositories"
             ),
             parallel=False,
             coro=app_utils.upgrade_packages(app.status.units.keys(), model, None),
         ),
-        PreUpgradeSubStep(
+        PreUpgradeStep(
             description=f"Refresh '{app.name}' to the latest revision of 'pacific/stable'",
             parallel=False,
             coro=model.upgrade_charm(app.name, "pacific/stable", switch=None),
         ),
-        PreUpgradeSubStep(
+        PreUpgradeStep(
             description="Ensure require-osd-release option matches with ceph-osd version",
             parallel=False,
             coro=app_utils.set_require_osd_release_option("ceph-mon/0", model),
         ),
-        UpgradeSubStep(
+        UpgradeStep(
             description=f"Upgrade '{app.name}' to the new channel: 'quincy/stable'",
             parallel=False,
             coro=model.upgrade_charm(app.name, "quincy/stable"),
         ),
-        UpgradeSubStep(
+        UpgradeStep(
             description=(
                 f"Change charm config of '{app.name}' "
                 f"'{app.origin_setting}' to 'cloud:focal-yoga'"
@@ -435,12 +432,12 @@ def test_ceph_mon_upgrade_plan_xena_to_yoga(
                 app.name, {f"{app.origin_setting}": "cloud:focal-yoga"}
             ),
         ),
-        PostUpgradeSubStep(
+        PostUpgradeStep(
             description=f"Wait 300 s for model {model.name} to reach the idle state.",
             parallel=False,
             coro=model.wait_for_idle(300, None),
         ),
-        PostUpgradeSubStep(
+        PostUpgradeStep(
             description=f"Check if the workload of '{app.name}' has been upgraded",
             parallel=False,
             coro=app._check_upgrade(target),
@@ -467,28 +464,28 @@ def test_ceph_mon_upgrade_plan_ussuri_to_victoria(
     )
     upgrade_plan = app.generate_upgrade_plan(target)
 
-    expected_plan = ApplicationUpgradeStep(
-        description=f"Upgrade plan for '{app.name}' to {target}", parallel=False
+    expected_plan = ApplicationUpgradePlan(
+        description=f"Upgrade plan for '{app.name}' to {target}"
     )
     upgrade_steps = [
-        PreUpgradeSubStep(
+        PreUpgradeStep(
             description=(
                 f"Upgrade software packages of '{app.name}' from the current APT repositories"
             ),
             parallel=False,
             coro=app_utils.upgrade_packages(app.status.units.keys(), model, None),
         ),
-        PreUpgradeSubStep(
+        PreUpgradeStep(
             description=f"Refresh '{app.name}' to the latest revision of 'octopus/stable'",
             parallel=False,
             coro=model.upgrade_charm(app.name, "octopus/stable", switch=None),
         ),
-        PreUpgradeSubStep(
+        PreUpgradeStep(
             description="Ensure require-osd-release option matches with ceph-osd version",
             parallel=False,
             coro=app_utils.set_require_osd_release_option("ceph-mon/0", model),
         ),
-        UpgradeSubStep(
+        UpgradeStep(
             description=(
                 f"Change charm config of '{app.name}' "
                 f"'{app.origin_setting}' to 'cloud:focal-victoria'"
@@ -498,12 +495,12 @@ def test_ceph_mon_upgrade_plan_ussuri_to_victoria(
                 app.name, {f"{app.origin_setting}": "cloud:focal-victoria"}
             ),
         ),
-        PostUpgradeSubStep(
+        PostUpgradeStep(
             description=f"Wait 300 s for model {model.name} to reach the idle state.",
             parallel=False,
             coro=model.wait_for_idle(300, None),
         ),
-        PostUpgradeSubStep(
+        PostUpgradeStep(
             description=f"Check if the workload of '{app.name}' has been upgraded",
             parallel=False,
             coro=app._check_upgrade(target),
@@ -578,24 +575,24 @@ def test_ovn_principal_upgrade_plan(status, config, model):
 
     upgrade_plan = app.generate_upgrade_plan(target)
 
-    expected_plan = ApplicationUpgradeStep(
-        description=f"Upgrade plan for '{app.name}' to {target}", parallel=False
+    expected_plan = ApplicationUpgradePlan(
+        description=f"Upgrade plan for '{app.name}' to {target}"
     )
 
     upgrade_steps = [
-        PreUpgradeSubStep(
+        PreUpgradeStep(
             description=(
                 f"Upgrade software packages of '{app.name}' from the current APT repositories"
             ),
             parallel=False,
             coro=app_utils.upgrade_packages(app.status.units.keys(), model, None),
         ),
-        PreUpgradeSubStep(
+        PreUpgradeStep(
             description=f"Refresh '{app.name}' to the latest revision of '22.03/stable'",
             parallel=False,
             coro=model.upgrade_charm(app.name, "22.03/stable", switch=None),
         ),
-        UpgradeSubStep(
+        UpgradeStep(
             description=(
                 f"Change charm config of '{app.name}' "
                 f"'{app.origin_setting}' to 'cloud:focal-victoria'"
@@ -605,12 +602,12 @@ def test_ovn_principal_upgrade_plan(status, config, model):
                 app.name, {f"{app.origin_setting}": "cloud:focal-victoria"}
             ),
         ),
-        PostUpgradeSubStep(
+        PostUpgradeStep(
             description=f"Wait 120 s for app {app.name} to reach the idle state.",
             parallel=False,
             coro=model.wait_for_idle(120, [app.name]),
         ),
-        PostUpgradeSubStep(
+        PostUpgradeStep(
             description=f"Check if the workload of '{app.name}' has been upgraded",
             parallel=False,
             coro=app._check_upgrade(target),
@@ -632,12 +629,11 @@ def test_mysql_innodb_cluster_upgrade(status, config, model):
         "mysql-innodb-cluster",
     )
     upgrade_plan = app.generate_upgrade_plan(target)
-    expected_plan = ApplicationUpgradeStep(
-        description=f"Upgrade plan for '{app.name}' to {target}",
-        parallel=False,
+    expected_plan = ApplicationUpgradePlan(
+        description=f"Upgrade plan for '{app.name}' to {target}"
     )
     upgrade_steps = [
-        PreUpgradeSubStep(
+        PreUpgradeStep(
             description=(
                 f"Upgrade software packages of '{app.name}' from the current APT repositories"
             ),
@@ -646,12 +642,12 @@ def test_mysql_innodb_cluster_upgrade(status, config, model):
                 app.status.units.keys(), model, ["mysql-server-core-8.0"]
             ),
         ),
-        PreUpgradeSubStep(
+        PreUpgradeStep(
             description=f"Refresh '{app.name}' to the latest revision of '8.0/stable'",
             parallel=False,
             coro=model.upgrade_charm(app.name, "8.0/stable", switch=None),
         ),
-        UpgradeSubStep(
+        UpgradeStep(
             description=(
                 f"Change charm config of '{app.name}' "
                 f"'{app.origin_setting}' to 'cloud:focal-victoria'"
@@ -661,12 +657,12 @@ def test_mysql_innodb_cluster_upgrade(status, config, model):
                 app.name, {f"{app.origin_setting}": "cloud:focal-victoria"}
             ),
         ),
-        PostUpgradeSubStep(
+        PostUpgradeStep(
             description=f"Wait 120 s for app {app.name} to reach the idle state.",
             parallel=False,
             coro=model.wait_for_idle(120, [app.name]),
         ),
-        PostUpgradeSubStep(
+        PostUpgradeStep(
             description=f"Check if the workload of '{app.name}' has been upgraded",
             parallel=False,
             coro=app._check_upgrade(target),

--- a/tests/unit/apps/test_auxiliary_subordinate.py
+++ b/tests/unit/apps/test_auxiliary_subordinate.py
@@ -20,7 +20,7 @@ from cou.apps.auxiliary_subordinate import (
     OvnSubordinateApplication,
 )
 from cou.exceptions import ApplicationError
-from cou.steps import UpgradeStep
+from cou.steps import ApplicationUpgradeStep, PreUpgradeSubStep, UpgradeSubStep
 from cou.utils.openstack import OpenStackRelease
 from tests.unit.apps.utils import add_steps
 
@@ -41,12 +41,12 @@ def test_auxiliary_subordinate_upgrade_plan_to_victoria(apps, model):
     app = apps["keystone_mysql_router"]
 
     upgrade_plan = app.generate_upgrade_plan(target)
-    expected_plan = UpgradeStep(
+    expected_plan = ApplicationUpgradeStep(
         description=f"Upgrade plan for '{app.name}' to {target}",
         parallel=False,
     )
     expected_plan.add_step(
-        UpgradeStep(
+        PreUpgradeSubStep(
             description=f"Refresh '{app.name}' to the latest revision of '8.0/stable'",
             parallel=False,
             coro=model.upgrade_charm(app.name, "8.0/stable", switch=None),
@@ -106,12 +106,12 @@ def test_ovn_subordinate_upgrade_plan(status, model):
 
     upgrade_plan = app.generate_upgrade_plan(target)
 
-    expected_plan = UpgradeStep(
+    expected_plan = ApplicationUpgradeStep(
         description=f"Upgrade plan for '{app.name}' to {target}", parallel=False
     )
 
     upgrade_steps = [
-        UpgradeStep(
+        PreUpgradeSubStep(
             description=f"Refresh '{app.name}' to the latest revision of '22.03/stable'",
             parallel=False,
             coro=model.upgrade_charm(app.name, "22.03/stable", switch=None),
@@ -136,7 +136,7 @@ def test_ovn_subordinate_upgrade_plan_cant_upgrade_charm(status, model):
         "ovn-chassis",
     )
 
-    expected_plan = UpgradeStep(
+    expected_plan = ApplicationUpgradeStep(
         description=f"Upgrade plan for '{app.name}' to {target}", parallel=False
     )
 
@@ -158,12 +158,12 @@ def test_ceph_dashboard_upgrade_plan_ussuri_to_victoria(status, config, model):
 
     upgrade_plan = app.generate_upgrade_plan(target)
 
-    expected_plan = UpgradeStep(
+    expected_plan = ApplicationUpgradeStep(
         description=f"Upgrade plan for '{app.name}' to {target}", parallel=False
     )
 
     upgrade_steps = [
-        UpgradeStep(
+        PreUpgradeSubStep(
             description=f"Refresh '{app.name}' to the latest revision of 'octopus/stable'",
             parallel=False,
             coro=model.upgrade_charm(app.name, "octopus/stable", switch=None),
@@ -187,17 +187,17 @@ def test_ceph_dashboard_upgrade_plan_xena_to_yoga(status, config, model):
 
     upgrade_plan = app.generate_upgrade_plan(target)
 
-    expected_plan = UpgradeStep(
+    expected_plan = ApplicationUpgradeStep(
         description=f"Upgrade plan for '{app.name}' to {target}", parallel=False
     )
 
     upgrade_steps = [
-        UpgradeStep(
+        PreUpgradeSubStep(
             description=f"Refresh '{app.name}' to the latest revision of 'pacific/stable'",
             parallel=False,
             coro=model.upgrade_charm(app.name, "pacific/stable", switch=None),
         ),
-        UpgradeStep(
+        UpgradeSubStep(
             description=f"Upgrade '{app.name}' to the new channel: 'quincy/stable'",
             parallel=False,
             coro=model.upgrade_charm(app.name, "quincy/stable"),

--- a/tests/unit/apps/test_auxiliary_subordinate.py
+++ b/tests/unit/apps/test_auxiliary_subordinate.py
@@ -20,7 +20,7 @@ from cou.apps.auxiliary_subordinate import (
     OvnSubordinateApplication,
 )
 from cou.exceptions import ApplicationError
-from cou.steps import ApplicationUpgradeStep, PreUpgradeSubStep, UpgradeSubStep
+from cou.steps import ApplicationUpgradePlan, PreUpgradeStep, UpgradeStep
 from cou.utils.openstack import OpenStackRelease
 from tests.unit.apps.utils import add_steps
 
@@ -41,12 +41,11 @@ def test_auxiliary_subordinate_upgrade_plan_to_victoria(apps, model):
     app = apps["keystone_mysql_router"]
 
     upgrade_plan = app.generate_upgrade_plan(target)
-    expected_plan = ApplicationUpgradeStep(
+    expected_plan = ApplicationUpgradePlan(
         description=f"Upgrade plan for '{app.name}' to {target}",
-        parallel=False,
     )
     expected_plan.add_step(
-        PreUpgradeSubStep(
+        PreUpgradeStep(
             description=f"Refresh '{app.name}' to the latest revision of '8.0/stable'",
             parallel=False,
             coro=model.upgrade_charm(app.name, "8.0/stable", switch=None),
@@ -106,12 +105,12 @@ def test_ovn_subordinate_upgrade_plan(status, model):
 
     upgrade_plan = app.generate_upgrade_plan(target)
 
-    expected_plan = ApplicationUpgradeStep(
-        description=f"Upgrade plan for '{app.name}' to {target}", parallel=False
+    expected_plan = ApplicationUpgradePlan(
+        description=f"Upgrade plan for '{app.name}' to {target}"
     )
 
     upgrade_steps = [
-        PreUpgradeSubStep(
+        PreUpgradeStep(
             description=f"Refresh '{app.name}' to the latest revision of '22.03/stable'",
             parallel=False,
             coro=model.upgrade_charm(app.name, "22.03/stable", switch=None),
@@ -136,8 +135,8 @@ def test_ovn_subordinate_upgrade_plan_cant_upgrade_charm(status, model):
         "ovn-chassis",
     )
 
-    expected_plan = ApplicationUpgradeStep(
-        description=f"Upgrade plan for '{app.name}' to {target}", parallel=False
+    expected_plan = ApplicationUpgradePlan(
+        description=f"Upgrade plan for '{app.name}' to {target}"
     )
 
     upgrade_plan = app.generate_upgrade_plan(target)
@@ -158,12 +157,12 @@ def test_ceph_dashboard_upgrade_plan_ussuri_to_victoria(status, config, model):
 
     upgrade_plan = app.generate_upgrade_plan(target)
 
-    expected_plan = ApplicationUpgradeStep(
-        description=f"Upgrade plan for '{app.name}' to {target}", parallel=False
+    expected_plan = ApplicationUpgradePlan(
+        description=f"Upgrade plan for '{app.name}' to {target}"
     )
 
     upgrade_steps = [
-        PreUpgradeSubStep(
+        PreUpgradeStep(
             description=f"Refresh '{app.name}' to the latest revision of 'octopus/stable'",
             parallel=False,
             coro=model.upgrade_charm(app.name, "octopus/stable", switch=None),
@@ -187,17 +186,17 @@ def test_ceph_dashboard_upgrade_plan_xena_to_yoga(status, config, model):
 
     upgrade_plan = app.generate_upgrade_plan(target)
 
-    expected_plan = ApplicationUpgradeStep(
-        description=f"Upgrade plan for '{app.name}' to {target}", parallel=False
+    expected_plan = ApplicationUpgradePlan(
+        description=f"Upgrade plan for '{app.name}' to {target}"
     )
 
     upgrade_steps = [
-        PreUpgradeSubStep(
+        PreUpgradeStep(
             description=f"Refresh '{app.name}' to the latest revision of 'pacific/stable'",
             parallel=False,
             coro=model.upgrade_charm(app.name, "pacific/stable", switch=None),
         ),
-        UpgradeSubStep(
+        UpgradeStep(
             description=f"Upgrade '{app.name}' to the new channel: 'quincy/stable'",
             parallel=False,
             coro=model.upgrade_charm(app.name, "quincy/stable"),

--- a/tests/unit/apps/test_channel_based.py
+++ b/tests/unit/apps/test_channel_based.py
@@ -12,10 +12,10 @@
 
 from cou.apps.channel_based import OpenStackChannelBasedApplication
 from cou.steps import (
-    ApplicationUpgradeStep,
-    PostUpgradeSubStep,
-    PreUpgradeSubStep,
-    UpgradeSubStep,
+    ApplicationUpgradePlan,
+    PostUpgradeStep,
+    PreUpgradeStep,
+    UpgradeStep,
 )
 from cou.utils import app_utils
 from cou.utils.openstack import OpenStackRelease
@@ -91,30 +91,29 @@ def test_application_versionless_upgrade_plan_ussuri_to_victoria(status, config,
 
     upgrade_plan = app.generate_upgrade_plan(target)
 
-    expected_plan = ApplicationUpgradeStep(
-        description=f"Upgrade plan for '{app.name}' to {target}",
-        parallel=False,
+    expected_plan = ApplicationUpgradePlan(
+        description=f"Upgrade plan for '{app.name}' to {target}"
     )
 
     upgrade_steps = [
-        PreUpgradeSubStep(
+        PreUpgradeStep(
             description=(
                 f"Upgrade software packages of '{app.name}' from the current APT repositories"
             ),
             parallel=False,
             coro=app_utils.upgrade_packages(app.status.units.keys(), model, None),
         ),
-        PreUpgradeSubStep(
+        PreUpgradeStep(
             description=f"Refresh '{app.name}' to the latest revision of 'ussuri/stable'",
             parallel=False,
             coro=model.upgrade_charm(app.name, "ussuri/stable", switch=None),
         ),
-        UpgradeSubStep(
+        UpgradeStep(
             description=f"Upgrade '{app.name}' to the new channel: 'victoria/stable'",
             parallel=False,
             coro=model.upgrade_charm(app.name, "victoria/stable"),
         ),
-        UpgradeSubStep(
+        UpgradeStep(
             description=(
                 f"Change charm config of '{app.name}' "
                 f"'{app.origin_setting}' to 'cloud:focal-victoria'"
@@ -147,30 +146,29 @@ def test_application_gnocchi_upgrade_plan_ussuri_to_victoria(status, config, mod
 
     upgrade_plan = app.generate_upgrade_plan(target)
 
-    expected_plan = ApplicationUpgradeStep(
-        description=f"Upgrade plan for '{app.name}' to {target}",
-        parallel=False,
+    expected_plan = ApplicationUpgradePlan(
+        description=f"Upgrade plan for '{app.name}' to {target}"
     )
 
     upgrade_steps = [
-        PreUpgradeSubStep(
+        PreUpgradeStep(
             description=(
                 f"Upgrade software packages of '{app.name}' from the current APT repositories"
             ),
             parallel=False,
             coro=app_utils.upgrade_packages(app.status.units.keys(), model, None),
         ),
-        PreUpgradeSubStep(
+        PreUpgradeStep(
             description=f"Refresh '{app.name}' to the latest revision of 'ussuri/stable'",
             parallel=False,
             coro=model.upgrade_charm(app.name, "ussuri/stable", switch=None),
         ),
-        UpgradeSubStep(
+        UpgradeStep(
             description=f"Upgrade '{app.name}' to the new channel: 'victoria/stable'",
             parallel=False,
             coro=model.upgrade_charm(app.name, "victoria/stable"),
         ),
-        UpgradeSubStep(
+        UpgradeStep(
             description=(
                 f"Change charm config of '{app.name}' "
                 f"'{app.origin_setting}' to 'cloud:focal-victoria'"
@@ -181,12 +179,12 @@ def test_application_gnocchi_upgrade_plan_ussuri_to_victoria(status, config, mod
                 {f"{app.origin_setting}": "cloud:focal-victoria"},
             ),
         ),
-        PostUpgradeSubStep(
+        PostUpgradeStep(
             description=f"Wait 120 s for app {app.name} to reach the idle state.",
             parallel=False,
             coro=model.wait_for_idle(120, [app.name]),
         ),
-        PostUpgradeSubStep(
+        PostUpgradeStep(
             description=f"Check if the workload of '{app.name}' has been upgraded",
             parallel=False,
             coro=app._check_upgrade(target),
@@ -212,30 +210,29 @@ def test_application_designate_bind_upgrade_plan_ussuri_to_victoria(status, conf
 
     upgrade_plan = app.generate_upgrade_plan(target)
 
-    expected_plan = ApplicationUpgradeStep(
-        description=f"Upgrade plan for '{app.name}' to {target}",
-        parallel=False,
+    expected_plan = ApplicationUpgradePlan(
+        description=f"Upgrade plan for '{app.name}' to {target}"
     )
 
     upgrade_steps = [
-        PreUpgradeSubStep(
+        PreUpgradeStep(
             description=(
                 f"Upgrade software packages of '{app.name}' from the current APT repositories"
             ),
             parallel=False,
             coro=app_utils.upgrade_packages(app.status.units.keys(), model, None),
         ),
-        PreUpgradeSubStep(
+        PreUpgradeStep(
             description=f"Refresh '{app.name}' to the latest revision of 'ussuri/stable'",
             parallel=False,
             coro=model.upgrade_charm(app.name, "ussuri/stable", switch=None),
         ),
-        UpgradeSubStep(
+        UpgradeStep(
             description=f"Upgrade '{app.name}' to the new channel: 'victoria/stable'",
             parallel=False,
             coro=model.upgrade_charm(app.name, "victoria/stable"),
         ),
-        UpgradeSubStep(
+        UpgradeStep(
             description=(
                 f"Change charm config of '{app.name}' "
                 f"'{app.origin_setting}' to 'cloud:focal-victoria'"
@@ -246,12 +243,12 @@ def test_application_designate_bind_upgrade_plan_ussuri_to_victoria(status, conf
                 {f"{app.origin_setting}": "cloud:focal-victoria"},
             ),
         ),
-        PostUpgradeSubStep(
+        PostUpgradeStep(
             description=f"Wait 120 s for app {app.name} to reach the idle state.",
             parallel=False,
             coro=model.wait_for_idle(120, [app.name]),
         ),
-        PostUpgradeSubStep(
+        PostUpgradeStep(
             description=f"Check if the workload of '{app.name}' has been upgraded",
             parallel=False,
             coro=app._check_upgrade(target),

--- a/tests/unit/apps/test_channel_based.py
+++ b/tests/unit/apps/test_channel_based.py
@@ -11,7 +11,12 @@
 #  limitations under the License.
 
 from cou.apps.channel_based import OpenStackChannelBasedApplication
-from cou.steps import UpgradeStep
+from cou.steps import (
+    ApplicationUpgradeStep,
+    PostUpgradeSubStep,
+    PreUpgradeSubStep,
+    UpgradeSubStep,
+)
 from cou.utils import app_utils
 from cou.utils.openstack import OpenStackRelease
 from tests.unit.apps.utils import add_steps
@@ -86,30 +91,30 @@ def test_application_versionless_upgrade_plan_ussuri_to_victoria(status, config,
 
     upgrade_plan = app.generate_upgrade_plan(target)
 
-    expected_plan = UpgradeStep(
+    expected_plan = ApplicationUpgradeStep(
         description=f"Upgrade plan for '{app.name}' to {target}",
         parallel=False,
     )
 
     upgrade_steps = [
-        UpgradeStep(
+        PreUpgradeSubStep(
             description=(
                 f"Upgrade software packages of '{app.name}' from the current APT repositories"
             ),
             parallel=False,
             coro=app_utils.upgrade_packages(app.status.units.keys(), model, None),
         ),
-        UpgradeStep(
+        PreUpgradeSubStep(
             description=f"Refresh '{app.name}' to the latest revision of 'ussuri/stable'",
             parallel=False,
             coro=model.upgrade_charm(app.name, "ussuri/stable", switch=None),
         ),
-        UpgradeStep(
+        UpgradeSubStep(
             description=f"Upgrade '{app.name}' to the new channel: 'victoria/stable'",
             parallel=False,
             coro=model.upgrade_charm(app.name, "victoria/stable"),
         ),
-        UpgradeStep(
+        UpgradeSubStep(
             description=(
                 f"Change charm config of '{app.name}' "
                 f"'{app.origin_setting}' to 'cloud:focal-victoria'"
@@ -142,30 +147,30 @@ def test_application_gnocchi_upgrade_plan_ussuri_to_victoria(status, config, mod
 
     upgrade_plan = app.generate_upgrade_plan(target)
 
-    expected_plan = UpgradeStep(
+    expected_plan = ApplicationUpgradeStep(
         description=f"Upgrade plan for '{app.name}' to {target}",
         parallel=False,
     )
 
     upgrade_steps = [
-        UpgradeStep(
+        PreUpgradeSubStep(
             description=(
                 f"Upgrade software packages of '{app.name}' from the current APT repositories"
             ),
             parallel=False,
             coro=app_utils.upgrade_packages(app.status.units.keys(), model, None),
         ),
-        UpgradeStep(
+        PreUpgradeSubStep(
             description=f"Refresh '{app.name}' to the latest revision of 'ussuri/stable'",
             parallel=False,
             coro=model.upgrade_charm(app.name, "ussuri/stable", switch=None),
         ),
-        UpgradeStep(
+        UpgradeSubStep(
             description=f"Upgrade '{app.name}' to the new channel: 'victoria/stable'",
             parallel=False,
             coro=model.upgrade_charm(app.name, "victoria/stable"),
         ),
-        UpgradeStep(
+        UpgradeSubStep(
             description=(
                 f"Change charm config of '{app.name}' "
                 f"'{app.origin_setting}' to 'cloud:focal-victoria'"
@@ -176,12 +181,12 @@ def test_application_gnocchi_upgrade_plan_ussuri_to_victoria(status, config, mod
                 {f"{app.origin_setting}": "cloud:focal-victoria"},
             ),
         ),
-        UpgradeStep(
+        PostUpgradeSubStep(
             description=f"Wait 120 s for app {app.name} to reach the idle state.",
             parallel=False,
             coro=model.wait_for_idle(120, [app.name]),
         ),
-        UpgradeStep(
+        PostUpgradeSubStep(
             description=f"Check if the workload of '{app.name}' has been upgraded",
             parallel=False,
             coro=app._check_upgrade(target),
@@ -207,30 +212,30 @@ def test_application_designate_bind_upgrade_plan_ussuri_to_victoria(status, conf
 
     upgrade_plan = app.generate_upgrade_plan(target)
 
-    expected_plan = UpgradeStep(
+    expected_plan = ApplicationUpgradeStep(
         description=f"Upgrade plan for '{app.name}' to {target}",
         parallel=False,
     )
 
     upgrade_steps = [
-        UpgradeStep(
+        PreUpgradeSubStep(
             description=(
                 f"Upgrade software packages of '{app.name}' from the current APT repositories"
             ),
             parallel=False,
             coro=app_utils.upgrade_packages(app.status.units.keys(), model, None),
         ),
-        UpgradeStep(
+        PreUpgradeSubStep(
             description=f"Refresh '{app.name}' to the latest revision of 'ussuri/stable'",
             parallel=False,
             coro=model.upgrade_charm(app.name, "ussuri/stable", switch=None),
         ),
-        UpgradeStep(
+        UpgradeSubStep(
             description=f"Upgrade '{app.name}' to the new channel: 'victoria/stable'",
             parallel=False,
             coro=model.upgrade_charm(app.name, "victoria/stable"),
         ),
-        UpgradeStep(
+        UpgradeSubStep(
             description=(
                 f"Change charm config of '{app.name}' "
                 f"'{app.origin_setting}' to 'cloud:focal-victoria'"
@@ -241,12 +246,12 @@ def test_application_designate_bind_upgrade_plan_ussuri_to_victoria(status, conf
                 {f"{app.origin_setting}": "cloud:focal-victoria"},
             ),
         ),
-        UpgradeStep(
+        PostUpgradeSubStep(
             description=f"Wait 120 s for app {app.name} to reach the idle state.",
             parallel=False,
             coro=model.wait_for_idle(120, [app.name]),
         ),
-        UpgradeStep(
+        PostUpgradeSubStep(
             description=f"Check if the workload of '{app.name}' has been upgraded",
             parallel=False,
             coro=app._check_upgrade(target),

--- a/tests/unit/apps/test_core.py
+++ b/tests/unit/apps/test_core.py
@@ -22,10 +22,10 @@ from cou.exceptions import (
     MismatchedOpenStackVersions,
 )
 from cou.steps import (
-    ApplicationUpgradeStep,
-    PostUpgradeSubStep,
-    PreUpgradeSubStep,
-    UpgradeSubStep,
+    ApplicationUpgradePlan,
+    PostUpgradeStep,
+    PreUpgradeStep,
+    UpgradeStep,
 )
 from cou.utils import app_utils
 from cou.utils.openstack import OpenStackRelease
@@ -328,33 +328,33 @@ def test_upgrade_plan_ussuri_to_victoria(status, config, model):
     app_config = config["openstack_ussuri"]
     app = Keystone("my_keystone", app_status, app_config, model, "keystone")
     upgrade_plan = app.generate_upgrade_plan(target)
-    expected_plan = ApplicationUpgradeStep(
+    expected_plan = ApplicationUpgradePlan(
         description=f"Upgrade plan for '{app.name}' to {target}"
     )
     upgrade_steps = [
-        PreUpgradeSubStep(
+        PreUpgradeStep(
             description=(
                 f"Upgrade software packages of '{app.name}' from the current APT repositories"
             ),
             parallel=False,
             coro=app_utils.upgrade_packages(app.status.units.keys(), model, None),
         ),
-        PreUpgradeSubStep(
+        PreUpgradeStep(
             description=f"Refresh '{app.name}' to the latest revision of 'ussuri/stable'",
             parallel=False,
             coro=model.upgrade_charm(app.name, "ussuri/stable", switch=None),
         ),
-        UpgradeSubStep(
+        UpgradeStep(
             description=f"Change charm config of '{app.name}' 'action-managed-upgrade' to False.",
             parallel=False,
             coro=model.set_application_config(app.name, {"action-managed-upgrade": False}),
         ),
-        UpgradeSubStep(
+        UpgradeStep(
             description=f"Upgrade '{app.name}' to the new channel: 'victoria/stable'",
             parallel=False,
             coro=model.upgrade_charm(app.name, "victoria/stable"),
         ),
-        UpgradeSubStep(
+        UpgradeStep(
             description=(
                 f"Change charm config of '{app.name}' "
                 f"'{app.origin_setting}' to 'cloud:focal-victoria'"
@@ -364,12 +364,12 @@ def test_upgrade_plan_ussuri_to_victoria(status, config, model):
                 app.name, {f"{app.origin_setting}": "cloud:focal-victoria"}
             ),
         ),
-        PostUpgradeSubStep(
+        PostUpgradeStep(
             description=f"Wait 300 s for model {model.name} to reach the idle state.",
             parallel=False,
             coro=model.wait_for_idle(300, None),
         ),
-        PostUpgradeSubStep(
+        PostUpgradeStep(
             description=f"Check if the workload of '{app.name}' has been upgraded",
             parallel=False,
             coro=app._check_upgrade(target),
@@ -386,33 +386,33 @@ def test_upgrade_plan_ussuri_to_victoria_ch_migration(status, config, model):
     app_config = config["openstack_ussuri"]
     app = Keystone("my_keystone", app_status, app_config, model, "keystone")
     upgrade_plan = app.generate_upgrade_plan(target)
-    expected_plan = ApplicationUpgradeStep(
+    expected_plan = ApplicationUpgradePlan(
         description=f"Upgrade plan for '{app.name}' to {target}"
     )
     upgrade_steps = [
-        PreUpgradeSubStep(
+        PreUpgradeStep(
             description=(
                 f"Upgrade software packages of '{app.name}' from the current APT repositories"
             ),
             parallel=False,
             coro=app_utils.upgrade_packages(app.status.units.keys(), model, None),
         ),
-        PreUpgradeSubStep(
+        PreUpgradeStep(
             description=f"Migration of '{app.name}' from charmstore to charmhub",
             parallel=False,
             coro=model.upgrade_charm(app.name, "ussuri/stable", switch="ch:keystone"),
         ),
-        UpgradeSubStep(
+        UpgradeStep(
             description=f"Change charm config of '{app.name}' 'action-managed-upgrade' to False.",
             parallel=False,
             coro=model.set_application_config(app.name, {"action-managed-upgrade": False}),
         ),
-        UpgradeSubStep(
+        UpgradeStep(
             description=f"Upgrade '{app.name}' to the new channel: 'victoria/stable'",
             parallel=False,
             coro=model.upgrade_charm(app.name, "victoria/stable"),
         ),
-        UpgradeSubStep(
+        UpgradeStep(
             description=(
                 f"Change charm config of '{app.name}' "
                 f"'{app.origin_setting}' to 'cloud:focal-victoria'"
@@ -422,12 +422,12 @@ def test_upgrade_plan_ussuri_to_victoria_ch_migration(status, config, model):
                 app.name, {f"{app.origin_setting}": "cloud:focal-victoria"}
             ),
         ),
-        PostUpgradeSubStep(
+        PostUpgradeStep(
             description=f"Wait 300 s for model {model.name} to reach the idle state.",
             parallel=False,
             coro=model.wait_for_idle(300, None),
         ),
-        PostUpgradeSubStep(
+        PostUpgradeStep(
             description=f"Check if the workload of '{app.name}' has been upgraded",
             parallel=False,
             coro=app._check_upgrade(target),
@@ -447,24 +447,24 @@ def test_upgrade_plan_channel_on_next_os_release(status, config, model):
     app = Keystone("my_keystone", app_status, app_config, model, "keystone")
     upgrade_plan = app.generate_upgrade_plan(target)
 
-    expected_plan = ApplicationUpgradeStep(
-        description=f"Upgrade plan for '{app.name}' to {target}",
+    expected_plan = ApplicationUpgradePlan(
+        description=f"Upgrade plan for '{app.name}' to {target}"
     )
     # no sub-step for refresh current channel or next channel
     upgrade_steps = [
-        PreUpgradeSubStep(
+        PreUpgradeStep(
             description=(
                 f"Upgrade software packages of '{app.name}' from the current APT repositories"
             ),
             parallel=False,
             coro=app_utils.upgrade_packages(app.status.units.keys(), model, None),
         ),
-        UpgradeSubStep(
+        UpgradeStep(
             description=f"Change charm config of '{app.name}' 'action-managed-upgrade' to False.",
             parallel=False,
             coro=model.set_application_config(app.name, {"action-managed-upgrade": False}),
         ),
-        UpgradeSubStep(
+        UpgradeStep(
             description=(
                 f"Change charm config of '{app.name}' "
                 f"'{app.origin_setting}' to 'cloud:focal-victoria'"
@@ -474,12 +474,12 @@ def test_upgrade_plan_channel_on_next_os_release(status, config, model):
                 app.name, {f"{app.origin_setting}": "cloud:focal-victoria"}
             ),
         ),
-        PostUpgradeSubStep(
+        PostUpgradeStep(
             description=f"Wait 300 s for model {model.name} to reach the idle state.",
             parallel=False,
             coro=model.wait_for_idle(300, None),
         ),
-        PostUpgradeSubStep(
+        PostUpgradeStep(
             description=f"Check if the workload of '{app.name}' has been upgraded",
             parallel=False,
             coro=app._check_upgrade(target),
@@ -498,39 +498,38 @@ def test_upgrade_plan_origin_already_on_next_openstack_release(status, config, m
     app_config["openstack-origin"]["value"] = "cloud:focal-victoria"
     app = Keystone("my_keystone", app_status, app_config, model, "keystone")
     upgrade_plan = app.generate_upgrade_plan(target)
-    expected_plan = ApplicationUpgradeStep(
-        description=f"Upgrade plan for '{app.name}' to {target}",
-        parallel=False,
+    expected_plan = ApplicationUpgradePlan(
+        description=f"Upgrade plan for '{app.name}' to {target}"
     )
     upgrade_steps = [
-        PreUpgradeSubStep(
+        PreUpgradeStep(
             description=(
                 f"Upgrade software packages of '{app.name}' from the current APT repositories"
             ),
             parallel=False,
             coro=app_utils.upgrade_packages(app.status.units.keys(), model, None),
         ),
-        PreUpgradeSubStep(
+        PreUpgradeStep(
             description=f"Refresh '{app.name}' to the latest revision of 'ussuri/stable'",
             parallel=False,
             coro=model.upgrade_charm(app.name, "ussuri/stable", switch=None),
         ),
-        UpgradeSubStep(
+        UpgradeStep(
             description=f"Change charm config of '{app.name}' 'action-managed-upgrade' to False.",
             parallel=False,
             coro=model.set_application_config(app.name, {"action-managed-upgrade": False}),
         ),
-        UpgradeSubStep(
+        UpgradeStep(
             description=f"Upgrade '{app.name}' to the new channel: 'victoria/stable'",
             parallel=False,
             coro=model.upgrade_charm(app.name, "victoria/stable"),
         ),
-        PostUpgradeSubStep(
+        PostUpgradeStep(
             description=f"Wait 300 s for model {model.name} to reach the idle state.",
             parallel=False,
             coro=model.wait_for_idle(300, None),
         ),
-        PostUpgradeSubStep(
+        PostUpgradeStep(
             description=f"Check if the workload of '{app.name}' has been upgraded",
             parallel=False,
             coro=app._check_upgrade(target),
@@ -568,29 +567,28 @@ def test_upgrade_plan_application_already_disable_action_managed(status, config,
         "keystone",
     )
     upgrade_plan = app.generate_upgrade_plan(target)
-    expected_plan = ApplicationUpgradeStep(
-        description=f"Upgrade plan for '{app.name}' to {target}",
-        parallel=False,
+    expected_plan = ApplicationUpgradePlan(
+        description=f"Upgrade plan for '{app.name}' to {target}"
     )
     upgrade_steps = [
-        PreUpgradeSubStep(
+        PreUpgradeStep(
             description=(
                 f"Upgrade software packages of '{app.name}' from the current APT repositories"
             ),
             parallel=False,
             coro=app_utils.upgrade_packages(app.status.units.keys(), model, None),
         ),
-        PreUpgradeSubStep(
+        PreUpgradeStep(
             description=f"Refresh '{app.name}' to the latest revision of 'ussuri/stable'",
             parallel=False,
             coro=model.upgrade_charm(app.name, "ussuri/stable", switch=None),
         ),
-        UpgradeSubStep(
+        UpgradeStep(
             description=f"Upgrade '{app.name}' to the new channel: 'victoria/stable'",
             parallel=False,
             coro=model.upgrade_charm(app.name, "victoria/stable"),
         ),
-        UpgradeSubStep(
+        UpgradeStep(
             description=(
                 f"Change charm config of '{app.name}' "
                 f"'{app.origin_setting}' to 'cloud:focal-victoria'"
@@ -600,12 +598,12 @@ def test_upgrade_plan_application_already_disable_action_managed(status, config,
                 app.name, {f"{app.origin_setting}": "cloud:focal-victoria"}
             ),
         ),
-        PostUpgradeSubStep(
+        PostUpgradeStep(
             description=f"Wait 300 s for model {model.name} to reach the idle state.",
             parallel=False,
             coro=model.wait_for_idle(300, None),
         ),
-        PostUpgradeSubStep(
+        PostUpgradeStep(
             description=f"Check if the workload of '{app.name}' has been upgraded",
             parallel=False,
             coro=app._check_upgrade(target),

--- a/tests/unit/apps/test_subordinate.py
+++ b/tests/unit/apps/test_subordinate.py
@@ -18,7 +18,7 @@ import pytest
 
 from cou.apps.subordinate import OpenStackSubordinateApplication
 from cou.exceptions import ApplicationError
-from cou.steps import ApplicationUpgradeStep, PreUpgradeSubStep, UpgradeSubStep
+from cou.steps import ApplicationUpgradePlan, PreUpgradeStep, UpgradeStep
 from cou.utils.openstack import OpenStackRelease
 from tests.unit.apps.utils import add_steps
 
@@ -52,17 +52,16 @@ def test_generate_upgrade_plan(status, model):
     )
     upgrade_plan = app.generate_upgrade_plan(target)
 
-    expected_plan = ApplicationUpgradeStep(
-        description=f"Upgrade plan for '{app.name}' to {target}",
-        parallel=False,
+    expected_plan = ApplicationUpgradePlan(
+        description=f"Upgrade plan for '{app.name}' to {target}"
     )
     upgrade_steps = [
-        PreUpgradeSubStep(
+        PreUpgradeStep(
             description=f"Refresh '{app.name}' to the latest revision of 'ussuri/stable'",
             parallel=False,
             coro=model.upgrade_charm(app.name, "ussuri/stable", switch=None),
         ),
-        UpgradeSubStep(
+        UpgradeStep(
             description=f"Upgrade '{app.name}' to the new channel: 'victoria/stable'",
             parallel=False,
             coro=model.upgrade_charm(app.name, "victoria/stable"),
@@ -128,17 +127,16 @@ def test_generate_plan_ch_migration(status, model, channel):
     app.channel = channel
     upgrade_plan = app.generate_upgrade_plan(target)
 
-    expected_plan = ApplicationUpgradeStep(
-        description=f"Upgrade plan for '{app.name}' to {target}",
-        parallel=False,
+    expected_plan = ApplicationUpgradePlan(
+        description=f"Upgrade plan for '{app.name}' to {target}"
     )
     upgrade_steps = [
-        PreUpgradeSubStep(
+        PreUpgradeStep(
             description=f"Migration of '{app.name}' from charmstore to charmhub",
             parallel=False,
             coro=model.upgrade_charm(app.name, "ussuri/stable", switch="ch:keystone-ldap"),
         ),
-        UpgradeSubStep(
+        UpgradeStep(
             description=f"Upgrade '{app.name}' to the new channel: 'wallaby/stable'",
             parallel=False,
             coro=model.upgrade_charm(app.name, "wallaby/stable"),
@@ -167,17 +165,14 @@ def test_generate_plan_from_to(status, model, from_os, to_os):
     app.channel = f"{from_os}/stable"
     upgrade_plan = app.generate_upgrade_plan(OpenStackRelease(to_os))
 
-    expected_plan = ApplicationUpgradeStep(
-        description=f"Upgrade plan for '{app.name}' to {to_os}",
-        parallel=False,
-    )
+    expected_plan = ApplicationUpgradePlan(description=f"Upgrade plan for '{app.name}' to {to_os}")
     upgrade_steps = [
-        PreUpgradeSubStep(
+        PreUpgradeStep(
             description=f"Refresh '{app.name}' to the latest revision of '{from_os}/stable'",
             parallel=False,
             coro=model.upgrade_charm(app.name, f"{from_os}/stable", switch=None),
         ),
-        UpgradeSubStep(
+        UpgradeStep(
             description=f"Upgrade '{app.name}' to the new channel: '{to_os}/stable'",
             parallel=False,
             coro=model.upgrade_charm(app.name, f"{to_os}/stable"),
@@ -206,12 +201,11 @@ def test_generate_plan_in_same_version(status, model, from_to):
 
     app.channel = f"{from_to}/stable"
     upgrade_plan = app.generate_upgrade_plan(OpenStackRelease(from_to))
-    expected_plan = ApplicationUpgradeStep(
-        description=f"Upgrade plan for '{app.name}' to {from_to}",
-        parallel=False,
+    expected_plan = ApplicationUpgradePlan(
+        description=f"Upgrade plan for '{app.name}' to {from_to}"
     )
     upgrade_steps = [
-        PreUpgradeSubStep(
+        PreUpgradeStep(
             description=f"Refresh '{app.name}' to the latest revision of '{from_to}/stable'",
             parallel=False,
             coro=model.upgrade_charm(app.name, f"{from_to}/stable", switch=None),

--- a/tests/unit/apps/test_subordinate.py
+++ b/tests/unit/apps/test_subordinate.py
@@ -18,7 +18,7 @@ import pytest
 
 from cou.apps.subordinate import OpenStackSubordinateApplication
 from cou.exceptions import ApplicationError
-from cou.steps import UpgradeStep
+from cou.steps import ApplicationUpgradeStep, PreUpgradeSubStep, UpgradeSubStep
 from cou.utils.openstack import OpenStackRelease
 from tests.unit.apps.utils import add_steps
 
@@ -52,17 +52,17 @@ def test_generate_upgrade_plan(status, model):
     )
     upgrade_plan = app.generate_upgrade_plan(target)
 
-    expected_plan = UpgradeStep(
+    expected_plan = ApplicationUpgradeStep(
         description=f"Upgrade plan for '{app.name}' to {target}",
         parallel=False,
     )
     upgrade_steps = [
-        UpgradeStep(
+        PreUpgradeSubStep(
             description=f"Refresh '{app.name}' to the latest revision of 'ussuri/stable'",
             parallel=False,
             coro=model.upgrade_charm(app.name, "ussuri/stable", switch=None),
         ),
-        UpgradeStep(
+        UpgradeSubStep(
             description=f"Upgrade '{app.name}' to the new channel: 'victoria/stable'",
             parallel=False,
             coro=model.upgrade_charm(app.name, "victoria/stable"),
@@ -128,17 +128,17 @@ def test_generate_plan_ch_migration(status, model, channel):
     app.channel = channel
     upgrade_plan = app.generate_upgrade_plan(target)
 
-    expected_plan = UpgradeStep(
+    expected_plan = ApplicationUpgradeStep(
         description=f"Upgrade plan for '{app.name}' to {target}",
         parallel=False,
     )
     upgrade_steps = [
-        UpgradeStep(
+        PreUpgradeSubStep(
             description=f"Migration of '{app.name}' from charmstore to charmhub",
             parallel=False,
             coro=model.upgrade_charm(app.name, "ussuri/stable", switch="ch:keystone-ldap"),
         ),
-        UpgradeStep(
+        UpgradeSubStep(
             description=f"Upgrade '{app.name}' to the new channel: 'wallaby/stable'",
             parallel=False,
             coro=model.upgrade_charm(app.name, "wallaby/stable"),
@@ -167,17 +167,17 @@ def test_generate_plan_from_to(status, model, from_os, to_os):
     app.channel = f"{from_os}/stable"
     upgrade_plan = app.generate_upgrade_plan(OpenStackRelease(to_os))
 
-    expected_plan = UpgradeStep(
+    expected_plan = ApplicationUpgradeStep(
         description=f"Upgrade plan for '{app.name}' to {to_os}",
         parallel=False,
     )
     upgrade_steps = [
-        UpgradeStep(
+        PreUpgradeSubStep(
             description=f"Refresh '{app.name}' to the latest revision of '{from_os}/stable'",
             parallel=False,
             coro=model.upgrade_charm(app.name, f"{from_os}/stable", switch=None),
         ),
-        UpgradeStep(
+        UpgradeSubStep(
             description=f"Upgrade '{app.name}' to the new channel: '{to_os}/stable'",
             parallel=False,
             coro=model.upgrade_charm(app.name, f"{to_os}/stable"),
@@ -206,12 +206,12 @@ def test_generate_plan_in_same_version(status, model, from_to):
 
     app.channel = f"{from_to}/stable"
     upgrade_plan = app.generate_upgrade_plan(OpenStackRelease(from_to))
-    expected_plan = UpgradeStep(
+    expected_plan = ApplicationUpgradeStep(
         description=f"Upgrade plan for '{app.name}' to {from_to}",
         parallel=False,
     )
     upgrade_steps = [
-        UpgradeStep(
+        PreUpgradeSubStep(
             description=f"Refresh '{app.name}' to the latest revision of '{from_to}/stable'",
             parallel=False,
             coro=model.upgrade_charm(app.name, f"{from_to}/stable", switch=None),

--- a/tests/unit/apps/utils.py
+++ b/tests/unit/apps/utils.py
@@ -11,9 +11,9 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-from cou.steps import UpgradeStep
+from cou.steps import BaseStep
 
 
-def add_steps(expected_plan: UpgradeStep, upgrade_steps: list[UpgradeStep]):
+def add_steps(expected_plan: BaseStep, upgrade_steps: list[BaseStep]):
     for step in upgrade_steps:
         expected_plan.add_step(step)

--- a/tests/unit/steps/test_steps.py
+++ b/tests/unit/steps/test_steps.py
@@ -50,22 +50,22 @@ def test_compare_step_coroutines(coro1, coro2, exp_result):
 
 
 @pytest.mark.parametrize(
-    "description, parallel, prompt, expected_prompt",
+    "description, parallel",
     [
-        ("test", False, True, True),
-        ("test description", True, False, False),
-        ("test description", True, None, True),
+        ("test", False),
+        ("test description", True),
+        ("test description", True),
     ],
 )
-def test_step_init(description, parallel, prompt, expected_prompt):
+def test_step_init(description, parallel):
     """Test BaseStep initialization."""
     coro = mock_coro()
-    step = BaseStep(description, parallel, coro, prompt)
+    step = BaseStep(description, parallel, coro)
 
     assert step.description == description
     assert step.parallel == parallel
     assert step._coro == coro
-    assert step.prompt == expected_prompt
+    assert step.prompt is True
     assert step._canceled is False
     assert step._task is None
 
@@ -277,15 +277,14 @@ async def test_step_cancel_task():
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("prompt, expected_prompt", [(True, True), (False, False), (None, False)])
-async def test_upgrade_plan_step_instances(prompt, expected_prompt):
+async def test_upgrade_plan_step_instances():
     """Test setting parallel for UpgradePlan."""
     description = "test plan"
-    step = UpgradePlan(description=description, prompt=prompt)
+    step = UpgradePlan(description=description)
 
     assert step._coro is None
     assert step.parallel is False
-    assert step.prompt == expected_prompt
+    assert step.prompt is False
 
 
 @pytest.mark.asyncio

--- a/tests/unit/steps/test_steps_plan.py
+++ b/tests/unit/steps/test_steps_plan.py
@@ -144,7 +144,7 @@ async def test_generate_plan(apps, model):
 
     upgrade_plan = await generate_plan(analysis_result, backup_database=True)
 
-    expected_plan = UpgradePlan(description="Upgrade cloud from 'ussuri' to 'victoria'")
+    expected_plan = UpgradePlan("Upgrade cloud from 'ussuri' to 'victoria'")
 
     expected_plan.add_step(
         PreUpgradeStep(
@@ -154,15 +154,13 @@ async def test_generate_plan(apps, model):
         )
     )
 
-    control_plane_principals = UpgradePlan(description="Control Plane principal(s) upgrade plan")
+    control_plane_principals = UpgradePlan("Control Plane principal(s) upgrade plan")
     keystone_plan = generate_expected_upgrade_plan_principal(app_keystone, target, model)
     cinder_plan = generate_expected_upgrade_plan_principal(app_cinder, target, model)
     control_plane_principals.add_step(keystone_plan)
     control_plane_principals.add_step(cinder_plan)
 
-    control_plane_subordinates = UpgradePlan(
-        description="Control Plane subordinate(s) upgrade plan"
-    )
+    control_plane_subordinates = UpgradePlan("Control Plane subordinate(s) upgrade plan")
     keystone_ldap_plan = generate_expected_upgrade_plan_subordinate(
         app_keystone_ldap, target, model
     )

--- a/tests/unit/steps/test_steps_plan.py
+++ b/tests/unit/steps/test_steps_plan.py
@@ -150,7 +150,6 @@ async def test_generate_plan(apps, model):
         PreUpgradeStep(
             description="Backup mysql databases",
             parallel=False,
-            prompt=True,
             coro=backup(model),
         )
     )

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -25,7 +25,7 @@ from cou.exceptions import (
     TimeoutException,
     UnitNotFound,
 )
-from cou.steps import UpgradeStep
+from cou.steps import BaseStep
 from cou.steps.analyze import Analysis
 
 
@@ -89,8 +89,8 @@ async def test_analyze_and_plan(mock_analyze, mock_generate_plan, cou_model):
 @patch("cou.cli.logger")
 async def test_get_upgrade_plan(mock_logger, mock_analyze_and_plan, mock_manually_upgrade):
     """Test get_upgrade_plan function."""
-    plan = UpgradeStep(description="Top level plan", parallel=False)
-    plan.add_step(UpgradeStep(description="backup mysql databases", parallel=False))
+    plan = BaseStep(description="Upgrade cloud from 'ussuri' to 'victoria'", parallel=False)
+    plan.add_step(BaseStep(description="backup mysql databases", parallel=False))
     mock_analysis_result = MagicMock()
 
     mock_analyze_and_plan.return_value = (mock_analysis_result, plan)
@@ -124,8 +124,8 @@ async def test_run_upgrade_quiet(
     expected_print_count,
 ):
     """Test get_upgrade_plan function in either quiet or non-quiet mode."""
-    plan = UpgradeStep(description="Top level plan", parallel=False)
-    plan.add_step(UpgradeStep(description="backup mysql databases", parallel=False))
+    plan = BaseStep(description="Upgrade cloud from 'ussuri' to 'victoria'", parallel=False)
+    plan.add_step(BaseStep(description="backup mysql databases", parallel=False))
     mock_analysis_result = MagicMock()
     mock_analyze_and_plan.return_value = (mock_analysis_result, plan)
 
@@ -161,8 +161,8 @@ async def test_run_upgrade_interactive(
     progress_indication_count,
 ):
     """Test get_upgrade_plan function in either interactive or non-interactive mode."""
-    plan = UpgradeStep(description="Top level plan", parallel=False)
-    plan.add_step(UpgradeStep(description="backup mysql databases", parallel=False))
+    plan = BaseStep(description="Upgrade cloud from 'ussuri' to 'victoria'", parallel=False)
+    plan.add_step(BaseStep(description="backup mysql databases", parallel=False))
     mock_analysis_result = MagicMock()
     mock_analyze_and_plan.return_value = (mock_analysis_result, plan)
 

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -25,7 +25,7 @@ from cou.exceptions import (
     TimeoutException,
     UnitNotFound,
 )
-from cou.steps import BaseStep
+from cou.steps import PreUpgradeStep, UpgradePlan
 from cou.steps.analyze import Analysis
 
 
@@ -89,8 +89,8 @@ async def test_analyze_and_plan(mock_analyze, mock_generate_plan, cou_model):
 @patch("cou.cli.logger")
 async def test_get_upgrade_plan(mock_logger, mock_analyze_and_plan, mock_manually_upgrade):
     """Test get_upgrade_plan function."""
-    plan = BaseStep(description="Upgrade cloud from 'ussuri' to 'victoria'", parallel=False)
-    plan.add_step(BaseStep(description="backup mysql databases", parallel=False))
+    plan = UpgradePlan(description="Upgrade cloud from 'ussuri' to 'victoria'")
+    plan.add_step(PreUpgradeStep(description="backup mysql databases", parallel=False))
     mock_analysis_result = MagicMock()
 
     mock_analyze_and_plan.return_value = (mock_analysis_result, plan)
@@ -124,8 +124,8 @@ async def test_run_upgrade_quiet(
     expected_print_count,
 ):
     """Test get_upgrade_plan function in either quiet or non-quiet mode."""
-    plan = BaseStep(description="Upgrade cloud from 'ussuri' to 'victoria'", parallel=False)
-    plan.add_step(BaseStep(description="backup mysql databases", parallel=False))
+    plan = UpgradePlan(description="Upgrade cloud from 'ussuri' to 'victoria'")
+    plan.add_step(PreUpgradeStep(description="backup mysql databases", parallel=False))
     mock_analysis_result = MagicMock()
     mock_analyze_and_plan.return_value = (mock_analysis_result, plan)
 
@@ -161,8 +161,8 @@ async def test_run_upgrade_interactive(
     progress_indication_count,
 ):
     """Test get_upgrade_plan function in either interactive or non-interactive mode."""
-    plan = BaseStep(description="Upgrade cloud from 'ussuri' to 'victoria'", parallel=False)
-    plan.add_step(BaseStep(description="backup mysql databases", parallel=False))
+    plan = UpgradePlan(description="Upgrade cloud from 'ussuri' to 'victoria'")
+    plan.add_step(PreUpgradeStep(description="backup mysql databases", parallel=False))
     mock_analysis_result = MagicMock()
     mock_analyze_and_plan.return_value = (mock_analysis_result, plan)
 


### PR DESCRIPTION
- Rename UpgradeStep to BaseStep
- Add prompt and description_prefix attributes 
- Define UpgradePlan, ApplicationUpgradePlan, UpgradeStep, PreUpgradeStep, and PostUpgradeStep for different types of steps. This will also be used to improve execute stage.
- Change "Top level plan" description to the cloud upgrade 'from' and 'to' information

fixes: #153