### PR TITLE
fix finishing indicator if HighestReleaseAchieved

### DIFF
--- a/cou/cli.py
+++ b/cou/cli.py
@@ -82,9 +82,7 @@ def get_log_level(quiet: bool = False, verbosity: int = 0) -> str:
     :return: Log level.
     :rtype: str
     """
-    if quiet:
-        return "CRITICAL"
-    return VerbosityLevel(verbosity).name
+    return "CRITICAL" if quiet else VerbosityLevel(verbosity).name
 
 
 async def continue_upgrade() -> bool:
@@ -220,8 +218,8 @@ def entrypoint() -> None:
         loop = asyncio.get_event_loop()
         loop.run_until_complete(_run_command(args))
     except HighestReleaseAchieved as exc:
+        progress_indicator.succeed()
         print(exc)
-        sys.exit(0)
     except TimeoutException:
         progress_indicator.fail()
         print("The connection was lost. Check your connection or increase the timeout.")

--- a/cou/logging.py
+++ b/cou/logging.py
@@ -78,7 +78,7 @@ def setup_logging(log_level: str = "INFO") -> None:
     root_logger.addHandler(log_file_handler)
     root_logger.addHandler(console_handler)
 
-    progress_indicator.stop_and_persist(text=f"Logs of this execution can be found at {file_name}")
+    progress_indicator.stop_and_persist(text=f"Full execution log: '{file_name}'")
 
 
 def filter_debug_logs(record: logging.LogRecord) -> bool:

--- a/cou/steps/plan.py
+++ b/cou/steps/plan.py
@@ -194,9 +194,9 @@ def determine_upgrade_target(
     # Check if the release is the "last" supported by the series
     if str(current_os_release) == LTS_TO_OS_RELEASE[current_series][-1]:
         raise HighestReleaseAchieved(
-            f"The cloud is already at the latest OpenStack release '{current_os_release}' "
-            f"compatible with series '{current_series}', and COU does not support series "
-            "upgrade. Please manually upgrade series and run COU again."
+            f"No upgrades available for OpenStack {str(current_os_release).capitalize()} on "
+            f"Ubuntu {current_series.capitalize()}.\nNewer OpenStack releases may be available "
+            "after upgrading to a later Ubuntu series."
         )
 
     # get the next release as the target from the current cloud os release

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -287,7 +287,7 @@ def test_entrypoint_highest_release(mock_run_command, mock_indicator):
 
     cli.entrypoint()
 
-    mock_indicator.stop.assert_called_once_with()
+    mock_indicator.succeed.assert_called_once_with()
     mock_indicator.stop.assert_called_once_with()
 
 

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -285,9 +285,9 @@ def test_entrypoint_highest_release(mock_run_command, mock_indicator):
     """Test TimeoutException exception during entrypoint execution."""
     mock_run_command.side_effect = HighestReleaseAchieved
 
-    with pytest.raises(SystemExit, match="0"):
-        cli.entrypoint()
+    cli.entrypoint()
 
+    mock_indicator.stop.assert_called_once_with()
     mock_indicator.stop.assert_called_once_with()
 
 


### PR DESCRIPTION
Without indicator finished, the message will break previous indicator.
- add success for progess_indicator after `HighestReleaseAchieved`
- improve message for `HighestReleaseAchieved`
- improve message for logging indicator

original stdout
```bash
$ cou upgrade --model openstack
Logs of this execution can be found at /home/rgildein/.local/share/cou/log/cou-20231215205252.log  
Connected to 'openstack' ✔
Analyzing cloud... ✔
Generating upgrade plan... \The cloud is already at the latest OpenStack release 'yoga' compatible with series 'focal', and COU does not support series upgrade. Please manually upgrade series and run COU again. 
```

new stdout
```bash
$ cou upgrade --model openstack
Full execution log: '/home/rgildein/.local/share/cou/log/cou-20231215205143.log'  
Connected to 'openstack' ✔
Analyzing cloud... ✔
Generating upgrade plan... ✔
No upgrades available for OpenStack Yoga on Ubuntu Focal.
Newer OpenStack releases may be available after upgrading to a later Ubuntu series.
```