### PR TITLE
Chore/no ref/improve os app

### DIFF
--- a/cou/apps/base.py
+++ b/cou/apps/base.py
@@ -487,10 +487,8 @@ class OpenStackApplication(COUApplication):
         # corner case for rabbitmq and hacluster.
         if len(self.possible_current_channels) > 1:
             logger.info(
-                (
-                    "'%s' has more than one channel compatible with the current OpenStack "
-                    "release: '%s'. '%s' will be used"
-                ),
+                "'%s' has more than one channel compatible with the current OpenStack release: "
+                "'%s'. '%s' will be used",
                 self.name,
                 self.current_os_release.codename,
                 channel,
@@ -590,7 +588,7 @@ class OpenStackApplication(COUApplication):
         :rtype: UnitUpgradeStep
         """
         return UnitUpgradeStep(
-            description=(f"Resume the unit: '{unit.name}'."),
+            description=f"Resume the unit: '{unit.name}'.",
             coro=self.model.run_action(
                 unit_name=unit.name, action_name="resume", raise_on_failure=True
             ),

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,7 +28,6 @@ install_requires =
     oslo.config
     juju<3.0
     colorama
-    ruamel.yaml
     packaging
     aioconsole
     halo

--- a/tests/unit/apps/test_core.py
+++ b/tests/unit/apps/test_core.py
@@ -890,7 +890,7 @@ def test_nova_compute_upgrade_plan(model):
             Upgrade software packages on unit nova-compute/1
             Upgrade software packages on unit nova-compute/2
         Refresh 'nova-compute' to the latest revision of 'ussuri/stable'
-        Change charm config of 'nova-compute' 'action-managed-upgrade' to True.
+        Change charm config of 'nova-compute' 'action-managed-upgrade' to True
         Upgrade 'nova-compute' to the new channel: 'victoria/stable'
         Change charm config of 'nova-compute' 'source' to 'cloud:focal-victoria'
         Upgrade plan for units: nova-compute/0, nova-compute/1, nova-compute/2
@@ -933,7 +933,7 @@ def test_nova_compute_upgrade_plan(model):
         can_upgrade_to="ussuri/stable",
         charm="nova-compute",
         channel="ussuri/stable",
-        config={"source": {"value": "distro"}},
+        config={"source": {"value": "distro"}, "action-managed-upgrade": {"value": False}},
         machines=machines,
         model=model,
         origin="ch",
@@ -957,7 +957,7 @@ def test_nova_compute_upgrade_plan_single_unit(model):
         Upgrade software packages of 'nova-compute' from the current APT repositories
             Upgrade software packages on unit nova-compute/0
         Refresh 'nova-compute' to the latest revision of 'ussuri/stable'
-        Change charm config of 'nova-compute' 'action-managed-upgrade' to True.
+        Change charm config of 'nova-compute' 'action-managed-upgrade' to True
         Upgrade 'nova-compute' to the new channel: 'victoria/stable'
         Change charm config of 'nova-compute' 'source' to 'cloud:focal-victoria'
         Upgrade plan for units: nova-compute/0
@@ -986,7 +986,7 @@ def test_nova_compute_upgrade_plan_single_unit(model):
         can_upgrade_to="ussuri/stable",
         charm="nova-compute",
         channel="ussuri/stable",
-        config={"source": {"value": "distro"}},
+        config={"source": {"value": "distro"}, "action-managed-upgrade": {"value": False}},
         machines=machines,
         model=model,
         origin="ch",


### PR DESCRIPTION
Fix unitests, which was broken after merging #262 and add better string representation of OpenStackApplication. This is used currently only in logging, but it's important for to be able to reproduce on what cloud COU was runned. 