### PR TITLE
drop `--hostname` from CLI

### DIFF
--- a/cou/commands.py
+++ b/cou/commands.py
@@ -176,16 +176,6 @@ def get_dataplane_common_opts_parser() -> argparse.ArgumentParser:
         type=str,
     )
     dp_upgrade_group.add_argument(
-        "--hostname",
-        "-n",
-        help="Specify machine hostnames(s) to upgrade.\nThis option accepts a single hostname as "
-        "well as a stringified comma-separated list of hostnames,\nand can be repeated multiple "
-        "times.",
-        action=SplitArgs,
-        dest="hostnames",
-        type=str,
-    )
-    dp_upgrade_group.add_argument(
         "--availability-zone",
         "--az",
         help="Specify availability zone(s) to upgrade.\nThis option accepts a single "
@@ -377,7 +367,6 @@ class CLIargs:
     upgrade_group: Optional[str] = None
     subcommand: Optional[str] = None  # for help option
     machines: Optional[set[str]] = None
-    hostnames: Optional[set[str]] = None
     availability_zones: Optional[set[str]] = None
 
     @property

--- a/cou/steps/plan.py
+++ b/cou/steps/plan.py
@@ -186,9 +186,6 @@ def verify_data_plane_cli_input(args: CLIargs, analysis_result: Analysis) -> Non
     if cli_machines := args.machines:
         verify_data_plane_cli_machines(cli_machines, analysis_result)
 
-    elif cli_hostnames := args.hostnames:
-        verify_data_plane_cli_hostnames(cli_hostnames, analysis_result)
-
     elif cli_azs := args.availability_zones:
         verify_data_plane_cli_azs(cli_azs, analysis_result)
 
@@ -206,27 +203,6 @@ def verify_data_plane_cli_machines(cli_machines: set[str], analysis_result: Anal
         data_plane_options=set(analysis_result.data_plane_machines.keys()),
         cli_input=cli_machines,
         parameter_type="Machine(s)",
-    )
-
-
-def verify_data_plane_cli_hostnames(cli_hostnames: set[str], analysis_result: Analysis) -> None:
-    """Verify if the hostnames passed from the CLI are valid.
-
-    :param cli_hostnames: Hostnames passed to the CLI as arguments
-    :type cli_hostnames: set[str]
-    :param analysis_result: Analysis result
-    :type analysis_result: Analysis
-    """
-    all_hostnames = {machine.hostname for machine in analysis_result.machines.values()}
-    data_plane_hostnames = {
-        machine.hostname for machine in analysis_result.data_plane_machines.values()
-    }
-
-    verify_data_plane_membership(
-        all_options=all_hostnames,
-        data_plane_options=data_plane_hostnames,
-        cli_input=cli_hostnames,
-        parameter_type="Hostname(s)",
     )
 
 
@@ -275,7 +251,7 @@ def verify_data_plane_membership(
     :type data_plane_options: set[str]
     :param cli_input: The input that come from the cli
     :type cli_input: set[str]
-    :param parameter_type: Type of the parameter passed (az, hostname or machine).
+    :param parameter_type: Type of the parameter passed (az or machine).
     :type parameter_type: str
     :raises DataPlaneMachineFilterError: When the value passed from the user is not sane.
     """
@@ -396,9 +372,6 @@ async def filter_hypervisors_machines(
 
     if cli_machines := args.machines:
         return [machine for machine in hypervisors_machines if machine.machine_id in cli_machines]
-
-    if cli_hostnames := args.hostnames:
-        return [machine for machine in hypervisors_machines if machine.hostname in cli_hostnames]
 
     if cli_azs := args.availability_zones:
         return [machine for machine in hypervisors_machines if machine.az in cli_azs]

--- a/cou/utils/juju_utils.py
+++ b/cou/utils/juju_utils.py
@@ -138,7 +138,6 @@ class COUMachine:
     """Representation of a juju machine."""
 
     machine_id: str
-    hostname: str
     az: Optional[str] = None  # simple deployments may not have azs
 
     def __repr__(self) -> str:
@@ -411,7 +410,6 @@ class COUModel:
         return {
             machine.id: COUMachine(
                 machine_id=machine.id,
-                hostname=machine.hostname,
                 az=machine.hardware_characteristics.get("availability-zone"),
             )
             for machine in model.machines.values()

--- a/tests/unit/steps/test_hypervisor.py
+++ b/tests/unit/steps/test_hypervisor.py
@@ -36,12 +36,12 @@ def test_azs():
     test_unit = COUUnit("my-unit", MagicMock(spec_set=COUMachine)(), "")
 
     # test accessing parts of AZs
-    assert azs["my-app"].name == "my-app"
-    assert azs["my-app"].app_units["my-app"] == []
+    assert azs["my-az"].name == "my-az"
+    assert azs["my-az"].app_units["my-app"] == []
 
     # append unit to the HypervisorGroup
-    azs["my-app"].app_units["my-app"].append(test_unit)
-    assert azs["my-app"].app_units["my-app"] == [test_unit]
+    azs["my-az"].app_units["my-app"].append(test_unit)
+    assert azs["my-az"].app_units["my-app"] == [test_unit]
 
 
 def test_hypervisor_azs_grouping():
@@ -76,7 +76,7 @@ def test_hypervisor_azs_grouping():
     5        started  10.10.10.6   host5          ubuntu@22.04  az2 Running
     ```
     """
-    machines = {f"{i}": COUMachine(f"{i}", f"host{i}", f"az{i//2}") for i in range(6)}
+    machines = {f"{i}": COUMachine(f"{i}", f"az{i//2}") for i in range(6)}
     units = {
         # app1
         "app1/0": COUUnit("app1/0", machines["0"], ""),

--- a/tests/unit/steps/test_steps_analyze.py
+++ b/tests/unit/steps/test_steps_analyze.py
@@ -413,7 +413,7 @@ def _app(name, units):
 
 def _unit(machine_id):
     unit = MagicMock(spec_set=COUUnit).return_value
-    unit.machine = COUMachine(machine_id, "juju-efc45", "zone-1")
+    unit.machine = COUMachine(machine_id, "zone-1")
     return unit
 
 

--- a/tests/unit/steps/test_steps_plan.py
+++ b/tests/unit/steps/test_steps_plan.py
@@ -538,22 +538,18 @@ def test_analysis_not_print_warn_manually_upgrade(mock_print, model):
 
 
 @patch("cou.steps.plan.verify_data_plane_cli_azs")
-@patch("cou.steps.plan.verify_data_plane_cli_hostnames")
 @patch("cou.steps.plan.verify_data_plane_cli_machines")
 def test_verify_data_plane_cli_no_input(
     mock_verify_machines,
-    mock_verify_hostnames,
     mock_verify_azs,
     cli_args,
 ):
     cli_args.machines = None
-    cli_args.hostnames = None
     cli_args.availability_zones = None
 
     assert cou_plan.verify_data_plane_cli_input(cli_args, MagicMock(spec_set=Analysis)()) is None
 
     mock_verify_machines.assert_not_called()
-    mock_verify_hostnames.assert_not_called()
     mock_verify_azs.assert_not_called()
 
 
@@ -567,15 +563,8 @@ def test_verify_data_plane_cli_no_input(
     ],
 )
 @patch("cou.steps.plan.verify_data_plane_cli_azs")
-@patch("cou.steps.plan.verify_data_plane_cli_hostnames")
-def test_verify_data_plane_cli_input_machines(
-    mock_verify_hostnames,
-    mock_verify_azs,
-    cli_machines,
-    cli_args,
-):
+def test_verify_data_plane_cli_input_machines(mock_verify_azs, cli_machines, cli_args):
     cli_args.machines = cli_machines
-    cli_args.hostnames = None
     cli_args.availability_zones = None
     analysis_result = MagicMock(spec_set=Analysis)()
     analysis_result.data_plane_machines = analysis_result.machines = {
@@ -584,44 +573,22 @@ def test_verify_data_plane_cli_input_machines(
 
     assert cou_plan.verify_data_plane_cli_input(cli_args, analysis_result) is None
 
-    mock_verify_hostnames.assert_not_called()
     mock_verify_azs.assert_not_called()
 
 
-@patch("cou.steps.plan.verify_data_plane_cli_azs")
 @patch("cou.steps.plan.verify_data_plane_cli_machines")
-def test_verify_data_plane_cli_input_hostnames(mock_verify_machines, mock_verify_azs, cli_args):
-    hostname = "test-host-machine"
-    machine = MagicMock(spec_set=COUMachine)()
-    machine.hostname = hostname
-    analysis_result = MagicMock(spec_set=Analysis)()
-    analysis_result.data_plane_machines = analysis_result.machines = {"0": machine}
-    cli_args.machines = None
-    cli_args.hostnames = {hostname}
-    cli_args.availability_zones = None
-
-    assert cou_plan.verify_data_plane_cli_input(cli_args, analysis_result) is None
-
-    mock_verify_machines.assert_not_called()
-    mock_verify_azs.assert_not_called()
-
-
-@patch("cou.steps.plan.verify_data_plane_cli_hostnames")
-@patch("cou.steps.plan.verify_data_plane_cli_machines")
-def test_verify_data_plane_cli_input_azs(mock_verify_machines, mock_verify_hostnames, cli_args):
+def test_verify_data_plane_cli_input_azs(mock_verify_machines, cli_args):
     az = "test-az-0"
     machine = MagicMock(spec_set=COUMachine)()
     machine.az = az
     analysis_result = MagicMock(spec_set=Analysis)()
     analysis_result.data_plane_machines = analysis_result.machines = {"0": machine}
     cli_args.machines = None
-    cli_args.hostnames = None
     cli_args.availability_zones = {az}
 
     assert cou_plan.verify_data_plane_cli_input(cli_args, analysis_result) is None
 
     mock_verify_machines.assert_not_called()
-    mock_verify_hostnames.assert_not_called()
 
 
 @pytest.mark.parametrize(
@@ -641,27 +608,6 @@ def test_verify_data_plane_cli_machines_raise(cli_machines, exp_error_msg):
 
     with pytest.raises(DataPlaneMachineFilterError, match=exp_error_msg):
         cou_plan.verify_data_plane_cli_machines(cli_machines, analysis_result)
-
-
-@pytest.mark.parametrize(
-    "cli_hostnames, exp_error_msg",
-    [
-        ({"juju-c307f8-1"}, r"Hostname.*are not considered as data-plane."),
-        ({"juju-not-existing"}, r"Hostname.*don't exist."),
-    ],
-)
-def test_verify_data_plane_cli_hostname_raise(cli_hostnames, exp_error_msg):
-    machine0 = MagicMock(spec_set=COUMachine)()
-    machine0.hostname = "juju-c307f8-0"
-    machine1 = MagicMock(spec_set=COUMachine)()
-    machine1.hostname = "juju-c307f8-1"
-    analysis_result = MagicMock(spec_set=Analysis)()
-    analysis_result.machines = {"0": machine0, "1": machine1}
-    analysis_result.data_plane_machines = {"0": machine0}
-    analysis_result.control_plane_machines = {"1": machine1}
-
-    with pytest.raises(DataPlaneMachineFilterError, match=exp_error_msg):
-        cou_plan.verify_data_plane_cli_hostnames(cli_hostnames, analysis_result)
 
 
 @pytest.mark.parametrize(
@@ -692,7 +638,6 @@ def test_verify_data_plane_cli_azs_raise_cannot_find():
     mock_machine = MagicMock()
     mock_machine.az = None
     mock_machine.id = "1"
-    mock_machine.hostname = "juju-5e8cf8-1"
 
     mock_analyze.machines = {"1": mock_machine}
     mock_analyze.data_plane_machines = {"1": mock_machine}
@@ -701,41 +646,27 @@ def test_verify_data_plane_cli_azs_raise_cannot_find():
 
 
 @pytest.mark.parametrize(
-    "force, cli_machines, cli_hostnames, cli_azs, expected_machines",
+    "force, cli_machines, cli_azs, expected_machines",
     [
         # machines input
-        (False, {"0", "1", "2"}, None, None, {"0", "1"}),
-        (False, {"2"}, None, None, set()),
-        (False, {"0", "1"}, None, None, {"0", "1"}),
-        (False, {"0"}, None, None, {"0"}),
-        (True, {"0", "1", "2"}, None, None, {"0", "1", "2"}),
-        (True, {"2"}, None, None, {"2"}),
-        (True, {"0"}, None, None, {"0"}),
-        # hostnames input
-        (False, None, {"juju-c307f8-0", "juju-c307f8-1", "juju-c307f8-2"}, None, {"0", "1"}),
-        (False, None, {"juju-c307f8-2"}, None, set()),
-        (False, None, {"juju-c307f8-0", "juju-c307f8-1"}, None, {"0", "1"}),
-        (False, None, {"juju-c307f8-0"}, None, {"0"}),
-        (
-            True,
-            None,
-            {"juju-c307f8-0", "juju-c307f8-1", "juju-c307f8-2"},
-            None,
-            {"0", "1", "2"},
-        ),
-        (True, None, {"juju-c307f8-2"}, None, {"2"}),
-        (True, None, {"juju-c307f8-0"}, None, {"0"}),
+        (False, {"0", "1", "2"}, None, {"0", "1"}),
+        (False, {"2"}, None, set()),
+        (False, {"0", "1"}, None, {"0", "1"}),
+        (False, {"0"}, None, {"0"}),
+        (True, {"0", "1", "2"}, None, {"0", "1", "2"}),
+        (True, {"2"}, None, {"2"}),
+        (True, {"0"}, None, {"0"}),
         # az input
-        (False, None, None, {"zone-1", "zone-2", "zone-3"}, {"0", "1"}),
-        (False, None, None, {"zone-3"}, set()),
-        (False, None, None, {"zone-1", "zone-2"}, {"0", "1"}),
-        (False, None, None, {"zone-1"}, {"0"}),
-        (True, None, None, {"zone-1", "zone-2", "zone-3"}, {"0", "1", "2"}),
-        (True, None, None, {"zone-3"}, {"2"}),
-        (True, None, None, {"zone-1"}, {"0"}),
+        (False, None, {"zone-1", "zone-2", "zone-3"}, {"0", "1"}),
+        (False, None, {"zone-3"}, set()),
+        (False, None, {"zone-1", "zone-2"}, {"0", "1"}),
+        (False, None, {"zone-1"}, {"0"}),
+        (True, None, {"zone-1", "zone-2", "zone-3"}, {"0", "1", "2"}),
+        (True, None, {"zone-3"}, {"2"}),
+        (True, None, {"zone-1"}, {"0"}),
         # no input
-        (False, None, None, None, {"0", "1"}),
-        (True, None, None, None, {"0", "1", "2"}),
+        (False, None, None, {"0", "1"}),
+        (True, None, None, {"0", "1", "2"}),
     ],
 )
 @pytest.mark.asyncio
@@ -744,18 +675,16 @@ async def test_filter_hypervisors_machines(
     mock_hypervisors_machines,
     force,
     cli_machines,
-    cli_hostnames,
     cli_azs,
     expected_machines,
     cli_args,
 ):
 
     empty_hypervisors_machines = {
-        COUMachine(str(machine_id), f"juju-c307f8-{machine_id}", f"zone-{machine_id + 1}")
-        for machine_id in range(2)
+        COUMachine(str(machine_id), f"zone-{machine_id + 1}") for machine_id in range(2)
     }
     # assuming that machine-2 has some VMs running
-    non_empty_hypervisor_machine = COUMachine("2", "juju-c307f8-2", "zone-3")
+    non_empty_hypervisor_machine = COUMachine("2", "zone-3")
 
     upgradable_hypervisors = empty_hypervisors_machines
     if force:
@@ -764,7 +693,6 @@ async def test_filter_hypervisors_machines(
     mock_hypervisors_machines.return_value = upgradable_hypervisors
 
     cli_args.machines = cli_machines
-    cli_args.hostnames = cli_hostnames
     cli_args.availability_zones = cli_azs
     cli_args.force = force
 
@@ -799,7 +727,7 @@ async def test_filter_hypervisors_machines(
 async def test_get_upgradable_hypervisors_machines(
     mock_empty_hypervisors, cli_force, empty_hypervisors, expected_result
 ):
-    machines = {f"{i}": COUMachine(f"{i}", f"juju-c307f8-{i}", f"zone-{i + 1}") for i in range(3)}
+    machines = {f"{i}": COUMachine(f"{i}", f"zone-{i + 1}") for i in range(3)}
     nova_compute = MagicMock(spec_set=OpenStackApplication)()
     nova_compute.charm = "nova-compute"
     nova_compute.units = {

--- a/tests/unit/test_commands.py
+++ b/tests/unit/test_commands.py
@@ -146,7 +146,6 @@ def test_parse_args_quiet_verbose_exclusive(args):
                 backup=True,
                 force=False,
                 machines=None,
-                hostnames=None,
                 availability_zones=None,
                 **{"upgrade_group": "data-plane"}
             ),
@@ -161,7 +160,6 @@ def test_parse_args_quiet_verbose_exclusive(args):
                 backup=True,
                 force=True,
                 machines=None,
-                hostnames=None,
                 availability_zones=None,
                 **{"upgrade_group": "data-plane"}
             ),
@@ -188,7 +186,6 @@ def test_parse_args_quiet_verbose_exclusive(args):
                 backup=True,
                 force=False,
                 machines={"1", "2", "3"},
-                hostnames=None,
                 availability_zones=None,
                 **{"upgrade_group": "data-plane"}
             ),
@@ -203,7 +200,6 @@ def test_parse_args_quiet_verbose_exclusive(args):
                 backup=True,
                 force=True,
                 machines={"1", "2", "3"},
-                hostnames=None,
                 availability_zones=None,
                 **{"upgrade_group": "data-plane"}
             ),
@@ -218,7 +214,6 @@ def test_parse_args_quiet_verbose_exclusive(args):
                 backup=True,
                 force=False,
                 machines=None,
-                hostnames=None,
                 availability_zones={"1", "2", "3"},
                 **{"upgrade_group": "data-plane"}
             ),
@@ -233,54 +228,7 @@ def test_parse_args_quiet_verbose_exclusive(args):
                 backup=True,
                 force=True,
                 machines=None,
-                hostnames=None,
                 availability_zones={"1", "2", "3"},
-                **{"upgrade_group": "data-plane"}
-            ),
-        ),
-        (
-            ["plan", "data-plane", "--hostname=1", "-n=2,3"],
-            CLIargs(
-                command="plan",
-                model_name=None,
-                verbosity=0,
-                quiet=False,
-                backup=True,
-                force=False,
-                machines=None,
-                hostnames={"1", "2", "3"},
-                availability_zones=None,
-                **{"upgrade_group": "data-plane"}
-            ),
-        ),
-        (
-            ["plan", "data-plane", "--hostname=1", "--force", "-n=2,3"],
-            CLIargs(
-                command="plan",
-                model_name=None,
-                verbosity=0,
-                quiet=False,
-                backup=True,
-                force=True,
-                machines=None,
-                hostnames={"1", "2", "3"},
-                availability_zones=None,
-                **{"upgrade_group": "data-plane"}
-            ),
-        ),
-        (
-            # repetitive machine 3
-            ["plan", "data-plane", "--hostname=1,2,3", "--force", "-n=3,4"],
-            CLIargs(
-                command="plan",
-                model_name=None,
-                verbosity=0,
-                quiet=False,
-                backup=True,
-                force=True,
-                machines=None,
-                hostnames={"1", "2", "3", "4"},
-                availability_zones=None,
                 **{"upgrade_group": "data-plane"}
             ),
         ),
@@ -398,7 +346,6 @@ def test_parse_args_plan(args, expected_CLIargs):
                 backup=True,
                 force=False,
                 machines=None,
-                hostnames=None,
                 availability_zones=None,
                 **{"upgrade_group": "data-plane"}
             ),
@@ -416,7 +363,6 @@ def test_parse_args_plan(args, expected_CLIargs):
                 backup=True,
                 force=True,
                 machines=None,
-                hostnames=None,
                 availability_zones=None,
                 **{"upgrade_group": "data-plane"}
             ),
