### PR TITLE
Introduce env vars to define idle state timeout

### DIFF
--- a/cou/apps/auxiliary.py
+++ b/cou/apps/auxiliary.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 """Auxiliary application class."""
 import logging
+import os
 from typing import Optional
 
 from cou.apps.base import OpenStackApplication
@@ -129,7 +130,7 @@ class RabbitMQServer(OpenStackAuxiliaryApplication):
     RabbitMQ must wait for the entire model to be idle before declaring the upgrade complete.
     """
 
-    wait_timeout = 30 * 60  # 30 min
+    wait_timeout = int(os.environ.get("COU_LONG_IDLE_TIMEOUT", 30 * 60))  # 30 min
     wait_for_model = True
 
 
@@ -137,7 +138,7 @@ class RabbitMQServer(OpenStackAuxiliaryApplication):
 class CephMonApplication(OpenStackAuxiliaryApplication):
     """Application for Ceph Monitor charm."""
 
-    wait_timeout = 30 * 60  # 30 min
+    wait_timeout = int(os.environ.get("COU_LONG_IDLE_TIMEOUT", 30 * 60))  # 30 min
     wait_for_model = True
 
     def pre_upgrade_steps(
@@ -200,7 +201,7 @@ class MysqlInnodbClusterApplication(OpenStackAuxiliaryApplication):
     # NOTE(agileshaw): holding 'mysql-server-core-8.0' package prevents undesired
     # mysqld processes from restarting, which lead to outages
     packages_to_hold: Optional[list] = ["mysql-server-core-8.0"]
-    wait_timeout = 30 * 60  # 30 min
+    wait_timeout = int(os.environ.get("COU_LONG_IDLE_TIMEOUT", 30 * 60))  # 30 min
 
 
 # NOTE (gabrielcocenza): Although CephOSD class is empty now, it will be

--- a/cou/apps/base.py
+++ b/cou/apps/base.py
@@ -16,6 +16,7 @@
 from __future__ import annotations
 
 import logging
+import os
 from collections import defaultdict
 from dataclasses import dataclass, field
 from typing import Any, Iterable, Optional
@@ -44,7 +45,6 @@ from cou.utils.openstack import (
 
 logger = logging.getLogger(__name__)
 
-DEFAULT_WAITING_TIMEOUT = 5 * 60  # 5 min
 ORIGIN_SETTINGS = ("openstack-origin", "source")
 REQUIRED_SETTINGS = ("enable-auto-restarts", "action-managed-upgrade", *ORIGIN_SETTINGS)
 
@@ -63,7 +63,9 @@ class OpenStackApplication(COUApplication):
     """
 
     packages_to_hold: Optional[list] = field(default=None, init=False)
-    wait_timeout: int = field(default=DEFAULT_WAITING_TIMEOUT, init=False)
+    wait_timeout: int = field(
+        default=int(os.environ.get("COU_STANDARD_IDLE_TIMEOUT", 5 * 60)), init=False
+    )
     wait_for_model: bool = field(default=False, init=False)  # waiting only for application itself
 
     def __post_init__(self) -> None:

--- a/cou/apps/core.py
+++ b/cou/apps/core.py
@@ -14,6 +14,7 @@
 
 """Core application class."""
 import logging
+import os
 from typing import Optional
 
 from cou.apps.base import OpenStackApplication
@@ -33,7 +34,7 @@ class Keystone(OpenStackApplication):
     Keystone must wait for the entire model to be idle before declaring the upgrade complete.
     """
 
-    wait_timeout = 30 * 60  # 30 min
+    wait_timeout = int(os.environ.get("COU_LONG_IDLE_TIMEOUT", 30 * 60))  # 30 min
     wait_for_model = True
 
 
@@ -44,7 +45,7 @@ class Octavia(OpenStackApplication):
     Octavia required more time to settle before COU can continue.
     """
 
-    wait_timeout = 30 * 60  # 30 min
+    wait_timeout = int(os.environ.get("COU_LONG_IDLE_TIMEOUT", 30 * 60))  # 30 min
 
 
 @AppFactory.register_application(["nova-compute"])
@@ -54,7 +55,7 @@ class NovaCompute(OpenStackApplication):
     Nova Compute must wait for the entire model to be idle before declaring the upgrade complete.
     """
 
-    wait_timeout = 30 * 60  # 30 min
+    wait_timeout = int(os.environ.get("COU_LONG_IDLE_TIMEOUT", 30 * 60))  # 30 min
     wait_for_model = True
     upgrade_units_running_vms = False
 

--- a/docs/reference/environment-variables.rst
+++ b/docs/reference/environment-variables.rst
@@ -6,3 +6,5 @@ Environment Variables
 * **COU_TIMEOUT** - define timeout for **COU** retry policy. Default value is 10 seconds.
 * **COU_MODEL_RETRIES** - define how many times to retry the connection to Juju model before giving up. Default value is 5 times.
 * **COU_MODEL_RETRY_BACKOFF** - define number of seconds to increase the wait between connection to the Juju model retry attempts. Default value is 2 seconds.
+* **COU_STANDARD_IDLE_TIMEOUT** - define the idle timeout to check if the application has upgraded. Default value is 300 seconds.
+* **COU_LONG_IDLE_TIMEOUT** - define the idle timeout for applications that take more time than usual to upgrade like, for example, Keystone and Octavia. Default value is 1800 seconds.


### PR DESCRIPTION
- COU_STANDARD_IDLE_TIMEOUT for standard OpenStackApplication
- COU_LONG_IDLE_TIMEOUT for apps that take more time to upgrade
- updated documentation

Closes #269 