### PR TITLE
fix zaza.model.run_on_unit

### DIFF
--- a/tests/functional/tests/model.py
+++ b/tests/functional/tests/model.py
@@ -58,7 +58,8 @@ class COUModelTest(unittest.TestCase):
         test_file = "test.txt"
         path = f"/tmp/{test_file}"
         exp_path = os.path.join(tmp_dir, test_file)
-        zaza.model.run_on_unit(unit_name=TESTED_UNIT, command=f"echo 'test' > {path}")
+        zaza.sync_wrapper(self.model.connect)()
+        zaza.sync_wrapper(self.model._model.units[TESTED_UNIT].run)(f"echo 'test' > {path}")
 
         zaza.sync_wrapper(self.model.scp_from_unit)(TESTED_UNIT, path, tmp_dir)
         self.assertTrue(os.path.exists(exp_path))


### PR DESCRIPTION
Fixing the functional tests running command on unit. 

Zaza add waiting for action result in [commit](https://github.com/openstack-charmers/zaza/commit/3e7b2a5ec74b2ada7a2c2286ef57b31f5c0eac53), which cause waiting forever. I reported an issue on zaza side, since that function previous supported running commands and now it supports only running actions.