@@ -432,7 +378,6 @@ def test_parse_args_plan(args, expected_CLIargs):
                 backup=False,
                 force=False,
                 machines=None,
-                hostnames=None,
                 availability_zones=None,
                 **{"upgrade_group": "data-plane"}
             ),
@@ -448,7 +393,6 @@ def test_parse_args_plan(args, expected_CLIargs):
                 backup=True,
                 force=False,
                 machines=None,
-                hostnames=None,
                 availability_zones=None,
                 **{"upgrade_group": "data-plane"}
             ),
@@ -490,7 +434,6 @@ def test_parse_args_plan(args, expected_CLIargs):
                 backup=True,
                 force=False,
                 machines={"1", "2", "3"},
-                hostnames=None,
                 availability_zones=None,
                 **{"upgrade_group": "data-plane"}
             ),
@@ -506,7 +449,6 @@ def test_parse_args_plan(args, expected_CLIargs):
                 backup=True,
                 force=True,
                 machines={"1", "2", "3"},
-                hostnames=None,
                 availability_zones=None,
                 **{"upgrade_group": "data-plane"}
             ),
@@ -522,7 +464,6 @@ def test_parse_args_plan(args, expected_CLIargs):
                 backup=True,
                 force=False,
                 machines=None,
-                hostnames=None,
                 availability_zones={"1", "2", "3"},
                 **{"upgrade_group": "data-plane"}
             ),
