### PR TITLE
Wait only for apps related with COU

### DIFF
--- a/cou/utils/juju_utils.py
+++ b/cou/utils/juju_utils.py
@@ -185,7 +185,7 @@ class COUModel:
 
         :param action: Action object
         :type: Action
-        :param raise_on_failure: Raise ActionFailed exception on failure, defaults to False
+        :param raise_on_failure: Whether to raise ActionFailed exception on failure, defaults to False
         :type raise_on_failure: bool
         :return: action results
         :rtype: Action

--- a/cou/utils/juju_utils.py
+++ b/cou/utils/juju_utils.py
@@ -450,7 +450,9 @@ class COUModel:
 
     @retry
     async def wait_for_idle(self, timeout: int, apps: Optional[list[str]] = None) -> None:
-        """Wait for model to reach an idle state.
+        """Wait for applications to reach an idle state.
+
+        If no applications are provided, this function will wait for all COU-related applications.
 
         :param timeout: Timeout in seconds.
         :type timeout: int
@@ -458,6 +460,10 @@ class COUModel:
         :type apps: Optional[list[str]], optional
         """
         model = await self._get_model()
+        if apps is None:
+            cou_apps = await self.list_applications()
+            apps = list(cou_apps.keys())
+
         await model.wait_for_idle(
             apps=apps, timeout=timeout, idle_period=DEFAULT_MODEL_IDLE_PERIOD
         )

--- a/cou/utils/juju_utils.py
+++ b/cou/utils/juju_utils.py
@@ -185,7 +185,8 @@ class COUModel:
 
         :param action: Action object
         :type: Action
-        :param raise_on_failure: Whether to raise ActionFailed exception on failure, defaults to False
+        :param raise_on_failure: Whether to raise ActionFailed exception on failure, defaults
+                                 to False
         :type raise_on_failure: bool
         :return: action results
         :rtype: Action

--- a/tests/unit/utils/test_juju_utils.py
+++ b/tests/unit/utils/test_juju_utils.py
@@ -305,6 +305,21 @@ async def test_coumodel_get_status(mocked_model):
 
 
 @pytest.mark.asyncio
+@patch("cou.utils.juju_utils.is_charm_supported")
+async def test_coumodel_list_applications(mock_is_charm_supported, mocked_model):
+    """Test COUModel providing list of applications."""
+    mock_is_charm_supported.side_effect = [False, True]
+    model = juju_utils.COUModel("test-model")
+    app = MagicMock(spec_set=Application).return_value
+    mocked_model.applications = {"unsupported": app, "supported": app}
+
+    apps = await model.list_applications()
+
+    mock_is_charm_supported.assert_has_calls([call(app.charm_name), call(app.charm_name)])
+    assert apps == {"supported": app}
+
+
+@pytest.mark.asyncio
 async def test_coumodel_get_action_result(mocked_model):
     """Test COUModel get action result."""
     mocked_action = AsyncMock(spec_set=Action).return_value

--- a/tests/unit/utils/test_juju_utils.py
+++ b/tests/unit/utils/test_juju_utils.py
@@ -447,13 +447,16 @@ async def test_coumodel_upgrade_charm(mocked_model):
 
 
 @pytest.mark.asyncio
-async def test_coumodel_wait_for_idle(mocked_model):
+@patch("cou.utils.juju_utils.COUModel.list_applications")
+async def test_coumodel_wait_for_idle(mock_list_applications, mocked_model):
     """Test COUModel wait for model to be idle."""
     timeout = 60
     model = juju_utils.COUModel("test-model")
+    mock_list_applications.return_value = {"app1": MagicMock(), "app2": MagicMock()}
 
     await model.wait_for_idle(timeout)
 
     mocked_model.wait_for_idle.assert_awaited_once_with(
-        apps=None, timeout=timeout, idle_period=juju_utils.DEFAULT_MODEL_IDLE_PERIOD
+        apps=["app1", "app2"], timeout=timeout, idle_period=juju_utils.DEFAULT_MODEL_IDLE_PERIOD
     )
+    mock_list_applications.assert_awaited_once_with()


### PR DESCRIPTION
Add `list_applications` function to `COUModel`, which returns all applications related with COU based on if charm is supported by COU. Use this function in `wait_for_idle` if no app was provided. Previously function was waiting for whole model if no apps was provided, but now it will wait only for apps related with COU.

fixes: #154