### PR TITLE
fix wait for idle on slow network

### DIFF
--- a/cou/steps/plan.py
+++ b/cou/steps/plan.py
@@ -77,7 +77,9 @@ async def generate_plan(analysis_result: Analysis, backup_database: bool) -> Upg
         PreUpgradeStep(
             description="Verify that all OpenStack applications are in idle state",
             parallel=False,
-            coro=analysis_result.model.wait_for_idle(timeout=11, idle_period=10),
+            coro=analysis_result.model.wait_for_idle(
+                timeout=11, idle_period=10, raise_on_blocked=True
+            ),
         )
     )
     if backup_database:

--- a/cou/steps/plan.py
+++ b/cou/steps/plan.py
@@ -46,6 +46,7 @@ from cou.exceptions import (
 from cou.steps import PreUpgradeStep, UpgradePlan
 from cou.steps.analyze import Analysis
 from cou.steps.backup import backup
+from cou.utils.juju_utils import DEFAULT_TIMEOUT
 from cou.utils.openstack import LTS_TO_OS_RELEASE, OpenStackRelease
 
 logger = logging.getLogger(__name__)
@@ -78,7 +79,11 @@ async def generate_plan(analysis_result: Analysis, backup_database: bool) -> Upg
             description="Verify that all OpenStack applications are in idle state",
             parallel=False,
             coro=analysis_result.model.wait_for_idle(
-                timeout=11, idle_period=10, raise_on_blocked=True
+                # NOTE (rgildein): We need to DEFAULT_TIMEOUT so it's possible to change if
+                #                  a network is too slow, this could cause an issue.
+                timeout=DEFAULT_TIMEOUT + 1,
+                idle_period=10,
+                raise_on_blocked=True,
             ),
         )
     )

--- a/cou/utils/juju_utils.py
+++ b/cou/utils/juju_utils.py
@@ -24,7 +24,7 @@ from juju.application import Application
 from juju.client._definitions import FullStatus
 from juju.client.connector import NoConnectionException
 from juju.client.jujudata import FileJujuData
-from juju.errors import JujuError
+from juju.errors import JujuAppError, JujuError, JujuUnitError
 from juju.model import Model
 from juju.unit import Unit
 from macaroonbakery.httpbakery import BakeryException
@@ -450,6 +450,7 @@ class COUModel:
         timeout: int,
         idle_period: int = DEFAULT_MODEL_IDLE_PERIOD,
         apps: Optional[list[str]] = None,
+        raise_on_blocked: bool = False,
     ) -> None:
         """Wait for applications to reach an idle state.
 
@@ -464,6 +465,9 @@ class COUModel:
         :type idle_period: int
         :param apps: Applications to wait, defaults to None
         :type apps: Optional[list[str]], optional
+        :param raise_on_blocked: If any unit or app going into "blocked" status immediately raises
+                                 WaitForApplicationsTimeout.
+        :type raise_on_blocked: bool
         """
 
         @retry(timeout=timeout, no_retry_exceptions=(WaitForApplicationsTimeout,))
@@ -472,13 +476,21 @@ class COUModel:
             # NOTE(rgildein): Defining wrapper so we can use retry with proper timeout
             model = await self._get_model()
             try:
-                await model.wait_for_idle(apps=apps, timeout=timeout, idle_period=idle_period)
-            except asyncio.exceptions.TimeoutError as error:
+                await model.wait_for_idle(
+                    apps=apps,
+                    timeout=timeout,
+                    idle_period=idle_period,
+                    raise_on_blocked=raise_on_blocked,
+                )
+            except (asyncio.exceptions.TimeoutError, JujuAppError, JujuUnitError) as error:
                 # NOTE(rgildein): Catching TimeoutError raised as exception when wait_for_idle
                 # reached timeout. Also adding two spaces to make it more user friendly.
                 # example:
                 # Timed out waiting for model:
-                #   nova-compute/0 [executing] maintenance: Installing packages
+                #   rabbitmq-server/0 [idle] active: Unit is ready
+                #   neutron-api/0 [idle] active: Unit is ready
+                #   glance/0 [idle] active: Unit is ready
+                #   cinder/0 [idle] active: Unit is ready
                 msg = str(error).replace("\n", "\n  ", 1)
                 raise WaitForApplicationsTimeout(msg) from error
 

--- a/cou/utils/juju_utils.py
+++ b/cou/utils/juju_utils.py
@@ -479,7 +479,7 @@ class COUModel:
                 # example:
                 # Timed out waiting for model:
                 #   nova-compute/0 [executing] maintenance: Installing packages