@@ -538,7 +479,6 @@ def test_parse_args_plan(args, expected_CLIargs):
                 backup=True,
                 force=False,
                 machines=None,
-                hostnames=None,
                 availability_zones={"1", "2", "3"},
                 **{"upgrade_group": "data-plane"}
             ),
@@ -554,112 +494,7 @@ def test_parse_args_plan(args, expected_CLIargs):
                 backup=True,
                 force=True,
                 machines=None,
-                hostnames=None,
                 availability_zones={"1", "2", "3"},
-                **{"upgrade_group": "data-plane"}
-            ),
-        ),
-        (
-            ["upgrade", "data-plane", "--hostname=1", "-n=2,3"],
-            CLIargs(
-                command="upgrade",
-                model_name=None,
-                verbosity=0,
-                quiet=False,
-                auto_approve=False,
-                backup=True,
-                force=False,
-                machines=None,
-                hostnames={"1", "2", "3"},
-                availability_zones=None,
-                **{"upgrade_group": "data-plane"}
-            ),
-        ),
-        (
-            ["upgrade", "data-plane", "--hostname=1", "--force", "-n=2,3"],
-            CLIargs(
-                command="upgrade",
-                model_name=None,
-                verbosity=0,
-                quiet=False,
-                auto_approve=False,
-                backup=True,
-                force=True,
-                machines=None,
-                hostnames={"1", "2", "3"},
-                availability_zones=None,
-                **{"upgrade_group": "data-plane"}
-            ),
-        ),
-        (
-            ["upgrade", "data-plane", "--auto-approve", "--hostname=1", "-n=2,3"],
-            CLIargs(
-                command="upgrade",
-                model_name=None,
-                verbosity=0,
-                quiet=False,
-                auto_approve=True,
-                backup=True,
-                force=False,
-                machines=None,
-                hostnames={"1", "2", "3"},
-                availability_zones=None,
-                **{"upgrade_group": "data-plane"}
-            ),
-        ),
-        (
-            ["upgrade", "--auto-approve", "data-plane", "--hostname=1", "-n=2,3"],
-            CLIargs(
-                command="upgrade",
-                model_name=None,
-                verbosity=0,
-                quiet=False,
-                auto_approve=True,
-                backup=True,
-                force=False,
-                machines=None,
-                hostnames={"1", "2", "3"},
-                availability_zones=None,
-                **{"upgrade_group": "data-plane"}
-            ),
-        ),
-        (
-            ["upgrade", "data-plane", "--auto-approve", "--force", "--hostname=1", "-n=2,3"],
-            CLIargs(
-                command="upgrade",
-                model_name=None,
-                verbosity=0,
-                quiet=False,
-                auto_approve=True,
-                backup=True,
-                force=True,
-                machines=None,
-                hostnames={"1", "2", "3"},
-                availability_zones=None,
-                **{"upgrade_group": "data-plane"}
-            ),
-        ),
-        (
-            # repetitive machine 3
-            [
-                "upgrade",
-                "data-plane",
-                "--auto-approve",
-                "--force",
-                "--hostname=1, 2, 3",
-                "-n=3, 4",
-            ],
-            CLIargs(
-                command="upgrade",
-                model_name=None,
-                verbosity=0,
-                quiet=False,
-                auto_approve=True,
-                backup=True,
-                force=True,
-                machines=None,
-                hostnames={"1", "2", "3", "4"},
-                availability_zones=None,
                 **{"upgrade_group": "data-plane"}
             ),
         ),
