### PR TITLE
use self-hosted runner and LXD cloud for CI

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -26,7 +26,7 @@ jobs:
     with:
       python-version: ${{ matrix.python-version }}
       tox-version: '<4'
-    
+
   snap-build:
     name: Build snap package
     needs: lint-unit
@@ -61,7 +61,7 @@ jobs:
   func:
     name: Functional tests
     needs: snap-build
-    runs-on: self-hosted
+    runs-on: [self-hosted, large]
     timeout-minutes: 120
     steps:
       - uses: actions/checkout@v4
@@ -71,6 +71,13 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: '3.10'
+      - name: Setup Juju 2.9/stable environment
+        uses: charmed-kubernetes/actions-operator@main
+        with:
+          provider: lxd
+          juju-channel: 2.9/stable
+      - name: Remove tox install by actions-operator
+        run: sudo apt remove tox -y
       - name: Install tox
         run: |
           python -m pip install --upgrade pip


### PR DESCRIPTION
We do not require to run func test on top of OpenStack, so I changed the CI running on LXD cloud.