### PR TITLE
Add check for enable-auto-restarts config option

### DIFF
--- a/cou/apps/base.py
+++ b/cou/apps/base.py
@@ -397,7 +397,10 @@ class OpenStackApplication(COUApplication):
         """
         self._check_application_target(target)
         self._check_auto_restarts()
-        logger.info("%s application met all the necessary prerequisites", self.name)
+        logger.info(
+            "%s application met all the necessary prerequisites to generate the upgrade plan",
+            self.name,
+        )
 
     def generate_upgrade_plan(
         self,
@@ -723,7 +726,7 @@ class OpenStackApplication(COUApplication):
     def _check_auto_restarts(self) -> None:
         """Check if enable-auto-restarts is enabled.
 
-        If the enable-auto-restart is not enabled, this check will raise an exception.
+        If the enable-auto-restart option is not enabled, this check will raise an exception.
 
         :raises ApplicationError: When enable-auto-restarts is not enabled.
         """
@@ -741,7 +744,7 @@ class OpenStackApplication(COUApplication):
             )
 
     def _check_application_target(self, target: OpenStackRelease) -> None:
-        """Check if application release is not lower or equal to target.
+        """Check if application release is not lower than or equal to target.
 
         :param target: OpenStack release as target to upgrade.
         :type target: OpenStackRelease
@@ -756,6 +759,6 @@ class OpenStackApplication(COUApplication):
 
         if self.current_os_release >= target and self.apt_source_codename >= target:
             raise HaltUpgradePlanGeneration(
-                f"Application '{self.name}' already configured for release equal or greater "
+                f"Application '{self.name}' already configured for release equal to or greater "
                 f"than {target}. Ignoring."
             )

--- a/cou/apps/base.py
+++ b/cou/apps/base.py
@@ -729,7 +729,7 @@ class OpenStackApplication(COUApplication):
             logger.debug("%s application has not enable-auto-restarts config option", self.name)
             return
 
-        if self.config.get("enable-auto-restarts") is False:
+        if self.config["enable-auto-restarts"].get("value") is False:
             raise HaltUpgradePlanGeneration(
                 f"It is not safe to continue upgrading '{self.name}' application when the "
                 "'enable-auto-restart' is disabled. Please enable it before running COU again."

--- a/cou/apps/base.py
+++ b/cou/apps/base.py
@@ -392,6 +392,8 @@ class OpenStackApplication(COUApplication):
 
         :param target: OpenStack release as target to upgrade.
         :type target: OpenStackRelease
+        :raises ApplicationError: When enable-auto-restarts is not enabled.
+        :raises HaltUpgradePlanGeneration: When the application halt the upgrade plan generation.
         """
         self._check_application_target(target)
         self._check_auto_restarts()
@@ -723,7 +725,7 @@ class OpenStackApplication(COUApplication):
 
         If the enable-auto-restart is not enabled, this check will raise an exception.
 
-        :raises HaltUpgradePlanGeneration: When enable-auto-restarts is not enabled.
+        :raises ApplicationError: When enable-auto-restarts is not enabled.
         """
         if "enable-auto-restarts" not in self.config:
             logger.debug(
@@ -732,7 +734,7 @@ class OpenStackApplication(COUApplication):
             return
 
         if self.config["enable-auto-restarts"].get("value") is False:
-            raise HaltUpgradePlanGeneration(
+            raise ApplicationError(
                 "COU does not currently support upgrading applications that disable service "
                 "restarts. Please enable charm option enable-auto-restart and rerun COU to "
                 f"upgrade the {self.name} application."

--- a/cou/apps/base.py
+++ b/cou/apps/base.py
@@ -726,13 +726,16 @@ class OpenStackApplication(COUApplication):
         :raises HaltUpgradePlanGeneration: When enable-auto-restarts is not enabled.
         """
         if "enable-auto-restarts" not in self.config:
-            logger.debug("%s application has not enable-auto-restarts config option", self.name)
+            logger.debug(
+                "%s application does not have an enable-auto-restarts config option", self.name
+            )
             return
 
         if self.config["enable-auto-restarts"].get("value") is False:
             raise HaltUpgradePlanGeneration(
-                f"It is not safe to continue upgrading '{self.name}' application when the "
-                "'enable-auto-restart' is disabled. Please enable it before running COU again."
+                "COU does not currently support upgrading applications that disable service "
+                "restarts. Please enable charm option enable-auto-restart and rerun COU to "
+                f"upgrade the {self.name} application."
             )
 
     def _check_application_target(self, target: OpenStackRelease) -> None:
