### PR TITLE
Post uptgrade steps accept units to check if reached expected target.

### DIFF
--- a/cou/apps/base.py
+++ b/cou/apps/base.py
@@ -19,7 +19,7 @@ import logging
 from collections import defaultdict
 from dataclasses import dataclass, field
 from io import StringIO
-from typing import Any, Optional
+from typing import Any, Iterable, Optional
 
 from ruamel.yaml import YAML
 
@@ -319,30 +319,6 @@ class OpenStackApplication(COUApplication):
         """
         return f"cloud:{self.series}-{target.codename}"
 
-    async def _check_upgrade(self, target: OpenStackRelease) -> None:
-        """Check if an application has upgraded its workload version.
-
-        :param target: OpenStack release as target to upgrade.
-        :type target: OpenStackRelease
-        :raises ApplicationError: When the workload version of the charm doesn't upgrade.
-        """
-        status = await self.model.get_status()
-        app_status = status.applications.get(self.name)
-        units_not_upgraded = []
-        for unit in app_status.units.keys():
-            workload_version = app_status.units[unit].workload_version
-            compatible_os_versions = OpenStackCodenameLookup.find_compatible_versions(
-                self.charm, workload_version
-            )
-            if target not in compatible_os_versions:
-                units_not_upgraded.append(unit)
-
-        if units_not_upgraded:
-            units_not_upgraded_string = ", ".join(units_not_upgraded)
-            raise ApplicationError(
-                f"Cannot upgrade units '{units_not_upgraded_string}' to {target}."
-            )
-
     def pre_upgrade_steps(self, target: OpenStackRelease) -> list[PreUpgradeStep]:
         """Pre Upgrade steps planning.
 
@@ -393,19 +369,23 @@ class OpenStackApplication(COUApplication):
             self._get_change_install_repository_step(target),
         ]
 
-    def post_upgrade_steps(self, target: OpenStackRelease) -> list[PostUpgradeStep]:
+    def post_upgrade_steps(
+        self, target: OpenStackRelease, units: Optional[Iterable[COUUnit]]
+    ) -> list[PostUpgradeStep]:
         """Post Upgrade steps planning.
 
         Wait until the application reaches the idle state and then check the target workload.
 
         :param target: OpenStack release as target to upgrade.
         :type target: OpenStackRelease
+        :param units: Units to generate post upgrade plan
+        :type units: Optional[Iterable[COUUnit]]
         :return: List of post upgrade steps.
         :rtype: list[PostUpgradeStep]
         """
         return [
             self._get_wait_step(),
-            self._get_reached_expected_target_step(target),
+            self._get_reached_expected_target_step(target, units),
         ]
 
     def generate_upgrade_plan(
@@ -433,7 +413,7 @@ class OpenStackApplication(COUApplication):
         all_steps = (
             self.pre_upgrade_steps(target)
             + self.upgrade_steps(target, units, force)
-            + self.post_upgrade_steps(target)
+            + self.post_upgrade_steps(target, units)
         )
         for step in all_steps:
             if step:
@@ -651,18 +631,54 @@ class OpenStackApplication(COUApplication):
         )
         return UpgradeStep()
 
-    def _get_reached_expected_target_step(self, target: OpenStackRelease) -> PostUpgradeStep:
+    def _get_reached_expected_target_step(
+        self, target: OpenStackRelease, units: Optional[Iterable[COUUnit]]
+    ) -> PostUpgradeStep:
         """Get post upgrade step to check if application workload has been upgraded.
 
         :param target: OpenStack release as target to upgrade.
         :type target: OpenStackRelease
+        :param units: Units to generate post upgrade plan
+        :type units: Optional[Iterable[COUUnit]]
         :return: Post Upgrade step to check if application workload has been upgraded.
         :rtype: PostUpgradeStep
         """
+        if not units:
+            units = list(self.units.values())
         return PostUpgradeStep(
-            description=f"Check if the workload of '{self.name}' has been upgraded",
-            coro=self._check_upgrade(target),
+            description=(
+                f"Check if the workload of '{self.name}' has been upgraded on units: "
+                f"{', '.join([unit.name for unit in units])}"
+            ),
+            coro=self._verify_workload_upgrade(target, units),
         )
