### PR TITLE
Add base architecture of HypervisorUpgradePlanner

### DIFF
--- a/cou/steps/__init__.py
+++ b/cou/steps/__init__.py
@@ -293,8 +293,8 @@ class UpgradePlan(BaseStep):
         logger.debug("No coroutine to run for %s", repr(self))
 
 
-class AvailabilityZoneUpgradePlan(UpgradePlan):
-    """Represents the plan for upgrading availability zone upgrade.
+class HypervisorGroupUpgradePlan(UpgradePlan):
+    """Represents the plan for group of hypervisors.
 
     This class is intended to be used as group for hypervisor upgrade steps, therefore
     doesn't accept coroutine or parallel as inputs.
@@ -317,7 +317,7 @@ class HypervisorUpgradePlan(BaseStep):
     """Represents the plan for hypervisor upgrade.
 
     This class is intended to be used as a group for unit-level upgrade steps, which are
-    grouped by single hypervisor. It doesn't accept coroutine or parallel as inputs.
+    grouped by a single hypervisor. It doesn't accept coroutine or parallel as inputs.
 
     All sub-steps will run in parallel.
     """

--- a/cou/steps/__init__.py
+++ b/cou/steps/__init__.py
@@ -293,6 +293,16 @@ class UpgradePlan(BaseStep):
         logger.debug("No coroutine to run for %s", repr(self))
 
 
+class AvailabilityZoneUpgradePlan(UpgradePlan):
+    """Represents the plan for upgrading availability zone upgrade.
+
+    This class is intended to be used as group for hypervisor upgrade steps, therefore
+    doesn't accept coroutine or parallel as inputs.
+    """
+
+    prompt: bool = True
+
+
 class ApplicationUpgradePlan(UpgradePlan):
     """Represents the plan for application-level upgrade.
 
@@ -301,6 +311,26 @@ class ApplicationUpgradePlan(UpgradePlan):
     """
 
     prompt: bool = True
+
+
+class HypervisorUpgradePlan(BaseStep):
+    """Represents the plan for hypervisor upgrade.
+
+    This class is intended to be used as a group for unit-level upgrade steps, which are
+    grouped by single hypervisor. It doesn't accept coroutine or parallel as inputs.
+
+    All sub-steps will run in parallel.
+    """
+
+    prompt: bool = False
+
+    def __init__(self, description: str):
+        """Initialize upgrade plan.
+
+        :param description: Description of the step.
+        :type description: str
+        """
+        super().__init__(description=description, parallel=True, coro=None)
 
 
 class UpgradeStep(BaseStep):

