### PR TITLE
Improve CLI's UX

### DIFF
--- a/cou/cli.py
+++ b/cou/cli.py
@@ -99,7 +99,7 @@ async def continue_upgrade() -> bool:
 
     match input_value:
         case "y" | "yes":
-            logger.info("Start the upgrade.")
+            logger.info("Starting the upgrade.")
             return True
         case "n" | "no":
             logger.info("Exiting COU without running upgrades.")
@@ -151,7 +151,7 @@ async def get_upgrade_plan(model_name: Optional[str], backup_database: bool) -> 
     print_and_debug(upgrade_plan)
     manually_upgrade_data_plane(analysis_result)
     print(
-        "Please note that the actually upgrade steps could be different if the cloud state "
+        "Please note that the actual upgrade steps could be different if the cloud state "
         "changes because the plan will be re-calculated at upgrade time."
     )
 

--- a/cou/cli.py
+++ b/cou/cli.py
@@ -109,7 +109,7 @@ async def analyze_and_plan(
     :type model_name: Optional[str]
     :param backup_database: Whether to create database backup before upgrade.
     :type backup_database: bool
-    :return: Generated analyses and upgrade plan.
+    :return: Generated analysis and upgrade plan.
     :rtype: tuple[Analysis, UpgradePlan]
     """
     model = COUModel(model_name)
@@ -151,7 +151,7 @@ async def get_upgrade_plan(model_name: Optional[str], backup_database: bool) -> 
 async def run_upgrade(
     model_name: Optional[str],
     backup_database: bool,
-    interactive: bool,
+    prompt: bool,
     quiet: bool,
 ) -> None:
     """Run cloud upgrade.
@@ -160,8 +160,8 @@ async def run_upgrade(
     :type model_name: Optional[str]
     :param backup_database: Whether to create database backup before upgrade.
     :type backup_database: bool
-    :param interactive: Whether to run upgrade interactively.
-    :type interactive: bool
+    :param prompt: Whether to prompt to run upgrade interactively.
+    :type prompt: bool
     :param quiet: Whether to run upgrade in quiet mode.
     :type quiet: bool
     """
@@ -169,7 +169,7 @@ async def run_upgrade(
     logger.debug(upgrade_plan)
     print(upgrade_plan)
 
-    if interactive:
+    if prompt:
         prompt_input = (
             await ainput(prompt_message("Would you like to start the upgrade?"))
         ).casefold()
@@ -194,7 +194,7 @@ async def run_upgrade(
     if not quiet:
         print("Running cloud upgrade...")
 
-    await apply_step(upgrade_plan, interactive)
+    await apply_step(upgrade_plan, prompt)
     manually_upgrade_data_plane(analysis_result)
     print("Upgrade completed.")
 
@@ -208,8 +208,9 @@ async def _run_command(args: argparse.Namespace) -> None:
     match args.command:
         case "plan":
             await get_upgrade_plan(args.model_name, args.backup)
-        case "run":
-            await run_upgrade(args.model_name, args.backup, args.interactive, args.quiet)
+        case "upgrade":
+            prompt = not args.auto_approve
+            await run_upgrade(args.model_name, args.backup, prompt, args.quiet)
 
 
 def entrypoint() -> None:

--- a/cou/steps/execute.py
+++ b/cou/steps/execute.py
@@ -18,17 +18,17 @@ import logging
 import sys
 
 from aioconsole import ainput
-from colorama import Style
 
 from cou.steps import ApplicationUpgradePlan, BaseStep, UpgradeStep
 from cou.utils import progress_indicator
+from cou.utils.text_styler import bold, normal
 
 AVAILABLE_OPTIONS = ["y", "n"]
 
 logger = logging.getLogger(__name__)
 
 
-def prompt(parameter: str) -> str:
+def prompt_message(parameter: str) -> str:
     """Generate eye-catching prompt.
 
     :param parameter: String to show at the prompt with the user options.
@@ -36,27 +36,6 @@ def prompt(parameter: str) -> str:
     :return: Prompt string with the user options.
     :rtype: str
     """
-
-    def bold(text: str) -> str:
-        """Transform the text in bold format.
-
-        :param text: text to format.
-        :type text: str
-        :return: text formatted.
-        :rtype: str
-        """
-        return Style.RESET_ALL + Style.BRIGHT + text + Style.RESET_ALL
-
-    def normal(text: str) -> str:
-        """Transform the text in normal format.
-
-        :param text: text to format.
-        :type text: str
-        :return: text formatted.
-        :rtype: str
-        """
-        return Style.RESET_ALL + text + Style.RESET_ALL
-
     return (
         normal("\n" + parameter + "\nContinue (")
         + bold("y")
@@ -135,7 +114,7 @@ async def apply_step(step: BaseStep, interactive: bool, overwrite_progress: bool
         if not interactive or not step.prompt:
             result = "y"
         else:
-            result = (await ainput(prompt(description_to_prompt))).casefold()
+            result = (await ainput(prompt_message(description_to_prompt))).casefold()
 
         match result:
             case "y":

--- a/cou/steps/execute.py
+++ b/cou/steps/execute.py
@@ -45,13 +45,13 @@ def prompt_message(parameter: str) -> str:
     )
 
 
-async def _run_step(step: BaseStep, interactive: bool, overwrite_progress: bool = False) -> None:
+async def _run_step(step: BaseStep, prompt: bool, overwrite_progress: bool = False) -> None:
     """Run a step and all its sub-steps.
 
     :param step: Step to be executed.
     :type step: BaseStep
-    :param interactive: Whether to run upgrade step in interactive mode.
-    :type interactive: bool
+    :param prompt: Whether to run upgrade step with prompt (interactive mode).
+    :type prompt: bool
     :param overwrite_progress: Whether to overwrite the current step's progress indication message
     in CLI output. True to overwrite and False (the default) to persist.
     :type overwrite_progress: bool
@@ -71,7 +71,7 @@ async def _run_step(step: BaseStep, interactive: bool, overwrite_progress: bool 
     if step.parallel:
         logger.debug("running all sub-steps of %s step in parallel", step)
         grouped_coroutines = (
-            apply_step(sub_step, interactive, overwrite_substeps_progress)
+            apply_step(sub_step, prompt, overwrite_substeps_progress)
             for sub_step in step.sub_steps
         )
         await asyncio.gather(*grouped_coroutines)
@@ -79,7 +79,7 @@ async def _run_step(step: BaseStep, interactive: bool, overwrite_progress: bool 
         logger.debug("running all sub-steps of %s step sequentially", step)
         for sub_step in step.sub_steps:
             logger.debug("running sub-step %s of %s step", sub_step, step)
-            await apply_step(sub_step, interactive, overwrite_substeps_progress)
+            await apply_step(sub_step, prompt, overwrite_substeps_progress)
 
     # Upon completion of all sub-steps of ApplicationUpgradePlan, replace the current progress
     # indication message, if any, with a persistent application description message.
@@ -87,13 +87,13 @@ async def _run_step(step: BaseStep, interactive: bool, overwrite_progress: bool 
         progress_indicator.succeed(step.description)
 
 
-async def apply_step(step: BaseStep, interactive: bool, overwrite_progress: bool = False) -> None:
+async def apply_step(step: BaseStep, prompt: bool, overwrite_progress: bool = False) -> None:
     """Apply a step to execute.
 
     :param step: Step to be executed.
     :type step: BaseStep
-    :param interactive:
-    :type interactive: bool
+    :param prompt: Whether to run upgrade step with prompt (interactive mode).
+    :type prompt: bool
     :param overwrite_progress: Whether to overwrite the current step's progress indication message
     in CLI output. True to overwrite and False (the default) to persist.
     :type overwrite_progress: bool
@@ -111,7 +111,7 @@ async def apply_step(step: BaseStep, interactive: bool, overwrite_progress: bool
 
     result = ""
     while result.casefold() not in AVAILABLE_OPTIONS:
-        if not interactive or not step.prompt:
+        if not prompt or not step.prompt:
             result = "y"
         else:
             result = (await ainput(prompt_message(description_to_prompt))).casefold()
@@ -119,7 +119,7 @@ async def apply_step(step: BaseStep, interactive: bool, overwrite_progress: bool
         match result:
             case "y":
                 logger.info("Running: %s", step.description)
-                await _run_step(step, interactive, overwrite_progress)
+                await _run_step(step, prompt, overwrite_progress)
             case "n":
                 logger.info("Aborting plan")
                 sys.exit(1)

--- a/cou/utils/text_styler.py
+++ b/cou/utils/text_styler.py
@@ -1,0 +1,39 @@
+# Copyright 2023 Canonical Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Command line text styling utilities."""
+
+from colorama import Style
+
+
+def bold(text: str) -> str:
+    """Transform the text in bold format.
+
+    :param text: text to format.
+    :type text: str
+    :return: text formatted.
+    :rtype: str
+    """
+    return Style.RESET_ALL + Style.BRIGHT + text + Style.RESET_ALL
+
+
+def normal(text: str) -> str:
+    """Transform the text in normal format.
+
+    :param text: text to format.
+    :type text: str
+    :return: text formatted.
+    :rtype: str
+    """
+    return Style.RESET_ALL + text + Style.RESET_ALL

--- a/tests/functional/tests/smoke.py
+++ b/tests/functional/tests/smoke.py
@@ -154,7 +154,7 @@ class SmokeTest(unittest.TestCase):
 
     def test_help(self) -> None:
         """Test that help command is working."""
-        help_options = itertools.product(["", "plan", "run"], ["-h", "--help"])
+        help_options = itertools.product(["", "plan", "upgrade"], ["-h", "--help"])
         for cmd, help in help_options:
             help_cmd = [cmd, help] if cmd else [help]
             with self.subTest(help_cmd):
@@ -179,15 +179,15 @@ class SmokeTest(unittest.TestCase):
         expected_plan = self.generate_expected_plan(backup=False)
         self.assertIn(expected_plan, result)
 
-    def test_run(self) -> None:
-        """Test cou run."""
+    def test_upgrade(self) -> None:
+        """Test cou upgrade."""
         # designate-bind upgrades from ussuri to victoria
         expected_msgs_before_upgrade = [
             "Upgrade plan for 'designate-bind' to victoria",
             "Upgrade plan for 'mysql-innodb-cluster' to victoria",
         ]
         result_before_upgrade = self.cou(
-            ["run", "--model", self.model_name, "--no-backup", "--no-interactive"]
+            ["upgrade", "--model", self.model_name, "--no-backup", "--auto-approve"]
         ).stdout
         for expected_msg in expected_msgs_before_upgrade:
             with self.subTest(expected_msg):

--- a/tests/unit/steps/test_steps_execute.py
+++ b/tests/unit/steps/test_steps_execute.py
@@ -27,7 +27,7 @@ from cou.steps import (
     UpgradePlan,
     UpgradeStep,
 )
-from cou.steps.execute import _run_step, apply_step, prompt
+from cou.steps.execute import _run_step, apply_step, prompt_message
 
 
 @pytest.mark.asyncio
@@ -109,7 +109,7 @@ async def test_apply_step_abort(mock_run_step, mock_input, input_value):
     with pytest.raises(SystemExit):
         await apply_step(upgrade_step, True)
 
-    mock_input.assert_awaited_once_with(prompt("Test Step"))
+    mock_input.assert_awaited_once_with(prompt_message("Test Step"))
     mock_run_step.assert_not_awaited()
 
 
@@ -137,7 +137,7 @@ async def test_apply_step_continue(mock_run_step, mock_input, input_value):
 
     await apply_step(upgrade_step, True)
 
-    mock_input.assert_awaited_once_with(prompt("Test Step"))
+    mock_input.assert_awaited_once_with(prompt_message("Test Step"))
     mock_run_step.assert_awaited_once_with(upgrade_step, True, False)
 
 
@@ -152,7 +152,9 @@ async def test_apply_step_nonsense(mock_run_step, mock_input):
     with pytest.raises(SystemExit, match="1"):
         await apply_step(upgrade_step, True)
 
-    mock_input.assert_has_awaits([call(prompt("Test Step")), call(prompt("Test Step"))])
+    mock_input.assert_has_awaits(
+        [call(prompt_message("Test Step")), call(prompt_message("Test Step"))]
+    )
     mock_run_step.assert_not_awaited()
 
 
@@ -173,7 +175,7 @@ async def test_apply_application_upgrade_plan(mock_run_step, mock_input):
     mock_input.side_effect = ["y"]
     await apply_step(upgrade_plan, True)
 
-    mock_input.assert_has_awaits([call(prompt(expected_prompt))])
+    mock_input.assert_has_awaits([call(prompt_message(expected_prompt))])
 
 
 @pytest.mark.asyncio

--- a/tests/unit/steps/test_steps_execute.py
+++ b/tests/unit/steps/test_steps_execute.py
@@ -116,7 +116,7 @@ async def test_apply_step_abort(mock_run_step, mock_input, input_value):
 @pytest.mark.asyncio
 @patch("cou.steps.execute.ainput")
 @patch("cou.steps.execute._run_step")
-async def test_apply_step_non_interactive(mock_run_step, mock_input):
+async def test_apply_step_no_prompt(mock_run_step, mock_input):
     upgrade_step = AsyncMock(spec_set=UpgradeStep())
     upgrade_step.description = "Test Step"
 
@@ -181,7 +181,7 @@ async def test_apply_application_upgrade_plan(mock_run_step, mock_input):
 @pytest.mark.asyncio
 @patch("cou.steps.execute.ainput")
 @patch("cou.steps.execute._run_step")
-async def test_apply_application_upgrade_plan_non_interactive(mock_run_step, mock_input):
+async def test_apply_application_upgrade_plan_no_prompt(mock_run_step, mock_input):
     plan_description = "Test plan"
     upgrade_plan = ApplicationUpgradePlan(plan_description)
     upgrade_plan.sub_steps = [
@@ -358,7 +358,7 @@ class TestFullApplyPlan(unittest.IsolatedAsyncioTestCase):
             "sequential.4.0",
         ]
 
-        await apply_step(self.plan, interactive=False)
+        await apply_step(self.plan, prompt=False)
         results = self.execution_order[21:]
 
         self.assertListEqual(results, exp_results)
@@ -393,7 +393,7 @@ class TestFullApplyPlan(unittest.IsolatedAsyncioTestCase):
             "parallel.4.2",
         ]
 
-        await apply_step(self.plan, interactive=False)
+        await apply_step(self.plan, prompt=False)
         results = self.execution_order[:21]
 
         # checking the results without order, since they are run in parallel with

--- a/tests/unit/test_commands.py
+++ b/tests/unit/test_commands.py
@@ -28,14 +28,13 @@ from cou import commands
         ["--help"],
         ["help"],
         ["help", "plan"],
-        ["help", "run"],
-        ["help", "all"],
+        ["help", "upgrade"],
         ["plan", "-h"],
-        ["run", "-h"],
+        ["upgrade", "-h"],
         ["plan", "control-plane", "-h"],
         ["plan", "data-plane", "-h"],
-        ["run", "control-plane", "-h"],
-        ["run", "data-plane", "-h"],
+        ["upgrade", "control-plane", "-h"],
+        ["upgrade", "data-plane", "-h"],
     ],
 )
 def test_parse_args_help(args):
@@ -72,7 +71,7 @@ def test_parse_args_quiet_verbose_exclusive(args):
                 verbosity=0,
                 quiet=False,
                 backup=True,
-                **{"upgrade-group": None}
+                **{"upgrade_group": None}
             ),
         ),
         (
@@ -83,7 +82,7 @@ def test_parse_args_quiet_verbose_exclusive(args):
                 verbosity=0,
                 quiet=False,
                 backup=False,
-                **{"upgrade-group": None}
+                **{"upgrade_group": None}
             ),
         ),
         (
@@ -94,7 +93,7 @@ def test_parse_args_quiet_verbose_exclusive(args):
                 verbosity=0,
                 quiet=True,
                 backup=False,
-                **{"upgrade-group": None}
+                **{"upgrade_group": None}
             ),
         ),
         (
@@ -105,7 +104,7 @@ def test_parse_args_quiet_verbose_exclusive(args):
                 verbosity=0,
                 quiet=False,
                 backup=True,
-                **{"upgrade-group": None}
+                **{"upgrade_group": None}
             ),
         ),
         (
@@ -116,7 +115,7 @@ def test_parse_args_quiet_verbose_exclusive(args):
                 verbosity=0,
                 quiet=False,
                 backup=True,
-                **{"upgrade-group": "control-plane"}
+                **{"upgrade_group": "control-plane"}
             ),
         ),
         (
@@ -130,7 +129,7 @@ def test_parse_args_quiet_verbose_exclusive(args):
                 machines=None,
                 hostnames=None,
                 availability_zones=None,
-                **{"upgrade-group": "data-plane"}
+                **{"upgrade_group": "data-plane"}
             ),
         ),
         (
@@ -141,7 +140,7 @@ def test_parse_args_quiet_verbose_exclusive(args):
                 verbosity=1,
                 quiet=False,
                 backup=True,
-                **{"upgrade-group": "control-plane"}
+                **{"upgrade_group": "control-plane"}
             ),
         ),
         (
@@ -155,7 +154,7 @@ def test_parse_args_quiet_verbose_exclusive(args):
                 machines=["1", "2,3"],
                 hostnames=None,
                 availability_zones=None,
-                **{"upgrade-group": "data-plane"}
+                **{"upgrade_group": "data-plane"}
             ),
         ),
         (
@@ -169,7 +168,7 @@ def test_parse_args_quiet_verbose_exclusive(args):
                 machines=None,
                 hostnames=None,
                 availability_zones=["1", "2,3"],
-                **{"upgrade-group": "data-plane"}
+                **{"upgrade_group": "data-plane"}
             ),
         ),
         (
@@ -183,7 +182,7 @@ def test_parse_args_quiet_verbose_exclusive(args):
                 machines=None,
                 hostnames=["1", "2,3"],
                 availability_zones=None,
-                **{"upgrade-group": "data-plane"}
+                **{"upgrade_group": "data-plane"}
             ),
         ),
     ],
