### PR TITLE
Add specific test for NovaCompute upgrade plan

### DIFF
--- a/cou/apps/core.py
+++ b/cou/apps/core.py
@@ -77,6 +77,7 @@ class NovaCompute(OpenStackApplication):
         """
         if not units:
             units = list(self.units.values())
+
         app_steps = super().upgrade_steps(target, units, force)
         unit_steps = self._get_units_upgrade_steps(units, force)
         return app_steps + unit_steps

--- a/tests/unit/apps/test_core.py
+++ b/tests/unit/apps/test_core.py
@@ -34,7 +34,7 @@ from cou.utils import nova_compute as nova_compute_utils
 from cou.utils.juju_utils import COUMachine, COUUnit
 from cou.utils.openstack import OpenStackRelease
 from tests.unit.apps.utils import add_steps
-from tests.unit.utils import assert_steps
+from tests.unit.utils import assert_steps, dedent_plan, generate_cou_machine
 
 
 def test_application_different_wl(model):
@@ -877,3 +877,125 @@ def _generate_nova_compute_app(model):
     )
 
     return app
+
+
+def test_nova_compute_upgrade_plan(model):
+    """Testing generating nova-compute upgrade plan."""
+    target = OpenStackRelease("victoria")
+    exp_plan = dedent_plan(
+        """
+    Upgrade plan for 'nova-compute' to victoria
+        Upgrade software packages of 'nova-compute' from the current APT repositories
+            Upgrade software packages on unit nova-compute/0
+            Upgrade software packages on unit nova-compute/1
+            Upgrade software packages on unit nova-compute/2
+        Refresh 'nova-compute' to the latest revision of 'ussuri/stable'
+        Change charm config of 'nova-compute' 'action-managed-upgrade' to True.
+        Upgrade 'nova-compute' to the new channel: 'victoria/stable'
+        Change charm config of 'nova-compute' 'source' to 'cloud:focal-victoria'
+        Upgrade plan for units: nova-compute/0, nova-compute/1, nova-compute/2
+            Upgrade plan for unit: nova-compute/0
+                Disable nova-compute scheduler from unit: 'nova-compute/0'.
+                Check if unit nova-compute/0 has no VMs running before upgrading.
+                ├── Pause the unit: 'nova-compute/0'.
+                ├── Upgrade the unit: 'nova-compute/0'.
+                ├── Resume the unit: 'nova-compute/0'.
+                Enable nova-compute scheduler from unit: 'nova-compute/0'.
+            Upgrade plan for unit: nova-compute/1
+                Disable nova-compute scheduler from unit: 'nova-compute/1'.
+                Check if unit nova-compute/1 has no VMs running before upgrading.
+                ├── Pause the unit: 'nova-compute/1'.
+                ├── Upgrade the unit: 'nova-compute/1'.
+                ├── Resume the unit: 'nova-compute/1'.
+                Enable nova-compute scheduler from unit: 'nova-compute/1'.
+            Upgrade plan for unit: nova-compute/2
+                Disable nova-compute scheduler from unit: 'nova-compute/2'.
+                Check if unit nova-compute/2 has no VMs running before upgrading.
+                ├── Pause the unit: 'nova-compute/2'.
+                ├── Upgrade the unit: 'nova-compute/2'.
+                ├── Resume the unit: 'nova-compute/2'.
+                Enable nova-compute scheduler from unit: 'nova-compute/2'.
+        Wait 1800s for model test_model to reach the idle state.
+        Check if the workload of 'nova-compute' has been upgraded on units: nova-compute/0, nova-compute/1, nova-compute/2
+    """  # noqa: E501 line too long
+    )
+    machines = {f"{i}": generate_cou_machine(f"{i}", f"az-{i}") for i in range(3)}
+    units = {
+        f"nova-compute/{unit}": COUUnit(
+            name=f"nova-compute/{unit}",
+            workload_version="21.0.0",
+            machine=machines[f"{unit}"],
+        )
+        for unit in range(3)
+    }
+    nova_compute = NovaCompute(
+        name="nova-compute",
+        can_upgrade_to="ussuri/stable",
+        charm="nova-compute",
+        channel="ussuri/stable",
+        config={"source": {"value": "distro"}},
+        machines=machines,
+        model=model,
+        origin="ch",
+        series="focal",
+        subordinate_to=[],
+        units=units,
+        workload_version="21.0.0",
+    )
+
+    plan = nova_compute.generate_upgrade_plan(target, False)
+
+    assert str(plan) == exp_plan
+
+
+def test_nova_compute_upgrade_plan_single_unit(model):
+    """Testing generating nova-compute upgrade plan for single unit."""
+    target = OpenStackRelease("victoria")
+    exp_plan = dedent_plan(
+        """
+    Upgrade plan for 'nova-compute' to victoria
+        Upgrade software packages of 'nova-compute' from the current APT repositories
+            Upgrade software packages on unit nova-compute/0
+        Refresh 'nova-compute' to the latest revision of 'ussuri/stable'
+        Change charm config of 'nova-compute' 'action-managed-upgrade' to True.
+        Upgrade 'nova-compute' to the new channel: 'victoria/stable'
+        Change charm config of 'nova-compute' 'source' to 'cloud:focal-victoria'
+        Upgrade plan for units: nova-compute/0
+            Upgrade plan for unit: nova-compute/0
+                Disable nova-compute scheduler from unit: 'nova-compute/0'.
+                Check if unit nova-compute/0 has no VMs running before upgrading.
+                ├── Pause the unit: 'nova-compute/0'.
+                ├── Upgrade the unit: 'nova-compute/0'.
+                ├── Resume the unit: 'nova-compute/0'.
+                Enable nova-compute scheduler from unit: 'nova-compute/0'.
+        Wait 1800s for model test_model to reach the idle state.
+        Check if the workload of 'nova-compute' has been upgraded on units: nova-compute/0
+    """
+    )
+    machines = {f"{i}": generate_cou_machine(f"{i}", f"az-{i}") for i in range(3)}
+    units = {
+        f"nova-compute/{unit}": COUUnit(
+            name=f"nova-compute/{unit}",
+            workload_version="21.0.0",
+            machine=machines[f"{unit}"],
+        )
+        for unit in range(3)
+    }
+    nova_compute = NovaCompute(
+        name="nova-compute",
+        can_upgrade_to="ussuri/stable",
+        charm="nova-compute",
+        channel="ussuri/stable",
+        config={"source": {"value": "distro"}},
+        machines=machines,
+        model=model,
+        origin="ch",
+        series="focal",
+        subordinate_to=[],
+        units=units,
+        workload_version="21.0.0",
+    )
+
+    plan = nova_compute.generate_upgrade_plan(target, False, units=[units["nova-compute/0"]])
+
+    assert str(plan) == exp_plan

--- a/tests/unit/utils.py
+++ b/tests/unit/utils.py
@@ -12,88 +12,29 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Module to provide helper for writing unit tests."""
-
-import contextlib
-import io
-import unittest
-from unittest import mock
+from textwrap import dedent
+from unittest.mock import MagicMock
 
 from cou.steps import BaseStep