--- a/cou/steps/hypervisor.py
+++ b/cou/steps/hypervisor.py
@@ -1,0 +1,152 @@
+# Copyright 2024 Canonical Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Hypervisor planner."""
+import logging
+from dataclasses import dataclass
+
+from cou.apps.base import ApplicationUnit, OpenStackApplication
+from cou.steps import (
+    HypervisorUpgradePlan,
+    PostUpgradeStep,
+    PreUpgradeStep,
+    UpgradePlan,
+)
+from cou.utils.openstack import OpenStackRelease
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class Hypervisor:
+    """Hypervisor containing units for multiple applications."""
+
+    name: str
+    units: list[ApplicationUnit]
+
+
+@dataclass(frozen=True)
+class AZ:
+    """Availability Zone hypervisors in the az."""
+
+    name: str
+    hypervisors: list[Hypervisor]
+
+
+def verify_apps(apps: list[OpenStackApplication]) -> None:
+    """Verify OpenStack applications.
+
+    This function will verify that all machines contain nova-compute application.
+
+    :param apps: list of OpenStack applications
+    :type apps: list[OpenStackApplication]
+    """
+    raise NotImplementedError
+
+
+class HypervisorUpgradePlanner:
+    """Planer for all hypervisor updates.
+
+    This planner is meant to be used to upgrade machines contains the nova-compute application.
+    """
+
+    def __init__(self, apps: list[OpenStackApplication]) -> None:
+        """Initialize the Hypervisor class.
+
+        :param apps: list of OpenStack applications
+        :type apps: list[OpenStackApplication]
+        """
+        verify_apps(apps)
+        self._apps = apps
+
+    @property
+    def apps(self) -> list[OpenStackApplication]:
+        """Return list of apps in hypervisor class."""
+        return self._apps
+
+    @property
+    def azs(self) -> list[AZ]:
+        """Returns list of AZs defined in individual applications.
+
+        Each AZ contains a sorted list hypervisors, where each hypervisor has sorted list of units.
+        The order of units depends on the order in which they needs to be upgraded.
+        eg.
+        az1:
+        - hypervisor0:
+          - nova-compute/0
+          - cinder/0
+        - hypervisor1:
+          - nova-compute/1
+          - cinder/1
+        ...
+        """
+        raise NotImplementedError
+
+    def _generate_pre_upgrade_plan(self) -> PreUpgradeStep:
+        """Generate pre upgrade plan all application.
+
+        This section should create a plan with steps like changing Juju config option, etc.
+
+        :return: Pre-upgrade step with all needed pre-upgrade steps.
+        :rtype: PreUpgradeStep
+        """
+        raise NotImplementedError
+
+    def _generate_hypervisor_upgrade_plan(self, hypervisor: Hypervisor) -> HypervisorUpgradePlan:
+        """Genarete upgrade plan for single hypevisors.
+
+        Each hypervisor upgrade consists of a UnitUpgradeStep, so all substeps should be based
+        on UnitUpgradeStep.
+
+        :param hypervisor: hypervisor object
+        :type hypervisor: Hypervisor
+        :return: Upgrade plan for hypervisor.
+        :rtype: HypervisorUpgradePlan
+        """
+        raise NotImplementedError
+
+    def _generate_post_upgrade_plan(self) -> PostUpgradeStep:
+        """Generate post upgrade plan all application.
+
+        This section should create a plan with steps like checking versions, status of
+        application, etc.
+
+        :return: Post-upgrade step with all needed post-upgrade steps.
+        :rtype: PostUpgradeStep
+        """
+        raise NotImplementedError
+
+    # pylint: disable=unused-argument
+    def generate_upgrade_plan(self, target: OpenStackRelease) -> UpgradePlan:
+        """Generate full upgrade plan for all hypervisors.
+
+        This plan will be based on multiple HypervisorUpgradePlan.
+
+        :param target: OpenStack codename to upgrade.
+        :type target: OpenStackRelease
+        :return: Full upgrade plan
+        :rtype: UpgradePlan
+        """
+        plan = UpgradePlan("Upgrading all applications deployed on machines with hypervisor.")
+        logger.debug("generating pre upgrade steps")
+        plan.add_step(self._generate_pre_upgrade_plan())
+        for az in self.azs:
+            for hypervisor in az.hypervisors:
+                logger.debug("generating upgrade steps for %s in %s AZ", hypervisor.name, az.name)
+                plan.add_step(self._generate_hypervisor_upgrade_plan(hypervisor))
+
+        logger.debug("generating post upgrade steps")
+        plan.add_step(self._generate_post_upgrade_plan())
+
+        return plan

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,7 +81,15 @@ exclude = [
 relative_files = true
 concurrency = ["gevent"]
 source = ["."]
-omit = ["tests/**", "docs/**", "lib/**", "snap/**", "build/**", "setup.py"]
+omit = [
+    "tests/**",
+    "docs/**",
+    "lib/**",
+    "snap/**",
+    "build/**",
+    "setup.py",
+    "cou/steps/hypervisor.py",
+]
 
 [tool.coverage.report]
 fail_under = 100

--- a/tests/unit/steps/test_steps.py
+++ b/tests/unit/steps/test_steps.py
@@ -22,6 +22,7 @@ import pytest
 from cou.exceptions import CanceledStep
 from cou.steps import (
     BaseStep,
+    HypervisorUpgradePlan,
     PostUpgradeStep,
     PreUpgradeStep,
     UnitUpgradeStep,
@@ -392,3 +393,14 @@ async def test_step_full_run(sub_steps, exp_order, parallel):
 def test_is_unit_upgrade_step(step, exp_result):
     """Test helper function for checking if step is unit upgrade step."""
     assert is_unit_upgrade_step(step) == exp_result
+
+
+@pytest.mark.asyncio
+async def test_hypervisor_upgrade_plan_step_instances():
+    """Test setting parallel for HypervisorUpgradePlan."""
+    description = "test plan"
+    step = HypervisorUpgradePlan(description=description)
+
+    assert step._coro is None
+    assert step.parallel is True
+    assert step.prompt is False


### PR DESCRIPTION
This commit introduce the HypervisorUpgradePlanner, which takes apps as argument and group them by AZ and hypervisor. Like this it can easily generate plan to upgrade all hypervisors.