@@ -199,166 +198,155 @@ def test_parse_args_plan(args, expected_namespace):
     "args, expected_namespace",
     [
         (
-            ["run"],
+            ["upgrade"],
             Namespace(
-                command="run",
+                command="upgrade",
                 model_name=None,
-                parallel=False,
                 verbosity=0,
                 quiet=False,
-                interactive=True,
+                auto_approve=False,
                 backup=True,
-                **{"upgrade-group": None}
+                **{"upgrade_group": None}
             ),
         ),
         (
-            ["run", "--no-backup"],
+            ["upgrade", "--no-backup"],
             Namespace(
-                command="run",
+                command="upgrade",
                 model_name=None,
-                parallel=False,
                 verbosity=0,
                 quiet=False,
-                interactive=True,
+                auto_approve=False,
                 backup=False,
-                **{"upgrade-group": None}
+                **{"upgrade_group": None}
             ),
         ),
         (
-            ["run", "--no-backup", "--quiet"],
+            ["upgrade", "--no-backup", "--quiet"],
             Namespace(
-                command="run",
+                command="upgrade",
                 model_name=None,
-                parallel=False,
                 verbosity=0,
                 quiet=True,
-                interactive=True,
+                auto_approve=False,
                 backup=False,
-                **{"upgrade-group": None}
+                **{"upgrade_group": None}
             ),
         ),
         (
-            ["run", "--model=model_name"],
+            ["upgrade", "--model=model_name"],
             Namespace(
-                command="run",
+                command="upgrade",
                 model_name="model_name",
-                parallel=False,
                 verbosity=0,
                 quiet=False,
-                interactive=True,
+                auto_approve=False,
                 backup=True,
-                **{"upgrade-group": None}
+                **{"upgrade_group": None}
             ),
         ),
         (
-            ["run", "control-plane"],
+            ["upgrade", "control-plane"],
             Namespace(
-                command="run",
+                command="upgrade",
                 model_name=None,
-                parallel=False,
                 verbosity=0,
                 quiet=False,
-                interactive=True,
+                auto_approve=False,
                 backup=True,
-                **{"upgrade-group": "control-plane"}
+                **{"upgrade_group": "control-plane"}
             ),
         ),
         (
-            ["run", "data-plane"],
+            ["upgrade", "data-plane"],
             Namespace(
-                command="run",
+                command="upgrade",
                 model_name=None,
-                parallel=False,
                 verbosity=0,
                 quiet=False,
-                interactive=True,
+                auto_approve=False,
                 backup=True,
                 machines=None,
                 hostnames=None,
                 availability_zones=None,
-                **{"upgrade-group": "data-plane"}
+                **{"upgrade_group": "data-plane"}
             ),
         ),
         (
-            ["run", "control-plane", "--verbose"],
+            ["upgrade", "control-plane", "--verbose"],
             Namespace(
-                command="run",
+                command="upgrade",
                 model_name=None,
-                parallel=False,
                 verbosity=1,
                 quiet=False,
-                interactive=True,
+                auto_approve=False,
                 backup=True,
-                **{"upgrade-group": "control-plane"}
+                **{"upgrade_group": "control-plane"}
             ),
         ),
         (
-            ["run", "data-plane", "--machine=1", "-m=2,3"],
+            ["upgrade", "data-plane", "--machine=1", "-m=2,3"],
             Namespace(
-                command="run",
+                command="upgrade",
                 model_name=None,
-                parallel=False,
                 verbosity=0,
                 quiet=False,
-                interactive=True,
+                auto_approve=False,
                 backup=True,
                 machines=["1", "2,3"],
                 hostnames=None,
                 availability_zones=None,
-                **{"upgrade-group": "data-plane"}
+                **{"upgrade_group": "data-plane"}
             ),
         ),
         (
-            ["run", "data-plane", "--quiet", "--availability-zone=1", "--az=2,3"],
+            ["upgrade", "data-plane", "--quiet", "--availability-zone=1", "--az=2,3"],
             Namespace(
-                command="run",
+                command="upgrade",
                 model_name=None,
-                parallel=False,
                 verbosity=0,
                 quiet=True,
-                interactive=True,
+                auto_approve=False,
                 backup=True,
                 machines=None,
                 hostnames=None,
                 availability_zones=["1", "2,3"],
-                **{"upgrade-group": "data-plane"}
+                **{"upgrade_group": "data-plane"}
             ),
         ),
         (
-            ["run", "data-plane", "--parallel", "--hostname=1", "-n=2,3"],
+            ["upgrade", "data-plane", "--hostname=1", "-n=2,3"],
             Namespace(
-                command="run",
+                command="upgrade",
                 model_name=None,
-                parallel=True,
                 verbosity=0,
                 quiet=False,
-                interactive=True,
+                auto_approve=False,
                 backup=True,
                 machines=None,
                 hostnames=["1", "2,3"],
                 availability_zones=None,
-                **{"upgrade-group": "data-plane"}
+                **{"upgrade_group": "data-plane"}
             ),
         ),
         (
-            ["run", "data-plane", "--no-interactive", "--hostname=1", "-n=2,3"],
+            ["upgrade", "data-plane", "--auto-approve", "--hostname=1", "-n=2,3"],
             Namespace(
-                command="run",
+                command="upgrade",
                 model_name=None,
-                parallel=False,
                 verbosity=0,
                 quiet=False,
-                interactive=False,
+                auto_approve=True,
                 backup=True,
                 machines=None,
                 hostnames=["1", "2,3"],
                 availability_zones=None,
-                **{"upgrade-group": "data-plane"}
+                **{"upgrade_group": "data-plane"}
             ),
         ),
     ],
 )