-
-
-@contextlib.contextmanager
-def patch_open():
-    """Patch open().
-
-    Patch open() to allow mocking both open() itself and the file that is
-    yielded.
-
-    Yields the mock for "open" and "file", respectively.
-    """
-    mock_open = mock.MagicMock(spec=open)
-    mock_file = mock.MagicMock(spec=io.FileIO)
-
-    @contextlib.contextmanager
-    def stub_open(*args, **kwargs):
-        mock_open(*args, **kwargs)
-        yield mock_file
-
-    with mock.patch("builtins.open", stub_open):
-        yield mock_open, mock_file
-
-
-class BaseTestCase(unittest.TestCase):
-    """Base class for creating classes of unit tests."""
-
-    def shortDescription(self):
-        """Disable reporting unit test doc strings rather than names."""
-        return None
-
-    def setUp(self):
-        """Run setup of patches."""
-        self._patches = {}
-        self._patches_start = {}
-
-    def tearDown(self):
-        """Run teardown of patches."""
-        for k, v in self._patches.items():
-            v.stop()
-            setattr(self, k, None)
-        self._patches = None
-        self._patches_start = None
-
-    def patch_object(self, obj, attr, return_value=None, name=None, new=None, **kwargs):
-        """Patch the given object."""
-        if name is None:
-            name = attr
-        if new is not None:
-            mocked = mock.patch.object(obj, attr, new=new, **kwargs)
-        else:
-            mocked = mock.patch.object(obj, attr, **kwargs)
-        self._patches[name] = mocked
-        started = mocked.start()
-        if new is None:
-            started.return_value = return_value
-        self._patches_start[name] = started
-        setattr(self, name, started)
-
-    def patch(self, item, return_value=None, name=None, new=None, **kwargs):
-        """Patch the given item."""
-        if name is None:
-            raise RuntimeError("Must pass 'name' to .patch()")
-        if new is not None:
-            mocked = mock.patch(item, new=new, **kwargs)
-        else:
-            mocked = mock.patch(item, **kwargs)
-        self._patches[name] = mocked
-        started = mocked.start()
-        if new is None:
-            started.return_value = return_value
-        self._patches_start[name] = started
-        setattr(self, name, started)
+from cou.utils.juju_utils import COUMachine
 
 
 def assert_steps(step_1: BaseStep, step_2: BaseStep) -> None:
     """Compare two steps and raise exception if they are different."""
     msg = f"\n{step_1}!=\n{step_2}"
     assert step_1 == step_2, msg
