### PR TITLE
Update bash auto-completion

### DIFF
--- a/completions/bash/cou_bash_completion
+++ b/completions/bash/cou_bash_completion
@@ -5,13 +5,13 @@ _subcommand_args() {
             opts="--help --quiet --verbose --model --backup --no-backup"
             child_commands=""
             ;;
-        run)
-            opts="--help --quiet --verbose --parallel --model --interactive --no-interactive --backup --no-backup"
+        upgrade)
+            opts="--help --quiet --verbose --model ---auto-approve --backup --no-backup"
             child_commands=""
             ;;
         help)
             opts=""
-            child_commands="plan run"
+            child_commands="plan upgrade"
             ;;
         *)
             opts=""
@@ -28,7 +28,7 @@ _cou_bash_completion() {
     top_opts="--help --version"
 
     # Define the available subcommands
-    subcommands="plan run help"
+    subcommands="plan upgrade help"
 
     # Define completion for top-level options and subcommands
     if [ $COMP_CWORD -eq 1 ]; then


### PR DESCRIPTION
- Rename `run` to `upgrade`
- Replace `--no-interactive` with `--auto-approve` and remove  `--interactive`
- Drop `--parallel` option because we will always run steps in parallel
where possible

Merge only after #196 and #197

closes: #173 
closes: #200 