### PR TITLE
add first draft of pseudo code for data plane upgrade

### DIFF
--- a/cou/apps/data_plane.py
+++ b/cou/apps/data_plane.py
@@ -1,0 +1,72 @@
+# Copyright 2024 Canonical Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Data plane application class."""
+import logging
+from typing import Optional
+
+from cou.apps.base import OpenStackApplication
+from cou.apps.factory import AppFactory
+
+logger = logging.getLogger(__name__)
+
+
+class BaseDataPlaneApplication(OpenStackApplication):
+    """Base data plane application."""
+
+    async def _check_control_plane_was_upgraded(self) -> bool:
+        """Check that all control plane apps was upgraded.
+
+        This function is part of required pre-checks for all data plane apps.
+        """
+        raise NotImplementedError
+
+    async def populate_units(
+        self,
+        hostname: Optional[str] = None,
+        machine_id: Optional[str] = None,
+        az: Optional[str] = None,
+    ) -> None:
+        """Populate units and filtered specific machine, hostname or az.
+
+        :param hostname: machine hostname
+        :type hostname: str
+        :param machine_id: machine id
+        :type machine_id: str
+        :param az: az of machine
+        :type az: str
+        """
+        raise NotImplementedError
+
+
+@AppFactory.register_application(["nova-compute"])
+class NovaCompute(BaseDataPlaneApplication):
+    """Nova-compute application."""
+
+    wait_timeout = 30 * 60  # 30 min
+    wait_for_model = True
+
+    async def instance_count(self) -> int:
+        """Get number of instances running on hypervisor."""
+        raise NotImplementedError
+
+    async def populate_units(self, *args: Optional[str], **kwargs: Optional[str]) -> None:
+        """Populate units and filtered specific machine, hostname or az.
+
+        :param args: arguments parser
+        :type args: Any
+        :param kwargs: named argument parser
+        :type kwargs: Any
+        """
+        raise NotImplementedError

--- a/cou/steps/analyze.py
+++ b/cou/steps/analyze.py
@@ -56,13 +56,22 @@ class Analysis:
         self.current_cloud_series = self._get_minimum_cloud_series()
 
     @staticmethod
+    def _sort_apps(apps: list[OpenStackApplication]) -> list[OpenStackApplication]:
+        """Sort apps in order relevant to upgrade.
+
+        :param apps: List of applications to split.
+        :type apps: list[OpenStackApplication]
+        """
+        raise NotImplementedError
+
+    @staticmethod
     def _split_apps(
         apps: list[OpenStackApplication],
     ) -> tuple[list[OpenStackApplication], list[OpenStackApplication]]:
         """Split applications to control plane and data plane apps.
 
         :param apps: List of applications to split.
-        :type apps: Iterable[OpenStackApplication]
+        :type apps: list[OpenStackApplication]
         :return: Control plane and data plane application lists.
         :rtype: tuple[list[OpenStackApplication], list[OpenStackApplication]]
         """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,9 @@ ignore-paths = [
     "tests",
     "docs"
 ]
+disable = [
+    "W0223",
+]
 no-docstring-rgx = "__.*__"
 default-docstring-type = "sphinx"
 accept-no-param-doc = false
@@ -80,11 +83,14 @@ exclude = [
 relative_files = true
 concurrency = ["gevent"]
 source = ["."]
-omit = ["tests/**", "docs/**", "lib/**", "snap/**", "build/**", "setup.py"]
+omit = ["tests/**", "docs/**", "lib/**", "snap/**", "build/**", "setup.py", "cou/apps/data_plane.py"]
 
 [tool.coverage.report]
 fail_under = 100
 show_missing = true
+exclude_also = [
+    "raise NotImplementedError"
+]
 
 [tool.coverage.html]
 directory = "tests/unit/report/html"


### PR DESCRIPTION
The idea behind this approach is to handle all the machines and applications in them through Nova-compute applications. That way, not much code will change, what is benefit.

I prepared a diagram for a more detailed description.
![cou data-plane v1](https://github.com/canonical/charmed-openstack-upgrader/assets/34167657/28c48688-55d6-4692-85d3-f0a61d035a61)

Known issues:
 - Nova-compute application needs to be responsible for upgrading apps deployed under the same machine.
   - Steps like config changes must be done as pre-checks in nova-compute for all apps.