+
+
+def generate_cou_machine(machine_id: str, az: str | None = None) -> MagicMock:
+    machine = MagicMock(spec_set=COUMachine)()
+    machine.machine_id = machine_id
+    machine.az = az
+    return machine
+
+
+def dedent_plan(plan: str) -> str:
+    """Dedent the string plan."""
+    result = dedent(plan)
+    result = result[1:]  # skip first new line
+    result = result.replace("    ", "\t")  # replace 4 spaces with tap
+    return result


### PR DESCRIPTION
In unit tests of #251 we found out that generating upgrade plan for Nova-compute is missing some required steps, however I found out that I accidentally use OpenStackAPplication instead of NovaCompute application to generate those upgrade plans.

Current upgrade plan for NovaCompute application with 3 units:
```bash
Upgrade plan for 'nova-compute' to victoria
    Upgrade software packages of 'nova-compute' from the current APT repositories
        Upgrade software packages on unit nova-compute/0
        Upgrade software packages on unit nova-compute/1
        Upgrade software packages on unit nova-compute/2
    Refresh 'nova-compute' to the latest revision of 'ussuri/stable'
    Change charm config of 'nova-compute' 'action-managed-upgrade' to True.
    Upgrade 'nova-compute' to the new channel: 'victoria/stable'
    Change charm config of 'nova-compute' 'source' to 'cloud:focal-victoria'
    Upgrade plan for units: nova-compute/0, nova-compute/1, nova-compute/2
        Upgrade plan for unit: nova-compute/0
            Disable nova-compute scheduler from unit: 'nova-compute/0'.
            Check if unit nova-compute/0 has no VMs running before upgrading.
            ├── Pause the unit: 'nova-compute/0'.
            ├── Upgrade the unit: 'nova-compute/0'.
            ├── Resume the unit: 'nova-compute/0'.
            Enable nova-compute scheduler from unit: 'nova-compute/0'.
        Upgrade plan for unit: nova-compute/1
            Disable nova-compute scheduler from unit: 'nova-compute/1'.
            Check if unit nova-compute/1 has no VMs running before upgrading.
            ├── Pause the unit: 'nova-compute/1'.
            ├── Upgrade the unit: 'nova-compute/1'.
            ├── Resume the unit: 'nova-compute/1'.
            Enable nova-compute scheduler from unit: 'nova-compute/1'.
        Upgrade plan for unit: nova-compute/2
            Disable nova-compute scheduler from unit: 'nova-compute/2'.
            Check if unit nova-compute/2 has no VMs running before upgrading.
            ├── Pause the unit: 'nova-compute/2'.
            ├── Upgrade the unit: 'nova-compute/2'.
            ├── Resume the unit: 'nova-compute/2'.
            Enable nova-compute scheduler from unit: 'nova-compute/2'.
    Wait 1800s for model test_model to reach the idle state.
    Check if the workload of 'nova-compute' has been upgraded on units: nova-compute/0, nova-compute/1, nova-compute/2
```