### PR TITLE
Add wait for related apps as pre-upgrade

### DIFF
--- a/cou/steps/plan.py
+++ b/cou/steps/plan.py
@@ -72,6 +72,13 @@ async def generate_plan(analysis_result: Analysis, backup_database: bool) -> Upg
     print(f"Upgrading cloud from '{analysis_result.current_cloud_os_release}' to '{target}'\n.")
 
     plan = UpgradeStep(description="Top level plan", parallel=False)
+    plan.add_step(
+        UpgradeStep(
+            description="verify that all OpenStack applications are in idle state",
+            parallel=False,
+            coro=analysis_result.model.wait_for_idle(timeout=5),
+        )
+    )
     if backup_database:
         plan.add_step(
             UpgradeStep(

--- a/tests/unit/steps/test_steps_plan.py
+++ b/tests/unit/steps/test_steps_plan.py
@@ -144,7 +144,13 @@ async def test_generate_plan(apps, model):
         description="Top level plan",
         parallel=False,
     )
-
+    expected_plan.add_step(
+        UpgradeStep(
+            description="verify that all OpenStack applications are in idle state",
+            parallel=False,
+            coro=analysis_result.model.wait_for_idle(timeout=5),
+        )
+    )
     expected_plan.add_step(
         UpgradeStep(
             description="backup mysql databases",


### PR DESCRIPTION
After some playing around I decide to use only `wait_for_idle` directly instead of wrapping it with some HaltError.

Example of usage:
```bash
$ juju status --model zaza-413ca955bd34                                      
Model              Controller             Cloud/Region             Version  SLA          Timestamp
zaza-413ca955bd34  rgildein2              openstack/openstack      2.9.35   unsupported  11:47:44+01:00

App                                 Version  Status       Scale  Charm                  Channel        Rev  Exposed  Message
cinder                              16.4.2   active           1  cinder                 ussuri/stable  660  no       Unit is ready
cinder-mysql-router                 8.0.35   active           1  mysql-router           8.0/stable     111  no       Unit is ready
glance                              20.2.0   active           1  glance                 ussuri/stable  589  no       Unit is ready
glance-mysql-router                 8.0.35   active           1  mysql-router           8.0/stable     111  no       Unit is ready
keystone                            17.0.1   active           1  keystone               ussuri/stable  665  no       Application Ready
keystone-mysql-router               8.0.35   active           1  mysql-router           8.0/stable     111  no       Unit is ready
mysql                               8.0.35   active           3  mysql-innodb-cluster   8.0/stable     106  no       Unit is ready: Mode: R/O, Cluster is ONLINE and can tolerate up to ONE failure.
neutron-api                         16.4.2   active           1  neutron-api            ussuri/stable  564  no       Unit is ready
neutron-api-mysql-router            8.0.35   active           1  mysql-router           8.0/stable     111  no       Unit is ready
neutron-gateway                     16.4.2   active           1  neutron-gateway        ussuri/stable  522  no       Unit is ready
neutron-openvswitch                 16.4.2   active           1  neutron-openvswitch    ussuri/stable  526  no       Unit is ready
nova-cloud-controller               21.2.4   active           1  nova-cloud-controller  ussuri/stable  698  no       Unit is ready
nova-cloud-controller-mysql-router  8.0.35   active           1  mysql-router           8.0/stable     111  no       Unit is ready
nova-compute                        21.2.4   active           1  nova-compute           ussuri/stable  710  no       Unit is ready
placement                           3.0.1    active           1  placement              ussuri/stable   99  no       Unit is ready
placement-mysql-router              8.0.35   active           1  mysql-router           8.0/stable     111  no       Unit is ready
rabbitmq-server                     3.8.2    maintenance      1  rabbitmq-server        3.8/stable     176  no       Paused. Use 'resume' action to resume normal service.

Unit                                     Workload     Agent  Machine  Public address  Ports              Message
cinder/0*                                active       idle   7        1.1.1.2         8776/tcp           Unit is ready
  cinder-mysql-router/0*                 active       idle            1.1.1.2                            Unit is ready
glance/0*                                active       idle   10       1.1.1.39        9292/tcp           Unit is ready
  glance-mysql-router/0*                 active       idle            1.1.1.38                           Unit is ready
keystone/0*                              active       idle   11       1.1.1.129       5000/tcp           Unit is ready
  keystone-mysql-router/0*               active       idle            1.1.1.129                          Unit is ready
mysql/0                                  active       idle   0        1.1.1.206                          Unit is ready: Mode: R/O, Cluster is ONLINE and can tolerate up to ONE failure.
mysql/1                                  active       idle   1        1.1.1.76                           Unit is ready: Mode: R/O, Cluster is ONLINE and can tolerate up to ONE failure.
mysql/2*                                 active       idle   2        1.1.1.187                          Unit is ready: Mode: R/W, Cluster is ONLINE and can tolerate up to ONE failure.
neutron-api/0*                           active       idle   4        1.1.1.54        9696/tcp           Unit is ready
  neutron-api-mysql-router/0*            active       idle            1.1.1.54                           Unit is ready
neutron-gateway/0*                       active       idle   3        1.1.1.38                           Unit is ready
nova-cloud-controller/0*                 active       idle   6        1.1.1.235       8774/tcp,8775/tcp  Unit is ready
  nova-cloud-controller-mysql-router/0*  active       idle            1.1.1.235                          Unit is ready
nova-compute/0*                          active       idle   5        1.1.1.114                          Unit is ready
  neutron-openvswitch/0*                 active       idle            1.1.1.114                          Unit is ready
placement/0*                             active       idle   8        1.1.1.161       8778/tcp           Unit is ready
  placement-mysql-router/0*              active       idle            1.1.1.161                          Unit is ready
rabbitmq-server/0*                       maintenance  idle   9        1.1.1.84        5672/tcp           Paused. Use 'resume' action to resume normal service.

Machine  State    Address     Inst id                               Series  AZ    Message
0        started  1.1.1.206   a03d4bf5-769e-498e-8668-9935505f8069  focal   nova  ACTIVE
1        started  1.1.1.76    151b24f2-613a-4a0a-9967-106b82b0af1c  focal   nova  ACTIVE
2        started  1.1.1.187   76d762a6-c43f-41a6-b7ff-922f4198df37  focal   nova  ACTIVE
3        started  1.1.1.38    a2b37e9c-81f5-4b6a-8b5a-5f3c813b9da0  focal   nova  ACTIVE
4        started  1.1.1.54    f33b2c3f-b118-47f2-b5a5-f889ed48933b  focal   nova  ACTIVE
5        started  1.1.1.114   f92acebe-724e-4eb0-8d48-31b1cb5b4c73  focal   nova  ACTIVE
6        started  1.1.1.235   e9f64e7f-082e-48ab-a132-f7c2226e653a  focal   nova  ACTIVE
7        started  1.1.1.2     60534ffc-6347-46df-83d4-fe4ffa00f4fa  focal   nova  ACTIVE
8        started  1.1.1.161   e00d7f29-b659-43f0-803c-37d3d66118c6  focal   nova  ACTIVE
9        started  1.1.1.84    e26f8c06-41e9-471a-a54e-8f5a97ddc91b  focal   nova  ACTIVE
10       started  1.1.1.39    c0c3b262-f0c2-42b4-95c9-58918c6d1746  focal   nova  ACTIVE
11       started  1.1.1.129   9312db60-66b7-4de8-8df3-b0f702476ae0  focal   nova  ACTIVE

$ cou run --model zaza-413ca955bd34                       
Analyzing cloud... ✔
Generating upgrade plan... \Upgrading cloud from 'ussuri' to 'victoria'
.
Generating upgrade plan... ✔
Top level plan
        verify that all OpenStack applications are in idle state
        backup mysql databases
        Control Plane principal(s) upgrade plan
                Upgrade plan for 'rabbitmq-server' to victoria
                        Upgrade software packages of 'rabbitmq-server' from the current APT repositories
                        Upgrade 'rabbitmq-server' to the new channel: '3.9/stable'
                        Change charm config of 'rabbitmq-server' 'source' to 'cloud:focal-victoria'
                        Wait 1800s for model zaza-413ca955bd34 to reach the idle state.
                        Check if the workload of 'rabbitmq-server' has been upgraded
                Upgrade plan for 'keystone' to victoria
                        Upgrade software packages of 'keystone' from the current APT repositories
                        Upgrade 'keystone' to the new channel: 'victoria/stable'
                        Change charm config of 'keystone' 'openstack-origin' to 'cloud:focal-victoria'
                        Wait 1800s for model zaza-413ca955bd34 to reach the idle state.
                        Check if the workload of 'keystone' has been upgraded
                Upgrade plan for 'cinder' to victoria
                        Upgrade software packages of 'cinder' from the current APT repositories
                        Upgrade 'cinder' to the new channel: 'victoria/stable'
                        Change charm config of 'cinder' 'openstack-origin' to 'cloud:focal-victoria'
                        Wait 300s for app cinder to reach the idle state.
                        Check if the workload of 'cinder' has been upgraded
                Upgrade plan for 'glance' to victoria
                        Upgrade software packages of 'glance' from the current APT repositories
                        Upgrade 'glance' to the new channel: 'victoria/stable'
                        Change charm config of 'glance' 'openstack-origin' to 'cloud:focal-victoria'
                        Wait 300s for app glance to reach the idle state.
                        Check if the workload of 'glance' has been upgraded
                Upgrade plan for 'neutron-api' to victoria
                        Upgrade software packages of 'neutron-api' from the current APT repositories
                        Upgrade 'neutron-api' to the new channel: 'victoria/stable'
                        Change charm config of 'neutron-api' 'openstack-origin' to 'cloud:focal-victoria'
                        Wait 300s for app neutron-api to reach the idle state.
                        Check if the workload of 'neutron-api' has been upgraded
                Upgrade plan for 'neutron-gateway' to victoria
                        Upgrade software packages of 'neutron-gateway' from the current APT repositories
                        Upgrade 'neutron-gateway' to the new channel: 'victoria/stable'
                        Change charm config of 'neutron-gateway' 'openstack-origin' to 'cloud:focal-victoria'
                        Wait 300s for app neutron-gateway to reach the idle state.
                        Check if the workload of 'neutron-gateway' has been upgraded
                Upgrade plan for 'placement' to victoria
                        Upgrade software packages of 'placement' from the current APT repositories
                        Upgrade 'placement' to the new channel: 'victoria/stable'
                        Change charm config of 'placement' 'openstack-origin' to 'cloud:focal-victoria'
                        Wait 300s for app placement to reach the idle state.
                        Check if the workload of 'placement' has been upgraded
                Upgrade plan for 'nova-cloud-controller' to victoria
                        Upgrade software packages of 'nova-cloud-controller' from the current APT repositories
                        Upgrade 'nova-cloud-controller' to the new channel: 'victoria/stable'
                        Change charm config of 'nova-cloud-controller' 'openstack-origin' to 'cloud:focal-victoria'
                        Wait 300s for app nova-cloud-controller to reach the idle state.
                        Check if the workload of 'nova-cloud-controller' has been upgraded
                Upgrade plan for 'mysql' to victoria
                        Upgrade software packages of 'mysql' from the current APT repositories
                        Change charm config of 'mysql' 'source' to 'cloud:focal-victoria'
                        Wait 1800s for app mysql to reach the idle state.
                        Check if the workload of 'mysql' has been upgraded
        Control Plane subordinate(s) upgrade plan
                Upgrade plan for 'neutron-openvswitch' to victoria
                        Upgrade 'neutron-openvswitch' to the new channel: 'victoria/stable'

Top level plan (c)ontinue/(a)bort/(s)kip:c
verify that all OpenStack applications are in idle state (c)ontinue/(a)bort/(s)kip:c
Generating upgrade plan... ✖
The connection was lost. Check your connection or increase the timeout.
```

This output will be improved by #146 .

fixes: #78