+
+    async def _verify_workload_upgrade(
+        self, target: OpenStackRelease, units: Iterable[COUUnit]
+    ) -> None:
+        """Check if an application has upgraded its workload version.
+
+        :param target: OpenStack release as target to upgrade.
+        :type target: OpenStackRelease
+        :param units: Units to check if got upgraded
+        :type units: Iterable[COUUnit]
+        :raises ApplicationError: When the workload version of the charm doesn't upgrade.
+        """
+        status = await self.model.get_status()
+        app_status = status.applications.get(self.name)
+        units_not_upgraded = []
+        for unit in units:
+            workload_version = app_status.units[unit.name].workload_version
+            compatible_os_versions = OpenStackCodenameLookup.find_compatible_versions(
+                self.charm, workload_version
+            )
+            if target not in compatible_os_versions:
+                units_not_upgraded.append(unit.name)
+
+        if units_not_upgraded:
+            raise ApplicationError(
+                f"Cannot upgrade units '{', '.join(units_not_upgraded)}' to {target}."
+            )
 
     def _get_wait_step(self) -> PostUpgradeStep:
         """Get wait step for entire model or application.

--- a/cou/apps/channel_based.py
+++ b/cou/apps/channel_based.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 """Channel based application class."""
 import logging
+from typing import Iterable, Optional
 
 from cou.apps.base import OpenStackApplication
 from cou.apps.factory import AppFactory
@@ -59,7 +60,9 @@ class OpenStackChannelBasedApplication(OpenStackApplication):
         """
         return not all(unit.workload_version for unit in self.units.values())
 
-    def post_upgrade_steps(self, target: OpenStackRelease) -> list[PostUpgradeStep]:
+    def post_upgrade_steps(
+        self, target: OpenStackRelease, units: Optional[Iterable[COUUnit]]
+    ) -> list[PostUpgradeStep]:
         """Post Upgrade steps planning.
 
         Wait until the application reaches the idle state and then check the target workload.
@@ -67,9 +70,11 @@ class OpenStackChannelBasedApplication(OpenStackApplication):
 
         :param target: OpenStack release as target to upgrade.
         :type target: OpenStackRelease
+        :param units: Units to generate post upgrade plan
+        :type units: Optional[Iterable[COUUnit]]
         :return: List of post upgrade steps.
         :rtype: list[PostUpgradeStep]
         """
         if self.is_versionless:
             return []
-        return super().post_upgrade_steps(target)
+        return super().post_upgrade_steps(target, units)

--- a/cou/apps/subordinate.py
+++ b/cou/apps/subordinate.py
@@ -13,7 +13,7 @@
 #  limitations under the License.
 """Subordinate application class."""
 import logging
-from typing import Optional
+from typing import Iterable, Optional
 
 from cou.apps.base import OpenStackApplication
 from cou.apps.factory import AppFactory
@@ -53,11 +53,15 @@ class SubordinateBaseClass(OpenStackApplication):
         """
         return [self._get_upgrade_charm_step(target)]
 
-    def post_upgrade_steps(self, target: OpenStackRelease) -> list[PostUpgradeStep]:
+    def post_upgrade_steps(
+        self, target: OpenStackRelease, units: Optional[Iterable[COUUnit]]
+    ) -> list[PostUpgradeStep]:
         """Post Upgrade steps planning.
 
         :param target: OpenStack release as target to upgrade.
         :type target: OpenStackRelease