@@ -676,7 +511,6 @@ def test_parse_args_upgrade(args, expected_CLIargs):
     "args",
     [
         ["upgrade", "data-plane", "--machine 1", "--az 2"],
-        ["upgrade", "data-plane", "--hostname 1", "-m 2"],
         ["upgrade", "data-plane", "--availability-zone 1", "-n 2"],
         ["upgrade", "data-plane", "--machine 1", "-n 2"],
         ["upgrade", "data-plane", "--az 1", "-m 2"],

--- a/tests/unit/test_commands.py
+++ b/tests/unit/test_commands.py
@@ -232,6 +232,21 @@ def test_parse_args_quiet_verbose_exclusive(args):
                 **{"upgrade_group": "data-plane"}
             ),
         ),
+        (
+            # repetitive machine 3
+            ["plan", "data-plane", "--machine=1,2,3", "--force", "-m=3,4"],
+            CLIargs(
+                command="plan",
+                model_name=None,
+                verbosity=0,
+                quiet=False,
+                backup=True,
+                force=True,
+                machines={"1", "2", "3", "4"},
+                availability_zones=None,
+                **{"upgrade_group": "data-plane"}
+            ),
+        ),
     ],
 )
 def test_parse_args_plan(args, expected_CLIargs):
@@ -498,6 +513,29 @@ def test_parse_args_plan(args, expected_CLIargs):
                 **{"upgrade_group": "data-plane"}
             ),
         ),