@@ -743,7 +746,7 @@ class OpenStackApplication(COUApplication):
         :raises HaltUpgradePlanGeneration: When the application halt the upgrade plan generation.
         """
         logger.debug(
-            "%s application current os_relase is %s and apt source is %s",
+            "%s application current os_release is %s and apt source is %s",
             self.name,
             self.current_os_release,
             self.apt_source_codename,

--- a/tests/unit/apps/test_auxiliary.py
+++ b/tests/unit/apps/test_auxiliary.py
@@ -492,7 +492,7 @@ def test_auxiliary_raise_halt_upgrade(model):
     target = OpenStackRelease("victoria")
     charm = "rabbitmq-server"
     exp_msg = (
-        f"Application '{charm}' already configured for release equal or greater than {target}. "
+        f"Application '{charm}' already configured for release equal to or greater than {target}. "
         "Ignoring."
     )
     machines = {"0": MagicMock(spec_set=COUMachine)}

--- a/tests/unit/apps/test_base.py
+++ b/tests/unit/apps/test_base.py
@@ -300,8 +300,9 @@ def test_check_auto_restarts_error(_):
     """Test function to verify that enable-auto-restarts is disabled raising error."""
     app_name = "app"
     exp_error_msg = (
-        f"It is not safe to continue upgrading '{app_name}' application when the "
-        "'enable-auto-restart' is disabled. Please enable it before running COU again."
+        "COU does not currently support upgrading applications that disable service restarts. "
+        f"Please enable charm option enable-auto-restart and rerun COU to upgrade the {app_name} "
+        "application."
     )
     config = {"enable-auto-restarts": {"value": False}}
     app = OpenStackApplication(

--- a/tests/unit/apps/test_base.py
+++ b/tests/unit/apps/test_base.py
@@ -12,12 +12,12 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-from unittest.mock import MagicMock, call, patch
+from unittest.mock import MagicMock, PropertyMock, call, patch
 
 import pytest
 
 from cou.apps.base import OpenStackApplication
-from cou.exceptions import ApplicationError
+from cou.exceptions import ApplicationError, HaltUpgradePlanGeneration
 from cou.steps import UnitUpgradeStep, UpgradeStep
 from cou.utils.juju_utils import COUMachine, COUUnit
 from cou.utils.openstack import OpenStackRelease
@@ -281,3 +281,68 @@ def test_get_reached_expected_target_step(mock_workload_upgrade, units, model):
 
     app._get_reached_expected_target_step(target, units)
     mock_workload_upgrade.assert_has_calls(expected_calls)
+
+
+@patch("cou.apps.base.OpenStackApplication._verify_channel", return_value=None)
+def test_check_auto_restarts(_):
+    """Test function to verify that enable-auto-restarts is disabled."""
+    app_name = "app"
+    config = {}
+    app = OpenStackApplication(
+        app_name, "", app_name, "stable", config, {}, MagicMock(), "ch", "focal", [], {}, "1"
+    )
+
+    app._check_auto_restarts()
+
+
+@patch("cou.apps.base.OpenStackApplication._verify_channel", return_value=None)
+def test_check_auto_restarts_error(_):
+    """Test function to verify that enable-auto-restarts is disabled raising error."""
+    app_name = "app"
+    exp_error_msg = (
+        f"It is not safe to continue upgrading '{app_name}' application when the "
+        "'enable-auto-restart' is disabled. Please enable it before running COU again."
+    )
+    config = {"enable-auto-restarts": False}
+    app = OpenStackApplication(
+        app_name, "", app_name, "stable", config, {}, MagicMock(), "ch", "focal", [], {}, "1"
+    )
+
+    with pytest.raises(HaltUpgradePlanGeneration, match=exp_error_msg):
+        app._check_auto_restarts()
+
+
+@patch("cou.apps.base.OpenStackApplication._verify_channel", return_value=None)
+@patch("cou.apps.base.OpenStackApplication.apt_source_codename", new_callable=PropertyMock)
+@patch("cou.apps.base.OpenStackApplication.current_os_release", new_callable=PropertyMock)
+def test_check_application_target(current_os_release, apt_source_codename, _):
+    """Test function to verify target."""
+    target = OpenStackRelease("victoria")
+    release = OpenStackRelease("ussuri")
+    app_name = "app"
+    app = OpenStackApplication(
+        app_name, "", app_name, "stable", {}, {}, MagicMock(), "ch", "focal", [], {}, "1"
+    )
+    current_os_release.return_value = apt_source_codename.return_value = release
+
+    app._check_application_target(target)
+
+
+@patch("cou.apps.base.OpenStackApplication._verify_channel", return_value=None)
+@patch("cou.apps.base.OpenStackApplication.apt_source_codename", new_callable=PropertyMock)
+@patch("cou.apps.base.OpenStackApplication.current_os_release", new_callable=PropertyMock)
+def test_check_application_target_error(current_os_release, apt_source_codename, _):
+    """Test function to verify target raising error."""
+    target = OpenStackRelease("victoria")
+    app_name = "app"
+    exp_error_msg = (
+        f"Application '{app_name}' already configured for release equal or greater than {target}. "
+        "Ignoring."
+    )
+    app = OpenStackApplication(
+        app_name, "", app_name, "stable", {}, {}, MagicMock(), "ch", "focal", [], {}, "1"
+    )
+    current_os_release.return_value = apt_source_codename.return_value = target
+
+    with pytest.raises(HaltUpgradePlanGeneration, match=exp_error_msg):
+        app._check_application_target(target)

--- a/tests/unit/apps/test_base.py
+++ b/tests/unit/apps/test_base.py
@@ -309,7 +309,7 @@ def test_check_auto_restarts_error(_):
         app_name, "", app_name, "stable", config, {}, MagicMock(), "ch", "focal", [], {}, "1"
     )
 
-    with pytest.raises(HaltUpgradePlanGeneration, match=exp_error_msg):
+    with pytest.raises(ApplicationError, match=exp_error_msg):
         app._check_auto_restarts()
 
 

--- a/tests/unit/apps/test_base.py
+++ b/tests/unit/apps/test_base.py
@@ -303,7 +303,7 @@ def test_check_auto_restarts_error(_):
         f"It is not safe to continue upgrading '{app_name}' application when the "
         "'enable-auto-restart' is disabled. Please enable it before running COU again."
     )
-    config = {"enable-auto-restarts": False}
+    config = {"enable-auto-restarts": {"value": False}}
     app = OpenStackApplication(
         app_name, "", app_name, "stable", config, {}, MagicMock(), "ch", "focal", [], {}, "1"
     )

--- a/tests/unit/apps/test_base.py
+++ b/tests/unit/apps/test_base.py
@@ -283,11 +283,11 @@ def test_get_reached_expected_target_step(mock_workload_upgrade, units, model):
     mock_workload_upgrade.assert_has_calls(expected_calls)
 
 
+@pytest.mark.parametrize("config", ({}, {"enable-auto-restarts": {"value": True}}))
 @patch("cou.apps.base.OpenStackApplication._verify_channel", return_value=None)
-def test_check_auto_restarts(_):
+def test_check_auto_restarts(_, config):
     """Test function to verify that enable-auto-restarts is disabled."""
     app_name = "app"
-    config = {}
     app = OpenStackApplication(
         app_name, "", app_name, "stable", config, {}, MagicMock(), "ch", "focal", [], {}, "1"
     )
@@ -337,8 +337,8 @@ def test_check_application_target_error(current_os_release, apt_source_codename,
     target = OpenStackRelease("victoria")
     app_name = "app"
     exp_error_msg = (
-        f"Application '{app_name}' already configured for release equal or greater than {target}. "
-        "Ignoring."
+        f"Application '{app_name}' already configured for release equal to or greater than "
+        f"{target}. Ignoring."
     )
     app = OpenStackApplication(
         app_name, "", app_name, "stable", {}, {}, MagicMock(), "ch", "focal", [], {}, "1"

--- a/tests/unit/apps/test_core.py
+++ b/tests/unit/apps/test_core.py
@@ -641,7 +641,7 @@ def test_upgrade_plan_origin_already_on_next_openstack_release(model):
 def test_upgrade_plan_application_already_upgraded(model):
     """Test generate plan to upgrade Keystone from Victoria to Victoria."""
     exp_error_msg = (
-        "Application 'keystone' already configured for release equal or greater "
+        "Application 'keystone' already configured for release equal to or greater "
         "than victoria. Ignoring."
     )
     target = OpenStackRelease("victoria")

--- a/tests/unit/apps/test_subordinate.py
+++ b/tests/unit/apps/test_subordinate.py
@@ -36,7 +36,7 @@ def test_current_os_release(model):
         can_upgrade_to="ussuri/stable",
         charm="keystone-ldap",
         channel="ussuri/stable",
-        config={"source": {"value": "distro"}},
+        config={},
         machines=machines,
         model=model,
         origin="ch",
@@ -64,7 +64,7 @@ def test_generate_upgrade_plan(model):
         can_upgrade_to="ussuri/stable",
         charm="keystone-ldap",
         channel="ussuri/stable",
-        config={"source": {"value": "distro"}},
+        config={},
         machines=machines,
         model=model,
         origin="ch",
@@ -119,7 +119,7 @@ def test_channel_valid(model, channel):
         can_upgrade_to=channel,
         charm="keystone-ldap",
         channel=channel,
-        config={"source": {"value": "distro"}},
+        config={},
         machines=machines,
         model=model,
         origin="ch",
@@ -157,7 +157,7 @@ def test_channel_setter_invalid(model, channel):
             can_upgrade_to=channel,
             charm="keystone-ldap",
             channel=channel,
-            config={"source": {"value": "distro"}},
+            config={},
             machines=machines,
             model=model,
             origin="ch",
@@ -191,7 +191,7 @@ def test_generate_plan_ch_migration(model, channel):
         can_upgrade_to="wallaby/stable",
         charm="keystone-ldap",
         channel=f"ussuri/{channel}",
-        config={"source": {"value": "distro"}},
+        config={},
         machines=machines,
         model=model,
         origin="cs",
@@ -245,7 +245,7 @@ def test_generate_plan_from_to(model, from_os, to_os):
         can_upgrade_to=f"{to_os}/stable",
         charm="keystone-ldap",
         channel=f"{from_os}/stable",
-        config={"source": {"value": "distro"}},
+        config={},
         machines=machines,
         model=model,
         origin="ch",
@@ -282,6 +282,7 @@ def test_generate_plan_from_to(model, from_os, to_os):
 @pytest.mark.parametrize(
     "from_to",
     [
+        "ussuri",
         "victoria",
         "wallaby",
         "xena",
@@ -289,12 +290,7 @@ def test_generate_plan_from_to(model, from_os, to_os):
     ],
 )
 def test_generate_plan_in_same_channel(model, from_to):
-    """Test generate upgrade plan for OpenStackSubordinateApplication in same channel.
-
-    The version based on apt_source_codename is ussuri because the app series is central
-    and current os_release is defined as targeted version. Therefore using
-    from_to=ussuri, which will raise HaltUpgradePlanGeneratio, is not possible.
-    """
+    """Test generate upgrade plan for OpenStackSubordinateApplication in same channel."""
     target = OpenStackRelease(from_to)
     machines = {"0": MagicMock(spec_set=COUMachine)}
     app = OpenStackSubordinateApplication(
@@ -302,7 +298,7 @@ def test_generate_plan_in_same_channel(model, from_to):
         can_upgrade_to=f"{from_to}/stable",
         charm="keystone-ldap",
         channel=f"{from_to}/stable",
-        config={"source": {"value": "distro"}},
+        config={},
         machines=machines,
         model=model,
         origin="ch",

--- a/tests/unit/apps/test_subordinate.py
+++ b/tests/unit/apps/test_subordinate.py
@@ -282,15 +282,19 @@ def test_generate_plan_from_to(model, from_os, to_os):
 @pytest.mark.parametrize(
     "from_to",
     [
-        "ussuri",
         "victoria",
         "wallaby",
         "xena",
         "yoga",
     ],
 )
-def test_generate_plan_in_same_version(model, from_to):
-    """Test generate upgrade plan for OpenStackSubordinateApplication in same version."""
+def test_generate_plan_in_same_channel(model, from_to):
+    """Test generate upgrade plan for OpenStackSubordinateApplication in same channel.
+
+    The version based on apt_source_codename is ussuri because the app series is central
+    and current os_release is defined as targeted version. Because of this, we couldn't
+    use from_to=ussuri because it will raise HaltUpgradePlanGeneration.
+    """
     target = OpenStackRelease(from_to)
     machines = {"0": MagicMock(spec_set=COUMachine)}
     app = OpenStackSubordinateApplication(

--- a/tests/unit/apps/test_subordinate.py
+++ b/tests/unit/apps/test_subordinate.py
@@ -292,8 +292,8 @@ def test_generate_plan_in_same_channel(model, from_to):
     """Test generate upgrade plan for OpenStackSubordinateApplication in same channel.
 
     The version based on apt_source_codename is ussuri because the app series is central
-    and current os_release is defined as targeted version. Because of this, we couldn't
-    use from_to=ussuri because it will raise HaltUpgradePlanGeneration.
+    and current os_release is defined as targeted version. Therefore using
+    from_to=ussuri, which will raise HaltUpgradePlanGeneratio, is not possible.
     """
     target = OpenStackRelease(from_to)
     machines = {"0": MagicMock(spec_set=COUMachine)}


### PR DESCRIPTION
Add sanity checks for generating upgrade plan for application, where we can check all relevant pre-checks, before generating upgrade plan. Add _check_auto_restarts to verify that the `enable-auto-restarts` config option is disabled.