+        :param units: Units to generate post upgrade plan
+        :type units: Optional[Iterable[COUUnit]]
         :return: List of post upgrade steps.
         :rtype: list[PostUpgradeStep]
         """

--- a/tests/unit/apps/test_auxiliary.py
+++ b/tests/unit/apps/test_auxiliary.py
@@ -175,9 +175,12 @@ def test_auxiliary_upgrade_plan_ussuri_to_victoria_change_channel(model):
             coro=model.wait_for_active_idle(1800, apps=None),
         ),
         PostUpgradeStep(
-            description=f"Check if the workload of '{app.name}' has been upgraded",
+            description=(
+                f"Check if the workload of '{app.name}' has been upgraded on units: "
+                f"{', '.join([unit for unit in app.units.keys()])}"
+            ),
             parallel=False,
-            coro=app._check_upgrade(target),
+            coro=app._verify_workload_upgrade(target, app.units.values()),
         ),
     ]
     add_steps(expected_plan, upgrade_steps)
@@ -250,9 +253,12 @@ def test_auxiliary_upgrade_plan_ussuri_to_victoria(model):
             coro=model.wait_for_active_idle(1800, apps=None),
         ),
         PostUpgradeStep(
-            description=f"Check if the workload of '{app.name}' has been upgraded",
+            description=(
+                f"Check if the workload of '{app.name}' has been upgraded on units: "
+                f"{', '.join([unit for unit in app.units.keys()])}"
+            ),
             parallel=False,
-            coro=app._check_upgrade(target),
+            coro=app._verify_workload_upgrade(target, app.units.values()),
         ),
     ]
     add_steps(expected_plan, upgrade_steps)
@@ -331,9 +337,12 @@ def test_auxiliary_upgrade_plan_ussuri_to_victoria_ch_migration(model):
             coro=model.wait_for_active_idle(1800, apps=None),
         ),
         PostUpgradeStep(
-            description=f"Check if the workload of '{app.name}' has been upgraded",
+            description=(
+                f"Check if the workload of '{app.name}' has been upgraded on units: "
+                f"{', '.join([unit for unit in app.units.keys()])}"
+            ),
             parallel=False,
-            coro=app._check_upgrade(target),
+            coro=app._verify_workload_upgrade(target, app.units.values()),
         ),
     ]
     add_steps(expected_plan, upgrade_steps)
@@ -657,9 +666,12 @@ def test_ceph_mon_upgrade_plan_xena_to_yoga(model):
             coro=model.wait_for_active_idle(1800, apps=None),
         ),
         PostUpgradeStep(
-            description=f"Check if the workload of '{app.name}' has been upgraded",
+            description=(
+                f"Check if the workload of '{app.name}' has been upgraded on units: "
+                f"{', '.join([unit for unit in app.units.keys()])}"
+            ),
             parallel=False,
-            coro=app._check_upgrade(target),
+            coro=app._verify_workload_upgrade(target, app.units.values()),
         ),
     ]
     add_steps(expected_plan, upgrade_steps)
@@ -738,9 +750,12 @@ def test_ceph_mon_upgrade_plan_ussuri_to_victoria(model):
             coro=model.wait_for_active_idle(1800, apps=None),
         ),
         PostUpgradeStep(
-            description=f"Check if the workload of '{app.name}' has been upgraded",
+            description=(
+                f"Check if the workload of '{app.name}' has been upgraded on units: "
+                f"{', '.join([unit for unit in app.units.keys()])}"
+            ),
             parallel=False,
-            coro=app._check_upgrade(target),
+            coro=app._verify_workload_upgrade(target, app.units.values()),
         ),
     ]
     add_steps(expected_plan, upgrade_steps)
@@ -918,9 +933,12 @@ def test_ovn_principal_upgrade_plan(model):
             coro=model.wait_for_active_idle(300, apps=[app.name]),
         ),
         PostUpgradeStep(
-            description=f"Check if the workload of '{app.name}' has been upgraded",
+            description=(
+                f"Check if the workload of '{app.name}' has been upgraded on units: "
+                f"{', '.join([unit for unit in app.units.keys()])}"
+            ),
             parallel=False,
-            coro=app._check_upgrade(target),
+            coro=app._verify_workload_upgrade(target, app.units.values()),
         ),
     ]
     add_steps(expected_plan, upgrade_steps)
@@ -994,9 +1012,12 @@ def test_mysql_innodb_cluster_upgrade(model):
             coro=model.wait_for_active_idle(1800, apps=[app.name]),
         ),
         PostUpgradeStep(
-            description=f"Check if the workload of '{app.name}' has been upgraded",
+            description=(
+                f"Check if the workload of '{app.name}' has been upgraded on units: "
+                f"{', '.join([unit for unit in app.units.keys()])}"
+            ),
             parallel=False,
-            coro=app._check_upgrade(target),
+            coro=app._verify_workload_upgrade(target, app.units.values()),
         ),
     ]
     add_steps(expected_plan, upgrade_steps)

--- a/tests/unit/apps/test_base.py
+++ b/tests/unit/apps/test_base.py
@@ -12,7 +12,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, call, patch
 
 import pytest
 
@@ -20,6 +20,7 @@ from cou.apps.base import OpenStackApplication
 from cou.exceptions import ApplicationError
 from cou.steps import UnitUpgradeStep, UpgradeStep
 from cou.utils.juju_utils import COUMachine, COUUnit
+from cou.utils.openstack import OpenStackRelease
 from tests.unit.utils import assert_steps
 
 
@@ -219,3 +220,31 @@ def test_get_openstack_upgrade_step(model):
 
     step = app._get_openstack_upgrade_step(unit)
     assert_steps(step, expected_upgrade_step)
+
+
+@pytest.mark.parametrize(
+    "units",
+    [
+        [],
+        [COUUnit(f"my_app/{unit}", MagicMock(), MagicMock()) for unit in range(1)],
+        [COUUnit(f"my_app/{unit}", MagicMock(), MagicMock()) for unit in range(2)],
+        [COUUnit(f"my_app/{unit}", MagicMock(), MagicMock()) for unit in range(3)],
+    ],
+)
+@patch("cou.apps.base.OpenStackApplication._verify_workload_upgrade")
+def test_get_reached_expected_target_step(mock_workload_upgrade, units, model):
+    target = OpenStackRelease("victoria")
+    mock = MagicMock()
+    charm = "app"
+    app_name = "my_app"
+    channel = "ussuri/stable"
+    app_units = {f"my_app/{unit}": COUUnit(f"my_app/{unit}", mock, mock) for unit in range(3)}
+
+    app = OpenStackApplication(
+        app_name, "", charm, channel, {}, {}, model, "ch", "focal", [], app_units, "21.0.1"
+    )
+
+    expected_calls = [call(target, units)] if units else [call(target, list(app.units.values()))]
+
+    app._get_reached_expected_target_step(target, units)
+    mock_workload_upgrade.assert_has_calls(expected_calls)

--- a/tests/unit/apps/test_channel_based.py
+++ b/tests/unit/apps/test_channel_based.py
@@ -307,9 +307,12 @@ def test_application_gnocchi_upgrade_plan_ussuri_to_victoria(model):
             coro=model.wait_for_active_idle(300, apps=[app.name]),
         ),
         PostUpgradeStep(
-            description=f"Check if the workload of '{app.name}' has been upgraded",
+            description=(
+                f"Check if the workload of '{app.name}' has been upgraded on units: "
+                f"{', '.join([unit for unit in app.units.keys()])}"
+            ),
             parallel=False,
-            coro=app._check_upgrade(target),
+            coro=app._verify_workload_upgrade(target, app.units.values()),
         ),
     ]
 
@@ -393,9 +396,12 @@ def test_application_designate_bind_upgrade_plan_ussuri_to_victoria(model):
             coro=model.wait_for_active_idle(300, apps=[app.name]),
         ),
         PostUpgradeStep(
-            description=f"Check if the workload of '{app.name}' has been upgraded",
+            description=(
+                f"Check if the workload of '{app.name}' has been upgraded on units: "
+                f"{', '.join([unit for unit in app.units.keys()])}"
+            ),
             parallel=False,
-            coro=app._check_upgrade(target),
+            coro=app._verify_workload_upgrade(target, app.units.values()),
         ),
     ]
 

--- a/tests/unit/apps/test_core.py
+++ b/tests/unit/apps/test_core.py
@@ -208,7 +208,7 @@ def test_application_unknown_source(source_value, model):
 
 
 @pytest.mark.asyncio
-async def test_application_check_upgrade(model):
+async def test_application_verify_workload_upgrade(model):
     """Test Kyestone application check successful upgrade."""
     target = OpenStackRelease("victoria")
     machines = {"0": MagicMock(spec_set=COUMachine)}
@@ -245,11 +245,11 @@ async def test_application_check_upgrade(model):
     mock_status.return_value.applications = {"keystone": mock_app_status}
     model.get_status = mock_status
 
-    await app._check_upgrade(target)
+    assert await app._verify_workload_upgrade(target, app.units.values()) is None
 
 
 @pytest.mark.asyncio
-async def test_application_check_upgrade_fail(model):
+async def test_application_verify_workload_upgrade_fail(model):
     """Test Kyestone application check unsuccessful upgrade."""
     target = OpenStackRelease("victoria")
     exp_msg = "Cannot upgrade units 'keystone/0' to victoria."
@@ -288,7 +288,7 @@ async def test_application_check_upgrade_fail(model):
     model.get_status = mock_status
 
     with pytest.raises(ApplicationError, match=exp_msg):
-        await app._check_upgrade(target)
+        await app._verify_workload_upgrade(target, app.units.values())
 
 
 def test_upgrade_plan_ussuri_to_victoria(model):
@@ -367,9 +367,12 @@ def test_upgrade_plan_ussuri_to_victoria(model):
             coro=model.wait_for_active_idle(1800, apps=None),
         ),
         PostUpgradeStep(
-            description=f"Check if the workload of '{app.name}' has been upgraded",
+            description=(
+                f"Check if the workload of '{app.name}' has been upgraded on units: "
+                f"{', '.join([unit for unit in app.units.keys()])}"
+            ),
             parallel=False,
-            coro=app._check_upgrade(target),
+            coro=app._verify_workload_upgrade(target, app.units.values()),
         ),
     ]
     add_steps(expected_plan, upgrade_steps)
@@ -454,9 +457,12 @@ def test_upgrade_plan_ussuri_to_victoria_ch_migration(model):
             coro=model.wait_for_active_idle(1800, apps=None),
         ),
         PostUpgradeStep(
-            description=f"Check if the workload of '{app.name}' has been upgraded",
+            description=(
+                f"Check if the workload of '{app.name}' has been upgraded on units: "
+                f"{', '.join([unit for unit in app.units.keys()])}"
+            ),
             parallel=False,
-            coro=app._check_upgrade(target),
+            coro=app._verify_workload_upgrade(target, app.units.values()),
         ),
     ]
     add_steps(expected_plan, upgrade_steps)
@@ -535,9 +541,12 @@ def test_upgrade_plan_channel_on_next_os_release(model):
             coro=model.wait_for_active_idle(1800, apps=None),
         ),
         PostUpgradeStep(
-            description=f"Check if the workload of '{app.name}' has been upgraded",
+            description=(
+                f"Check if the workload of '{app.name}' has been upgraded on units: "
+                f"{', '.join([unit for unit in app.units.keys()])}"
+            ),
             parallel=False,
-            coro=app._check_upgrade(target),
+            coro=app._verify_workload_upgrade(target, app.units.values()),
         ),
     ]
     add_steps(expected_plan, upgrade_steps)
@@ -615,9 +624,12 @@ def test_upgrade_plan_origin_already_on_next_openstack_release(model):
             coro=model.wait_for_active_idle(1800, apps=None),
         ),
         PostUpgradeStep(
-            description=f"Check if the workload of '{app.name}' has been upgraded",
+            description=(
+                f"Check if the workload of '{app.name}' has been upgraded on units: "
+                f"{', '.join([unit for unit in app.units.keys()])}"
+            ),
             parallel=False,
-            coro=app._check_upgrade(target),
+            coro=app._verify_workload_upgrade(target, app.units.values()),
         ),
     ]
     add_steps(expected_plan, upgrade_steps)
@@ -735,9 +747,12 @@ def test_upgrade_plan_application_already_disable_action_managed(model):
             coro=model.wait_for_active_idle(1800, apps=None),
         ),
         PostUpgradeStep(
-            description=f"Check if the workload of '{app.name}' has been upgraded",
+            description=(
+                f"Check if the workload of '{app.name}' has been upgraded on units: "
+                f"{', '.join([unit for unit in app.units.keys()])}"
+            ),
             parallel=False,
-            coro=app._check_upgrade(target),
+            coro=app._verify_workload_upgrade(target, app.units.values()),
         ),
     ]
     add_steps(expected_plan, upgrade_steps)

--- a/tests/unit/steps/test_steps_plan.py
+++ b/tests/unit/steps/test_steps_plan.py
@@ -107,9 +107,12 @@ def generate_expected_upgrade_plan_principal(app, target, model):
         ),
         wait_step,
         PostUpgradeStep(
-            description=f"Check if the workload of '{app.name}' has been upgraded",
+            description=(
+                f"Check if the workload of '{app.name}' has been upgraded on units: "
+                f"{', '.join([unit for unit in app.units.keys()])}"
+            ),
             parallel=False,
-            coro=app._check_upgrade(target),
+            coro=app._verify_workload_upgrade(target, app.units.values()),
         ),
     ]
     add_steps(expected_plan, upgrade_steps)


### PR DESCRIPTION
- changed name from _check_upgrade to _get_reached_expected_target_step
- description shows which units are going to be checked if workload got upgraded