-                msg = str(error).replace("\n", "\n  ")
+                msg = str(error).replace("\n", "\n  ", 1)
                 raise WaitForApplicationsTimeout(msg) from error
 
         if apps is None:

--- a/tests/unit/steps/test_steps_plan.py
+++ b/tests/unit/steps/test_steps_plan.py
@@ -149,7 +149,9 @@ async def test_generate_plan(apps, model):
         PreUpgradeStep(
             description="Verify that all OpenStack applications are in idle state",
             parallel=False,
-            coro=analysis_result.model.wait_for_idle(timeout=11, idle_period=10),
+            coro=analysis_result.model.wait_for_idle(
+                timeout=11, idle_period=10, raise_on_blocked=True
+            ),
         )
     )
     expected_plan.add_step(

--- a/tests/unit/utils/test_juju_utils.py
+++ b/tests/unit/utils/test_juju_utils.py
@@ -482,7 +482,10 @@ async def test_coumodel_wait_for_idle(mock_get_supported_apps, mocked_model):
     await model.wait_for_idle(timeout)
 
     mocked_model.wait_for_idle.assert_awaited_once_with(
-        apps=["app1", "app2"], timeout=timeout, idle_period=juju_utils.DEFAULT_MODEL_IDLE_PERIOD
+        apps=["app1", "app2"],
+        timeout=timeout,
+        idle_period=juju_utils.DEFAULT_MODEL_IDLE_PERIOD,
+        raise_on_blocked=False,
     )
     mock_get_supported_apps.assert_awaited_once_with()
 
@@ -497,7 +500,10 @@ async def test_coumodel_wait_for_idle_apps(mock_get_supported_apps, mocked_model
     await model.wait_for_idle(timeout, apps=["app1"])
 
     mocked_model.wait_for_idle.assert_awaited_once_with(
-        apps=["app1"], timeout=timeout, idle_period=juju_utils.DEFAULT_MODEL_IDLE_PERIOD
+        apps=["app1"],
+        timeout=timeout,
+        idle_period=juju_utils.DEFAULT_MODEL_IDLE_PERIOD,
+        raise_on_blocked=False,
     )
     mock_get_supported_apps.assert_not_awaited()
 
@@ -515,6 +521,9 @@ async def test_coumodel_wait_for_idle_timeout(mock_get_supported_apps, mocked_mo
         await model.wait_for_idle(timeout, apps=exp_apps)
 
     mocked_model.wait_for_idle.assert_awaited_once_with(
-        apps=exp_apps, timeout=timeout, idle_period=juju_utils.DEFAULT_MODEL_IDLE_PERIOD
+        apps=exp_apps,
+        timeout=timeout,
+        idle_period=juju_utils.DEFAULT_MODEL_IDLE_PERIOD,
+        raise_on_blocked=False,
     )
     mock_get_supported_apps.assert_not_awaited()


### PR DESCRIPTION
During my manual testing, I found out two issues:

1. Using 11s for timeout in pre-upgrade step verifying that model is in idle state cause an issue on slow network. It raised an exception, saying that apps are not in idle. This was caused by slower network connection, since I was running it locally and the model was on an external OpenStack cloud. After changing timeout to 60 it works fine.  I also tested that running cou on the external cloud directly do no cause any issue.  Maybe we can set value to 60 (instead of using `DEFAULT_TIMEOUT`), but that can cause unwanted long waiting if any app is not in idle.

```bash
$ cou plan
...
Verify that all OpenStack applications are in idle state ✖
2023-12-01 17:44:45 [ERROR] Timed out waiting for model:
  rabbitmq-server/0 [idle] active: Unit is ready
  neutron-api/0 [idle] active: Unit is ready
  glance/0 [idle] active: Unit is ready
  cinder/0 [idle] active: Unit is ready
  ...  # all apps are in idle
# after change
$ COU_TIMEOUT=60 cou plan
...
Running cloud upgrade...
Verify that all OpenStack applications are in idle state ✔
Backup mysql databases ✔
...
```

2. error message from `wiat_for_idle` is not correct. Example before fix
```bash
2023-12-01 17:09:14 [ERROR] Timed out waiting for model:
  rabbitmq-server/0 [idle] active: Unit is ready
    neutron-api/0 [idle] active: Unit is ready
    glance/0 [idle] active: Unit is ready
    cinder/0 [idle] active: Unit is ready
    ...
#  example after fix
2023-12-01 17:09:14 [ERROR] Timed out waiting for model:
  rabbitmq-server/0 [idle] active: Unit is ready
  neutron-api/0 [idle] active: Unit is ready
  glance/0 [idle] active: Unit is ready
  cinder/0 [idle] active: Unit is ready
```