### PR TITLE
run func tests on GitHub instead of self-hosted

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -66,11 +66,11 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: '3.10'
-      - name: Setup Juju environment
+      - name: Setup Juju 2.9/stable environment
         uses: charmed-kubernetes/actions-operator@main
         with:
           provider: lxd
-          juju-channel: stable
+          juju-channel: 2.9/stable
       - name: Remove tox install by actions-operator
         run: sudo apt remove tox -y
       - name: Install tox

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -66,6 +66,13 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: '3.10'
+      - name: Setup Juju environment
+        uses: charmed-kubernetes/actions-operator@main
+        with:
+          provider: lxd
+          juju-channel: stable
+      - name: Remove tox install by actions-operator
+        run: sudo apt remove tox -y
       - name: Install tox
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -1,10 +1,6 @@
 
 name: Check workflow running linter, unit and functional tests
 
-concurrency:
-  group: ${{ github.workflow }}
-
-
 on:
   workflow_call:
   pull_request:
@@ -25,7 +21,7 @@ jobs:
     with:
       python-version: ${{ matrix.python-version }}
       tox-version: '<4'
-    
+
   snap-build:
     name: Build snap package
     needs: lint-unit
@@ -60,7 +56,7 @@ jobs:
   func:
     name: Functional tests
     needs: snap-build
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     timeout-minutes: 120
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Running functional tests on GitHub runner instead of self-hosted. With GitHub runner we do not need to have concurrency set-up.