### PR TITLE
Change from rabbitmq to designate-bind for smoke test.

### DIFF
--- a/tests/functional/tests/bundles/smoke.yaml
+++ b/tests/functional/tests/bundles/smoke.yaml
@@ -1,12 +1,7 @@
-variables:
-  openstack-origin: &openstack-origin distro
-
 series: focal
 
 applications:
-  rabbitmq-server:
-    charm: ch:rabbitmq-server
+  designate-bind:
+    charm: ch:designate-bind
     num_units: 1
-    channel: 3.8/stable
-    options:
-      source: *openstack-origin
+    channel: ussuri/stable

--- a/tests/functional/tests/model.py
+++ b/tests/functional/tests/model.py
@@ -27,6 +27,7 @@ class COUModelTest(unittest.TestCase):
 
     def test_connection(self):
         """Test model connection."""
+        zaza.sync_wrapper(self.model.connect)()
         self.assertTrue(self.model.connected)
 
     def test_get_charm_name(self):

--- a/tests/functional/tests/model.py
+++ b/tests/functional/tests/model.py
@@ -29,6 +29,8 @@ class COUModelTest(unittest.TestCase):
         """Test model connection."""
         zaza.sync_wrapper(self.model.connect)()
         self.assertTrue(self.model.connected)
+        zaza.sync_wrapper(self.model._model.disconnect)()
+        self.assertFalse(self.model.connected)
 
     def test_get_charm_name(self):
         """Test get charm name."""


### PR DESCRIPTION
- designate-bind uses less resources and reaches idle state without the need of relating with another charms.
- this application when alone in a model will generate upgrade plans. rabbitmq had the same workload version from ussuri to yoga and when alone, the next upgrade was pointing to jammy-yoga.
- added model connection status check test