### PR TITLE
Mark plan generation as failed when reaching highest supporting release

### DIFF
--- a/cou/cli.py
+++ b/cou/cli.py
@@ -220,6 +220,7 @@ def entrypoint() -> None:
         loop = asyncio.get_event_loop()
         loop.run_until_complete(_run_command(args))
     except HighestReleaseAchieved as exc:
+        progress_indicator.fail()
         print(exc)
         sys.exit(0)
     except TimeoutException:


### PR DESCRIPTION
If the cloud version is detected as the highest supporting release, mark plan generation as failed then print the message.