### PR TITLE
Check if applications status are active on wait_for_idle.

### DIFF
--- a/cou/apps/base.py
+++ b/cou/apps/base.py
@@ -697,5 +697,5 @@ class OpenStackApplication:
         return PostUpgradeStep(
             description=description,
             parallel=False,
-            coro=self.model.wait_for_idle(self.wait_timeout, apps=apps),
+            coro=self.model.wait_for_active_and_idle(self.wait_timeout, apps=apps),
         )

--- a/cou/apps/base.py
+++ b/cou/apps/base.py
@@ -697,5 +697,5 @@ class OpenStackApplication:
         return PostUpgradeStep(
             description=description,
             parallel=False,
-            coro=self.model.wait_for_active_and_idle(self.wait_timeout, apps=apps),
+            coro=self.model.wait_for_active_idle(self.wait_timeout, apps=apps),
         )

--- a/cou/steps/plan.py
+++ b/cou/steps/plan.py
@@ -78,7 +78,7 @@ async def generate_plan(analysis_result: Analysis, backup_database: bool) -> Upg
         PreUpgradeStep(
             description="Verify that all OpenStack applications are in idle state",
             parallel=False,
-            coro=analysis_result.model.wait_for_active_and_idle(
+            coro=analysis_result.model.wait_for_active_idle(
                 # NOTE (rgildein): We need to DEFAULT_TIMEOUT so it's possible to change if
                 # a network is too slow, this could cause an issue.
                 # We are using max function to ensure timeout is always at least 11 (1 second

--- a/cou/steps/plan.py
+++ b/cou/steps/plan.py
@@ -78,7 +78,7 @@ async def generate_plan(analysis_result: Analysis, backup_database: bool) -> Upg
         PreUpgradeStep(
             description="Verify that all OpenStack applications are in idle state",
             parallel=False,
-            coro=analysis_result.model.wait_for_idle(
+            coro=analysis_result.model.wait_for_active_and_idle(
                 # NOTE (rgildein): We need to DEFAULT_TIMEOUT so it's possible to change if
                 # a network is too slow, this could cause an issue.
                 # We are using max function to ensure timeout is always at least 11 (1 second

--- a/cou/utils/juju_utils.py
+++ b/cou/utils/juju_utils.py
@@ -445,14 +445,14 @@ class COUModel:
             switch=switch,
         )
 
-    async def wait_for_active_and_idle(
+    async def wait_for_active_idle(
         self,
         timeout: int,
         idle_period: int = DEFAULT_MODEL_IDLE_PERIOD,
         apps: Optional[list[str]] = None,
         raise_on_blocked: bool = False,
     ) -> None:
-        """Wait for application(s) to reach active and idle state.
+        """Wait for application(s) to reach active idle state.
 
         If no applications are provided, this function will wait for all COU-related applications.
 
@@ -471,8 +471,8 @@ class COUModel:
         """
 
         @retry(timeout=timeout, no_retry_exceptions=(WaitForApplicationsTimeout,))
-        @wraps(self.wait_for_active_and_idle)
-        async def _wait_for_active_and_idle() -> None:
+        @wraps(self.wait_for_active_idle)
+        async def _wait_for_active_idle() -> None:
             # NOTE(rgildein): Defining wrapper so we can use retry with proper timeout
             model = await self._get_model()
             try:
@@ -498,4 +498,4 @@ class COUModel:
         if apps is None:
             apps = await self._get_supported_apps()
 
-        await _wait_for_active_and_idle()
+        await _wait_for_active_idle()

--- a/cou/utils/juju_utils.py
+++ b/cou/utils/juju_utils.py
@@ -445,14 +445,14 @@ class COUModel:
             switch=switch,
         )
 
-    async def wait_for_idle(
+    async def wait_for_active_and_idle(
         self,
         timeout: int,
         idle_period: int = DEFAULT_MODEL_IDLE_PERIOD,
         apps: Optional[list[str]] = None,
         raise_on_blocked: bool = False,
     ) -> None:
-        """Wait for applications to reach an idle state.
+        """Wait for application(s) to reach active and idle state.
 
         If no applications are provided, this function will wait for all COU-related applications.
 
@@ -471,8 +471,8 @@ class COUModel:
         """
 
         @retry(timeout=timeout, no_retry_exceptions=(WaitForApplicationsTimeout,))
-        @wraps(self.wait_for_idle)
-        async def _wait_for_idle() -> None:
+        @wraps(self.wait_for_active_and_idle)
+        async def _wait_for_active_and_idle() -> None:
             # NOTE(rgildein): Defining wrapper so we can use retry with proper timeout
             model = await self._get_model()
             try:
@@ -481,6 +481,7 @@ class COUModel:
                     timeout=timeout,
                     idle_period=idle_period,
                     raise_on_blocked=raise_on_blocked,
+                    status="active",
                 )
             except (asyncio.exceptions.TimeoutError, JujuAppError, JujuUnitError) as error:
                 # NOTE(rgildein): Catching TimeoutError raised as exception when wait_for_idle
@@ -497,4 +498,4 @@ class COUModel:
         if apps is None:
             apps = await self._get_supported_apps()
 
-        await _wait_for_idle()
+        await _wait_for_active_and_idle()

--- a/tests/functional/tests/model.py
+++ b/tests/functional/tests/model.py
@@ -75,7 +75,7 @@ class COUModelTest(unittest.TestCase):
 
         # changing configuration and validating it was changed
         zaza.sync_wrapper(self.model.set_application_config)(TESTED_APP, new_config)
-        zaza.sync_wrapper(self.model.wait_for_idle)(120, apps=[TESTED_APP])
+        zaza.sync_wrapper(self.model.wait_for_active_and_idle)(120, apps=[TESTED_APP])
         config = zaza.sync_wrapper(self.model.get_application_config)(TESTED_APP)
 
         self.assertTrue(config["debug"]["value"])
@@ -89,4 +89,4 @@ class COUModelTest(unittest.TestCase):
         # get the current channel, so we will not change it
         channel = status.applications[TESTED_APP].charm_channel
         zaza.sync_wrapper(self.model.upgrade_charm)(TESTED_APP, channel=channel)
-        zaza.sync_wrapper(self.model.wait_for_idle)(120, apps=[TESTED_APP])
+        zaza.sync_wrapper(self.model.wait_for_active_and_idle)(120, apps=[TESTED_APP])

--- a/tests/functional/tests/model.py
+++ b/tests/functional/tests/model.py
@@ -75,7 +75,7 @@ class COUModelTest(unittest.TestCase):
 
         # changing configuration and validating it was changed
         zaza.sync_wrapper(self.model.set_application_config)(TESTED_APP, new_config)
-        zaza.sync_wrapper(self.model.wait_for_active_and_idle)(120, apps=[TESTED_APP])
+        zaza.sync_wrapper(self.model.wait_for_active_idle)(120, apps=[TESTED_APP])
         config = zaza.sync_wrapper(self.model.get_application_config)(TESTED_APP)
 
         self.assertTrue(config["debug"]["value"])
@@ -89,4 +89,4 @@ class COUModelTest(unittest.TestCase):
         # get the current channel, so we will not change it
         channel = status.applications[TESTED_APP].charm_channel
         zaza.sync_wrapper(self.model.upgrade_charm)(TESTED_APP, channel=channel)
-        zaza.sync_wrapper(self.model.wait_for_active_and_idle)(120, apps=[TESTED_APP])
+        zaza.sync_wrapper(self.model.wait_for_active_idle)(120, apps=[TESTED_APP])

--- a/tests/unit/apps/test_auxiliary.py
+++ b/tests/unit/apps/test_auxiliary.py
@@ -136,7 +136,7 @@ def test_auxiliary_upgrade_plan_ussuri_to_victoria_change_channel(status, config
         PostUpgradeStep(
             description=f"Wait 1800s for model {model.name} to reach the idle state.",
             parallel=False,
-            coro=model.wait_for_idle(1800, apps=None),
+            coro=model.wait_for_active_and_idle(1800, apps=None),
         ),
         PostUpgradeStep(
             description=f"Check if the workload of '{app.name}' has been upgraded",
@@ -194,7 +194,7 @@ def test_auxiliary_upgrade_plan_ussuri_to_victoria(status, config, model):
         PostUpgradeStep(
             description=f"Wait 1800s for model {model.name} to reach the idle state.",
             parallel=False,
-            coro=model.wait_for_idle(1800, apps=None),
+            coro=model.wait_for_active_and_idle(1800, apps=None),
         ),
         PostUpgradeStep(
             description=f"Check if the workload of '{app.name}' has been upgraded",
@@ -255,7 +255,7 @@ def test_auxiliary_upgrade_plan_ussuri_to_victoria_ch_migration(status, config, 
         PostUpgradeStep(
             description=f"Wait 1800s for model {model.name} to reach the idle state.",
             parallel=False,
-            coro=model.wait_for_idle(1800, apps=None),
+            coro=model.wait_for_active_and_idle(1800, apps=None),
         ),
         PostUpgradeStep(
             description=f"Check if the workload of '{app.name}' has been upgraded",
@@ -435,7 +435,7 @@ def test_ceph_mon_upgrade_plan_xena_to_yoga(
         PostUpgradeStep(
             description=f"Wait 1800s for model {model.name} to reach the idle state.",
             parallel=False,
-            coro=model.wait_for_idle(1800, apps=None),
+            coro=model.wait_for_active_and_idle(1800, apps=None),
         ),
         PostUpgradeStep(
             description=f"Check if the workload of '{app.name}' has been upgraded",
@@ -498,7 +498,7 @@ def test_ceph_mon_upgrade_plan_ussuri_to_victoria(
         PostUpgradeStep(
             description=f"Wait 1800s for model {model.name} to reach the idle state.",
             parallel=False,
-            coro=model.wait_for_idle(1800, apps=None),
+            coro=model.wait_for_active_and_idle(1800, apps=None),
         ),
         PostUpgradeStep(
             description=f"Check if the workload of '{app.name}' has been upgraded",
@@ -605,7 +605,7 @@ def test_ovn_principal_upgrade_plan(status, config, model):
         PostUpgradeStep(
             description=f"Wait 300s for app {app.name} to reach the idle state.",
             parallel=False,
-            coro=model.wait_for_idle(300, apps=[app.name]),
+            coro=model.wait_for_active_and_idle(300, apps=[app.name]),
         ),
         PostUpgradeStep(
             description=f"Check if the workload of '{app.name}' has been upgraded",
@@ -660,7 +660,7 @@ def test_mysql_innodb_cluster_upgrade(status, config, model):
         PostUpgradeStep(
             description=f"Wait 1800s for app {app.name} to reach the idle state.",
             parallel=False,
-            coro=model.wait_for_idle(1800, apps=[app.name]),
+            coro=model.wait_for_active_and_idle(1800, apps=[app.name]),
         ),
         PostUpgradeStep(
             description=f"Check if the workload of '{app.name}' has been upgraded",

--- a/tests/unit/apps/test_auxiliary.py
+++ b/tests/unit/apps/test_auxiliary.py
@@ -136,7 +136,7 @@ def test_auxiliary_upgrade_plan_ussuri_to_victoria_change_channel(status, config
         PostUpgradeStep(
             description=f"Wait 1800s for model {model.name} to reach the idle state.",
             parallel=False,
-            coro=model.wait_for_active_and_idle(1800, apps=None),
+            coro=model.wait_for_active_idle(1800, apps=None),
         ),
         PostUpgradeStep(
             description=f"Check if the workload of '{app.name}' has been upgraded",
@@ -194,7 +194,7 @@ def test_auxiliary_upgrade_plan_ussuri_to_victoria(status, config, model):
         PostUpgradeStep(
             description=f"Wait 1800s for model {model.name} to reach the idle state.",
             parallel=False,
-            coro=model.wait_for_active_and_idle(1800, apps=None),
+            coro=model.wait_for_active_idle(1800, apps=None),
         ),
         PostUpgradeStep(
             description=f"Check if the workload of '{app.name}' has been upgraded",
@@ -255,7 +255,7 @@ def test_auxiliary_upgrade_plan_ussuri_to_victoria_ch_migration(status, config, 
         PostUpgradeStep(
             description=f"Wait 1800s for model {model.name} to reach the idle state.",
             parallel=False,
-            coro=model.wait_for_active_and_idle(1800, apps=None),
+            coro=model.wait_for_active_idle(1800, apps=None),
         ),
         PostUpgradeStep(
             description=f"Check if the workload of '{app.name}' has been upgraded",
@@ -435,7 +435,7 @@ def test_ceph_mon_upgrade_plan_xena_to_yoga(
         PostUpgradeStep(
             description=f"Wait 1800s for model {model.name} to reach the idle state.",
             parallel=False,
-            coro=model.wait_for_active_and_idle(1800, apps=None),
+            coro=model.wait_for_active_idle(1800, apps=None),
         ),
         PostUpgradeStep(
             description=f"Check if the workload of '{app.name}' has been upgraded",
@@ -498,7 +498,7 @@ def test_ceph_mon_upgrade_plan_ussuri_to_victoria(
         PostUpgradeStep(
             description=f"Wait 1800s for model {model.name} to reach the idle state.",
             parallel=False,
-            coro=model.wait_for_active_and_idle(1800, apps=None),
+            coro=model.wait_for_active_idle(1800, apps=None),
         ),
         PostUpgradeStep(
             description=f"Check if the workload of '{app.name}' has been upgraded",
@@ -605,7 +605,7 @@ def test_ovn_principal_upgrade_plan(status, config, model):
         PostUpgradeStep(
             description=f"Wait 300s for app {app.name} to reach the idle state.",
             parallel=False,
-            coro=model.wait_for_active_and_idle(300, apps=[app.name]),
+            coro=model.wait_for_active_idle(300, apps=[app.name]),
         ),
         PostUpgradeStep(
             description=f"Check if the workload of '{app.name}' has been upgraded",
@@ -660,7 +660,7 @@ def test_mysql_innodb_cluster_upgrade(status, config, model):
         PostUpgradeStep(
             description=f"Wait 1800s for app {app.name} to reach the idle state.",
             parallel=False,
-            coro=model.wait_for_active_and_idle(1800, apps=[app.name]),
+            coro=model.wait_for_active_idle(1800, apps=[app.name]),
         ),
         PostUpgradeStep(
             description=f"Check if the workload of '{app.name}' has been upgraded",

--- a/tests/unit/apps/test_channel_based.py
+++ b/tests/unit/apps/test_channel_based.py
@@ -182,7 +182,7 @@ def test_application_gnocchi_upgrade_plan_ussuri_to_victoria(status, config, mod
         PostUpgradeStep(
             description=f"Wait 300s for app {app.name} to reach the idle state.",
             parallel=False,
-            coro=model.wait_for_idle(300, apps=[app.name]),
+            coro=model.wait_for_active_and_idle(300, apps=[app.name]),
         ),
         PostUpgradeStep(
             description=f"Check if the workload of '{app.name}' has been upgraded",
@@ -246,7 +246,7 @@ def test_application_designate_bind_upgrade_plan_ussuri_to_victoria(status, conf
         PostUpgradeStep(
             description=f"Wait 300s for app {app.name} to reach the idle state.",
             parallel=False,
-            coro=model.wait_for_idle(300, apps=[app.name]),
+            coro=model.wait_for_active_and_idle(300, apps=[app.name]),
         ),
         PostUpgradeStep(
             description=f"Check if the workload of '{app.name}' has been upgraded",

--- a/tests/unit/apps/test_channel_based.py
+++ b/tests/unit/apps/test_channel_based.py
@@ -182,7 +182,7 @@ def test_application_gnocchi_upgrade_plan_ussuri_to_victoria(status, config, mod
         PostUpgradeStep(
             description=f"Wait 300s for app {app.name} to reach the idle state.",
             parallel=False,
-            coro=model.wait_for_active_and_idle(300, apps=[app.name]),
+            coro=model.wait_for_active_idle(300, apps=[app.name]),
         ),
         PostUpgradeStep(
             description=f"Check if the workload of '{app.name}' has been upgraded",
@@ -246,7 +246,7 @@ def test_application_designate_bind_upgrade_plan_ussuri_to_victoria(status, conf
         PostUpgradeStep(
             description=f"Wait 300s for app {app.name} to reach the idle state.",
             parallel=False,
-            coro=model.wait_for_active_and_idle(300, apps=[app.name]),
+            coro=model.wait_for_active_idle(300, apps=[app.name]),
         ),
         PostUpgradeStep(
             description=f"Check if the workload of '{app.name}' has been upgraded",

--- a/tests/unit/apps/test_core.py
+++ b/tests/unit/apps/test_core.py
@@ -367,7 +367,7 @@ def test_upgrade_plan_ussuri_to_victoria(status, config, model):
         PostUpgradeStep(
             description=f"Wait 1800s for model {model.name} to reach the idle state.",
             parallel=False,
-            coro=model.wait_for_active_and_idle(1800, apps=None),
+            coro=model.wait_for_active_idle(1800, apps=None),
         ),
         PostUpgradeStep(
             description=f"Check if the workload of '{app.name}' has been upgraded",
@@ -425,7 +425,7 @@ def test_upgrade_plan_ussuri_to_victoria_ch_migration(status, config, model):
         PostUpgradeStep(
             description=f"Wait 1800s for model {model.name} to reach the idle state.",
             parallel=False,
-            coro=model.wait_for_active_and_idle(1800, apps=None),
+            coro=model.wait_for_active_idle(1800, apps=None),
         ),
         PostUpgradeStep(
             description=f"Check if the workload of '{app.name}' has been upgraded",
@@ -477,7 +477,7 @@ def test_upgrade_plan_channel_on_next_os_release(status, config, model):
         PostUpgradeStep(
             description=f"Wait 1800s for model {model.name} to reach the idle state.",
             parallel=False,
-            coro=model.wait_for_active_and_idle(1800, apps=None),
+            coro=model.wait_for_active_idle(1800, apps=None),
         ),
         PostUpgradeStep(
             description=f"Check if the workload of '{app.name}' has been upgraded",
@@ -527,7 +527,7 @@ def test_upgrade_plan_origin_already_on_next_openstack_release(status, config, m
         PostUpgradeStep(
             description=f"Wait 1800s for model {model.name} to reach the idle state.",
             parallel=False,
-            coro=model.wait_for_active_and_idle(1800, apps=None),
+            coro=model.wait_for_active_idle(1800, apps=None),
         ),
         PostUpgradeStep(
             description=f"Check if the workload of '{app.name}' has been upgraded",
@@ -601,7 +601,7 @@ def test_upgrade_plan_application_already_disable_action_managed(status, config,
         PostUpgradeStep(
             description=f"Wait 1800s for model {model.name} to reach the idle state.",
             parallel=False,
-            coro=model.wait_for_active_and_idle(1800, apps=None),
+            coro=model.wait_for_active_idle(1800, apps=None),
         ),
         PostUpgradeStep(
             description=f"Check if the workload of '{app.name}' has been upgraded",

--- a/tests/unit/apps/test_core.py
+++ b/tests/unit/apps/test_core.py
@@ -367,7 +367,7 @@ def test_upgrade_plan_ussuri_to_victoria(status, config, model):
         PostUpgradeStep(
             description=f"Wait 1800s for model {model.name} to reach the idle state.",
             parallel=False,
-            coro=model.wait_for_idle(1800, apps=None),
+            coro=model.wait_for_active_and_idle(1800, apps=None),
         ),
         PostUpgradeStep(
             description=f"Check if the workload of '{app.name}' has been upgraded",
@@ -425,7 +425,7 @@ def test_upgrade_plan_ussuri_to_victoria_ch_migration(status, config, model):
         PostUpgradeStep(
             description=f"Wait 1800s for model {model.name} to reach the idle state.",
             parallel=False,
-            coro=model.wait_for_idle(1800, apps=None),
+            coro=model.wait_for_active_and_idle(1800, apps=None),
         ),
         PostUpgradeStep(
             description=f"Check if the workload of '{app.name}' has been upgraded",
@@ -477,7 +477,7 @@ def test_upgrade_plan_channel_on_next_os_release(status, config, model):
         PostUpgradeStep(
             description=f"Wait 1800s for model {model.name} to reach the idle state.",
             parallel=False,
-            coro=model.wait_for_idle(1800, apps=None),
+            coro=model.wait_for_active_and_idle(1800, apps=None),
         ),
         PostUpgradeStep(
             description=f"Check if the workload of '{app.name}' has been upgraded",
@@ -527,7 +527,7 @@ def test_upgrade_plan_origin_already_on_next_openstack_release(status, config, m
         PostUpgradeStep(
             description=f"Wait 1800s for model {model.name} to reach the idle state.",
             parallel=False,
-            coro=model.wait_for_idle(1800, apps=None),
+            coro=model.wait_for_active_and_idle(1800, apps=None),
         ),
         PostUpgradeStep(
             description=f"Check if the workload of '{app.name}' has been upgraded",
@@ -601,7 +601,7 @@ def test_upgrade_plan_application_already_disable_action_managed(status, config,
         PostUpgradeStep(
             description=f"Wait 1800s for model {model.name} to reach the idle state.",
             parallel=False,
-            coro=model.wait_for_idle(1800, apps=None),
+            coro=model.wait_for_active_and_idle(1800, apps=None),
         ),
         PostUpgradeStep(
             description=f"Check if the workload of '{app.name}' has been upgraded",

--- a/tests/unit/steps/test_steps_plan.py
+++ b/tests/unit/steps/test_steps_plan.py
@@ -51,13 +51,13 @@ def generate_expected_upgrade_plan_principal(app, target, model):
         wait_step = PostUpgradeStep(
             description=f"Wait 1800s for model {model.name} to reach the idle state.",
             parallel=False,
-            coro=model.wait_for_idle(1800, apps=None),
+            coro=model.wait_for_active_and_idle(1800, apps=None),
         )
     else:
         wait_step = PostUpgradeStep(
             description=f"Wait 300s for app {app.name} to reach the idle state.",
             parallel=False,
-            coro=model.wait_for_idle(300, apps=[app.name]),
+            coro=model.wait_for_active_and_idle(300, apps=[app.name]),
         )
 
     upgrade_steps = [
@@ -149,7 +149,7 @@ async def test_generate_plan(apps, model):
         PreUpgradeStep(
             description="Verify that all OpenStack applications are in idle state",
             parallel=False,
-            coro=analysis_result.model.wait_for_idle(
+            coro=analysis_result.model.wait_for_active_and_idle(
                 timeout=11, idle_period=10, raise_on_blocked=True
             ),
         )

--- a/tests/unit/steps/test_steps_plan.py
+++ b/tests/unit/steps/test_steps_plan.py
@@ -51,13 +51,13 @@ def generate_expected_upgrade_plan_principal(app, target, model):
         wait_step = PostUpgradeStep(
             description=f"Wait 1800s for model {model.name} to reach the idle state.",
             parallel=False,
-            coro=model.wait_for_active_and_idle(1800, apps=None),
+            coro=model.wait_for_active_idle(1800, apps=None),
         )
     else:
         wait_step = PostUpgradeStep(
             description=f"Wait 300s for app {app.name} to reach the idle state.",
             parallel=False,
-            coro=model.wait_for_active_and_idle(300, apps=[app.name]),
+            coro=model.wait_for_active_idle(300, apps=[app.name]),
         )
 
     upgrade_steps = [
@@ -149,7 +149,7 @@ async def test_generate_plan(apps, model):
         PreUpgradeStep(
             description="Verify that all OpenStack applications are in idle state",
             parallel=False,
-            coro=analysis_result.model.wait_for_active_and_idle(
+            coro=analysis_result.model.wait_for_active_idle(
                 timeout=11, idle_period=10, raise_on_blocked=True
             ),
         )

--- a/tests/unit/utils/test_juju_utils.py
+++ b/tests/unit/utils/test_juju_utils.py
@@ -473,13 +473,13 @@ async def test_coumodel_upgrade_charm(mocked_model):
 
 @pytest.mark.asyncio
 @patch("cou.utils.juju_utils.COUModel._get_supported_apps")
-async def test_coumodel_wait_for_active_and_idle(mock_get_supported_apps, mocked_model):
-    """Test COUModel wait for related apps to be active and idle."""
+async def test_coumodel_wait_for_active_idle(mock_get_supported_apps, mocked_model):
+    """Test COUModel wait for related apps to be active idle."""
     timeout = 60
     model = juju_utils.COUModel("test-model")
     mock_get_supported_apps.return_value = ["app1", "app2"]
 
-    await model.wait_for_active_and_idle(timeout)
+    await model.wait_for_active_idle(timeout)
 
     mocked_model.wait_for_idle.assert_awaited_once_with(
         apps=["app1", "app2"],
@@ -493,12 +493,12 @@ async def test_coumodel_wait_for_active_and_idle(mock_get_supported_apps, mocked
 
 @pytest.mark.asyncio
 @patch("cou.utils.juju_utils.COUModel._get_supported_apps")
-async def test_coumodel_wait_for_active_and_idle_apps(mock_get_supported_apps, mocked_model):
-    """Test COUModel wait for specific apps to be active and idle."""
+async def test_coumodel_wait_for_active_idle_apps(mock_get_supported_apps, mocked_model):
+    """Test COUModel wait for specific apps to be active idle."""
     timeout = 60
     model = juju_utils.COUModel("test-model")
 
-    await model.wait_for_active_and_idle(timeout, apps=["app1"])
+    await model.wait_for_active_idle(timeout, apps=["app1"])
 
     mocked_model.wait_for_idle.assert_awaited_once_with(
         apps=["app1"],
@@ -512,15 +512,15 @@ async def test_coumodel_wait_for_active_and_idle_apps(mock_get_supported_apps, m
 
 @pytest.mark.asyncio
 @patch("cou.utils.juju_utils.COUModel._get_supported_apps")
-async def test_coumodel_wait_for_active_and_idle_timeout(mock_get_supported_apps, mocked_model):
-    """Test COUModel wait for model to be active and idle reach timeout."""
+async def test_coumodel_wait_for_active_idle_timeout(mock_get_supported_apps, mocked_model):
+    """Test COUModel wait for model to be active idle reach timeout."""
     timeout = 60
     exp_apps = ["app1", "app2"]
     mocked_model.wait_for_idle.side_effect = asyncio.exceptions.TimeoutError
     model = juju_utils.COUModel(None)
 
     with pytest.raises(WaitForApplicationsTimeout):
-        await model.wait_for_active_and_idle(timeout, apps=exp_apps)
+        await model.wait_for_active_idle(timeout, apps=exp_apps)
 
     mocked_model.wait_for_idle.assert_awaited_once_with(
         apps=exp_apps,

--- a/tests/unit/utils/test_juju_utils.py
+++ b/tests/unit/utils/test_juju_utils.py
@@ -473,57 +473,60 @@ async def test_coumodel_upgrade_charm(mocked_model):
 
 @pytest.mark.asyncio
 @patch("cou.utils.juju_utils.COUModel._get_supported_apps")
-async def test_coumodel_wait_for_idle(mock_get_supported_apps, mocked_model):
-    """Test COUModel wait for related apps to be idle."""
+async def test_coumodel_wait_for_active_and_idle(mock_get_supported_apps, mocked_model):
+    """Test COUModel wait for related apps to be active and idle."""
     timeout = 60
     model = juju_utils.COUModel("test-model")
     mock_get_supported_apps.return_value = ["app1", "app2"]
 
-    await model.wait_for_idle(timeout)
+    await model.wait_for_active_and_idle(timeout)
 
     mocked_model.wait_for_idle.assert_awaited_once_with(
         apps=["app1", "app2"],
         timeout=timeout,
         idle_period=juju_utils.DEFAULT_MODEL_IDLE_PERIOD,
         raise_on_blocked=False,
+        status="active",
     )
     mock_get_supported_apps.assert_awaited_once_with()
 
 
 @pytest.mark.asyncio
 @patch("cou.utils.juju_utils.COUModel._get_supported_apps")
-async def test_coumodel_wait_for_idle_apps(mock_get_supported_apps, mocked_model):
-    """Test COUModel wait for specific apps to be idle."""
+async def test_coumodel_wait_for_active_and_idle_apps(mock_get_supported_apps, mocked_model):
+    """Test COUModel wait for specific apps to be active and idle."""
     timeout = 60
     model = juju_utils.COUModel("test-model")
 
-    await model.wait_for_idle(timeout, apps=["app1"])
+    await model.wait_for_active_and_idle(timeout, apps=["app1"])
 
     mocked_model.wait_for_idle.assert_awaited_once_with(
         apps=["app1"],
         timeout=timeout,
         idle_period=juju_utils.DEFAULT_MODEL_IDLE_PERIOD,
         raise_on_blocked=False,
+        status="active",
     )
     mock_get_supported_apps.assert_not_awaited()
 
 
 @pytest.mark.asyncio
 @patch("cou.utils.juju_utils.COUModel._get_supported_apps")
-async def test_coumodel_wait_for_idle_timeout(mock_get_supported_apps, mocked_model):
-    """Test COUModel wait for model to be idle reach timeout."""
+async def test_coumodel_wait_for_active_and_idle_timeout(mock_get_supported_apps, mocked_model):
+    """Test COUModel wait for model to be active and idle reach timeout."""
     timeout = 60
     exp_apps = ["app1", "app2"]
     mocked_model.wait_for_idle.side_effect = asyncio.exceptions.TimeoutError
     model = juju_utils.COUModel(None)
 
     with pytest.raises(WaitForApplicationsTimeout):
-        await model.wait_for_idle(timeout, apps=exp_apps)
+        await model.wait_for_active_and_idle(timeout, apps=exp_apps)
 
     mocked_model.wait_for_idle.assert_awaited_once_with(
         apps=exp_apps,
         timeout=timeout,
         idle_period=juju_utils.DEFAULT_MODEL_IDLE_PERIOD,
         raise_on_blocked=False,
+        status="active",
     )
     mock_get_supported_apps.assert_not_awaited()


### PR DESCRIPTION
- Without status check, if a unit is on maintenance it will proceed to upgrade
  or pass the post-upgrade check after upgrading.
 - change function name from wait_for_idle to wait_for_active_and_idle to reflect
  the changes.

Closes: #199