-def test_parse_args_run(args, expected_namespace):
+def test_parse_args_upgrade(args, expected_namespace):
     """Test parsing 'run' subcommand and its arguments/options."""
     parsed_args = commands.parse_args(args)
 
@@ -368,12 +356,12 @@ def test_parse_args_run(args, expected_namespace):
 @pytest.mark.parametrize(
     "args",
     [
-        ["run", "data-plane", "--machine 1", "--az 2"],
-        ["run", "data-plane", "--hostname 1", "-m 2"],
-        ["run", "data-plane", "--availability-zone 1", "-n 2"],
-        ["run", "data-plane", "--machine 1", "-n 2"],
-        ["run", "data-plane", "--az 1", "-m 2"],
-        ["run", "data-plane", "-m 1", "-n 2"],
+        ["upgrade", "data-plane", "--machine 1", "--az 2"],
+        ["upgrade", "data-plane", "--hostname 1", "-m 2"],
+        ["upgrade", "data-plane", "--availability-zone 1", "-n 2"],
+        ["upgrade", "data-plane", "--machine 1", "-n 2"],
+        ["upgrade", "data-plane", "--az 1", "-m 2"],
+        ["upgrade", "data-plane", "-m 1", "-n 2"],
     ],
 )
 def test_parse_args_dataplane_exclusive_options(args):


### PR DESCRIPTION
- Rename `run` to `upgrade`
- Replace `--no-interactive` with `--auto-approve` and remove `--interactive` (since it is already the default)
- Remove `all` option for `cou help`
- Change "upgrade-group" to "upgrade_group" so in future we can refer it by `args.upgrade_group`
- Remove unnecessary default value for boolean arguments
- Drop `--parallel` option because we will always run steps in parallel
where possible

Merge only after #196 

relates-to: #173 
relates-to: #200 