+        (
+            # repetitive machine 3
+            [
+                "upgrade",
+                "data-plane",
+                "--auto-approve",
+                "--force",
+                "--machine=1, 2, 3",
+                "-m=3, 4",
+            ],
+            CLIargs(
+                command="upgrade",
+                model_name=None,
+                verbosity=0,
+                quiet=False,
+                auto_approve=True,
+                backup=True,
+                force=True,
+                machines={"1", "2", "3", "4"},
+                availability_zones=None,
+                **{"upgrade_group": "data-plane"}
+            ),
+        ),
     ],
 )
 def test_parse_args_upgrade(args, expected_CLIargs):
@@ -511,10 +549,7 @@ def test_parse_args_upgrade(args, expected_CLIargs):
     "args",
     [
         ["upgrade", "data-plane", "--machine 1", "--az 2"],
-        ["upgrade", "data-plane", "--availability-zone 1", "-n 2"],
-        ["upgrade", "data-plane", "--machine 1", "-n 2"],
         ["upgrade", "data-plane", "--az 1", "-m 2"],
-        ["upgrade", "data-plane", "-m 1", "-n 2"],
     ],
 )
 def test_parse_args_dataplane_exclusive_options(args):

--- a/tests/unit/utils/test_juju_utils.py
+++ b/tests/unit/utils/test_juju_utils.py
@@ -148,37 +148,29 @@ async def test_retry_failure():
 
 
 @pytest.mark.parametrize(
-    "machine_id, hostname, az",
+    "machine_id, az",
     [
         # one field different is considered another machine
-        ("0", "juju-c307f8-my_model-0", "zone-3"),
-        ("1", "juju-c307f8-my_model-1", "zone-2"),
+        ("0", "zone-3"),
+        ("1", "zone-2"),
     ],
 )
