### PR TITLE
Freeze protobuf

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -32,6 +32,9 @@ install_requires =
     packaging
     aioconsole
     halo
+    # Keep protobuf < 4.0 until macaroonbakery solves its incompatibility
+    # https://github.com/go-macaroon-bakery/py-macaroon-bakery/issues/94
+    protobuf<4.0
 
 [options.extras_require]
 lint =


### PR DESCRIPTION
macaroonbakery has a broken protobuf dependency. Pin the dependency until the fix on go-macaroon-bakery/py-macaroon-bakery#94