-def test_machine_not_eq(machine_id, hostname, az):
-    machine_0 = juju_utils.COUMachine(
-        machine_id="0", hostname="juju-c307f8-my_model-0", az="zone-1"
-    )
-    machine_1 = juju_utils.COUMachine(machine_id=machine_id, hostname=hostname, az=az)
+def test_machine_not_eq(machine_id, az):
+    machine_0 = juju_utils.COUMachine(machine_id="0", az="zone-1")
+    machine_1 = juju_utils.COUMachine(machine_id=machine_id, az=az)
 
     assert machine_0 != machine_1
 
 
 def test_machine_eq():
-    machine_0 = juju_utils.COUMachine(
-        machine_id="0", hostname="juju-c307f8-my_model-0", az="zone-1"
-    )
-    machine_1 = juju_utils.COUMachine(
-        machine_id="0", hostname="juju-c307f8-my_model-0", az="zone-1"
-    )
+    machine_0 = juju_utils.COUMachine(machine_id="0", az="zone-1")
+    machine_1 = juju_utils.COUMachine(machine_id="0", az="zone-1")
 
     assert machine_0 == machine_1
 
 
 def test_machine_repr():
-    machine_0 = juju_utils.COUMachine(
-        machine_id="0", hostname="juju-c307f8-my_model-0", az="zone-1"
-    )
+    machine_0 = juju_utils.COUMachine(machine_id="0", az="zone-1")
     expected_repr = "Machine[0]"
     assert repr(machine_0) == expected_repr
 
@@ -602,13 +594,9 @@ async def test_coumodel_wait_for_active_idle_timeout(mock_get_supported_apps, mo
         (
             ["0", "1", "2"],
             {
-                "0": juju_utils.COUMachine("0", "juju-90e5ce-0", "zone-1"),
-                "1": juju_utils.COUMachine(
-                    "1",
-                    "juju-90e5ce-1",
-                    "zone-2",
-                ),
-                "2": juju_utils.COUMachine("2", "juju-90e5ce-2", "zone-3"),
+                "0": juju_utils.COUMachine("0", "zone-1"),
+                "1": juju_utils.COUMachine("1", "zone-2"),
+                "2": juju_utils.COUMachine("2", "zone-3"),
             },
         ),
     ],
@@ -630,7 +618,6 @@ def _generate_juju_machines_mock(machine_ids: list[str]):
     for machine_id in machine_ids:
         machine = MagicMock(set=JujuMachine)
         machine.id = machine_id
-        machine.hostname = f"juju-90e5ce-{machine_id}"
         machine.hardware_characteristics = {
             "arch": "amd64",
             "mem": 0,
@@ -691,9 +678,9 @@ async def test_get_applications(mock_get_machines, mock_get_status, mocked_model
         mocked_model.applications[app].get_config = AsyncMock()
 
     exp_machines = {
-        "0": juju_utils.COUMachine("0", "juju-90e5ce-0"),
-        "1": juju_utils.COUMachine("1", "juju-90e5ce-1"),
-        "2": juju_utils.COUMachine("2", "juju-90e5ce-2"),
+        "0": juju_utils.COUMachine("0"),
+        "1": juju_utils.COUMachine("1"),
+        "2": juju_utils.COUMachine("2"),
     }
     exp_units = {
         "app1": dict([_generate_unit_status("app1", i, f"{i}") for i in range(3)]),

--- a/tests/unit/utils/test_nova_compute.py
+++ b/tests/unit/utils/test_nova_compute.py
@@ -112,6 +112,7 @@ async def test_verify_empty_hypervisor_before_upgrade_ActionFailed(
     mock_logger.warning.assert_called_once()
 
 
+@pytest.mark.asyncio
 @patch("cou.utils.nova_compute.get_instance_count", return_value=0)
 async def test_verify_empty_hypervisor_before_upgrade(mock_instance_count, model):
     nova_unit = _mock_nova_unit(1)
@@ -121,7 +122,7 @@ async def test_verify_empty_hypervisor_before_upgrade(mock_instance_count, model
 def _mock_nova_unit(nova_unit):
     mock_nova_unit = MagicMock(spec_set=COUUnit(MagicMock(), MagicMock(), MagicMock()))
     mock_nova_unit.name = f"nova-compute/{nova_unit}"
-    nova_machine = COUMachine(str(nova_unit), f"juju-c307f8-{nova_unit}", f"zone-{nova_unit + 1}")
+    nova_machine = COUMachine(str(nova_unit), f"zone-{nova_unit + 1}")
     mock_nova_unit.machine = nova_machine
 
     return mock_nova_unit


### PR DESCRIPTION
After discussion, we agreed that this option is not needed, since it can be confusing which hostname the user meant.