### PR TITLE
Aligning name of applications

### DIFF
--- a/cou/apps/auxiliary.py
+++ b/cou/apps/auxiliary.py
@@ -31,7 +31,7 @@ logger = logging.getLogger(__name__)
 
 
 @AppFactory.register_application(["vault", "ceph-fs", "ceph-radosgw"])
-class OpenStackAuxiliaryApplication(OpenStackApplication):
+class AuxiliaryApplication(OpenStackApplication):
     """Application for charms that can have multiple OpenStack releases for a workload."""
 
     def is_valid_track(self, charm_channel: str) -> bool:
@@ -123,7 +123,7 @@ class OpenStackAuxiliaryApplication(OpenStackApplication):
 
 
 @AppFactory.register_application(["rabbitmq-server"])
-class RabbitMQServer(OpenStackAuxiliaryApplication):
+class RabbitMQServer(AuxiliaryApplication):
     """RabbitMQ application.
 
     RabbitMQ must wait for the entire model to be idle before declaring the upgrade complete.
@@ -134,7 +134,7 @@ class RabbitMQServer(OpenStackAuxiliaryApplication):
 
 
 @AppFactory.register_application(["ceph-mon"])
-class CephMonApplication(OpenStackAuxiliaryApplication):
+class CephMon(AuxiliaryApplication):
     """Application for Ceph Monitor charm."""
 
     wait_timeout = 30 * 60  # 30 min
@@ -173,7 +173,7 @@ class CephMonApplication(OpenStackAuxiliaryApplication):
 
 
 @AppFactory.register_application(["ovn-central", "ovn-dedicated-chassis"])
-class OvnPrincipalApplication(OpenStackAuxiliaryApplication):
+class OvnPrincipal(AuxiliaryApplication):
     """Ovn principal application class."""
 
     def pre_upgrade_steps(
@@ -194,7 +194,7 @@ class OvnPrincipalApplication(OpenStackAuxiliaryApplication):
 
 
 @AppFactory.register_application(["mysql-innodb-cluster"])
-class MysqlInnodbClusterApplication(OpenStackAuxiliaryApplication):
+class MysqlInnodbCluster(AuxiliaryApplication):
     """Application for mysql-innodb-cluster charm."""
 
     # NOTE(agileshaw): holding 'mysql-server-core-8.0' package prevents undesired
@@ -205,8 +205,8 @@ class MysqlInnodbClusterApplication(OpenStackAuxiliaryApplication):
 
 # NOTE (gabrielcocenza): Although CephOSD class is empty now, it will be
 # necessary to add post upgrade plan to set require-osd-release. Registering on
-# OpenStackAuxiliaryApplication can be easily forgot and ceph-osd can't be instantiated
+# AuxiliaryApplication can be easily forgot and ceph-osd can't be instantiated
 # as a normal OpenStackApplication.
 @AppFactory.register_application(["ceph-osd"])
-class CephOSD(OpenStackAuxiliaryApplication):
+class CephOSD(AuxiliaryApplication):
     """Application for ceph-osd."""

--- a/cou/apps/auxiliary_subordinate.py
+++ b/cou/apps/auxiliary_subordinate.py
@@ -14,9 +14,9 @@
 """Auxiliary subordinate application class."""
 from typing import Optional
 
-from cou.apps.auxiliary import OpenStackAuxiliaryApplication
+from cou.apps.auxiliary import AuxiliaryApplication
 from cou.apps.factory import AppFactory
-from cou.apps.subordinate import SubordinateBaseClass
+from cou.apps.subordinate import SubordinateBase
 from cou.steps import PreUpgradeStep
 from cou.utils.app_utils import validate_ovn_support
 from cou.utils.juju_utils import COUUnit
@@ -24,9 +24,7 @@ from cou.utils.openstack import AUXILIARY_SUBORDINATES, OpenStackRelease
 
 
 @AppFactory.register_application(AUXILIARY_SUBORDINATES)
-class OpenStackAuxiliarySubordinateApplication(
-    SubordinateBaseClass, OpenStackAuxiliaryApplication
-):
+class AuxiliarySubordinateApplication(SubordinateBase, AuxiliaryApplication):
     """Auxiliary subordinate application class."""
 
     @property
@@ -42,7 +40,7 @@ class OpenStackAuxiliarySubordinateApplication(
 
 
 @AppFactory.register_application(["ovn-chassis"])
-class OvnSubordinateApplication(OpenStackAuxiliarySubordinateApplication):
+class OvnSubordinate(AuxiliarySubordinateApplication):
     """Ovn subordinate application class."""
 
     def pre_upgrade_steps(

--- a/cou/apps/channel_based.py
+++ b/cou/apps/channel_based.py
@@ -25,7 +25,7 @@ logger = logging.getLogger(__name__)
 
 
 @AppFactory.register_application(CHANNEL_BASED_CHARMS)
-class OpenStackChannelBasedApplication(OpenStackApplication):
+class ChannelBasedApplication(OpenStackApplication):
     """Application for charms that are channel based."""
 
     def _get_latest_os_version(self, unit: COUUnit) -> OpenStackRelease:

--- a/cou/apps/subordinate.py
+++ b/cou/apps/subordinate.py
@@ -24,7 +24,7 @@ from cou.utils.openstack import SUBORDINATES, OpenStackRelease
 logger = logging.getLogger(__name__)
 
 
-class SubordinateBaseClass(OpenStackApplication):
+class SubordinateBase(OpenStackApplication):
     """Subordinate base class."""
 
     def pre_upgrade_steps(
@@ -73,7 +73,7 @@ class SubordinateBaseClass(OpenStackApplication):
 
 
 @AppFactory.register_application(SUBORDINATES)
-class OpenStackSubordinateApplication(SubordinateBaseClass):
+class SubordinateApplication(SubordinateBase):
     """Subordinate application class."""
 
     @property

--- a/cou/steps/plan.py
+++ b/cou/steps/plan.py
@@ -21,22 +21,19 @@ from typing import Callable, Optional
 # decorator
 # pylint: disable=unused-import
 from cou.apps.auxiliary import (  # noqa: F401
-    CephMonApplication,
-    OpenStackAuxiliaryApplication,
-    OvnPrincipalApplication,
+    AuxiliaryApplication,
+    CephMon,
+    OvnPrincipal,
     RabbitMQServer,
 )
 from cou.apps.auxiliary_subordinate import (  # noqa: F401
-    OpenStackAuxiliarySubordinateApplication,
-    OvnSubordinateApplication,
+    AuxiliarySubordinateApplication,
+    OvnSubordinate,
 )
 from cou.apps.base import OpenStackApplication
-from cou.apps.channel_based import OpenStackChannelBasedApplication  # noqa: F401
+from cou.apps.channel_based import ChannelBasedApplication  # noqa: F401
 from cou.apps.core import Keystone, Octavia  # noqa: F401
-from cou.apps.subordinate import (  # noqa: F401
-    OpenStackSubordinateApplication,
-    SubordinateBaseClass,
-)
+from cou.apps.subordinate import SubordinateApplication, SubordinateBase  # noqa: F401
 from cou.commands import CLIargs
 from cou.exceptions import (
     DataPlaneCannotUpgrade,
@@ -318,7 +315,7 @@ def _generate_control_plane_plan(
         description="Control Plane principal(s) upgrade plan",
         target=target,
         force=force,
-        filter_function=lambda app: not isinstance(app, SubordinateBaseClass),
+        filter_function=lambda app: not isinstance(app, SubordinateBase),
     )
 
     subordinate_upgrade_plan = create_upgrade_group(
@@ -326,7 +323,7 @@ def _generate_control_plane_plan(
         description="Control Plane subordinate(s) upgrade plan",
         target=target,
         force=force,
-        filter_function=lambda app: isinstance(app, SubordinateBaseClass),
+        filter_function=lambda app: isinstance(app, SubordinateBase),
     )
 
     logger.debug("Generation of the control plane upgrade plan complete")

--- a/tests/unit/apps/test_auxiliary.py
+++ b/tests/unit/apps/test_auxiliary.py
@@ -16,12 +16,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from cou.apps.auxiliary import (
-    CephMonApplication,
-    MysqlInnodbClusterApplication,
-    OvnPrincipalApplication,
-    RabbitMQServer,
-)
+from cou.apps.auxiliary import CephMon, MysqlInnodbCluster, OvnPrincipal, RabbitMQServer
 from cou.exceptions import ApplicationError, HaltUpgradePlanGeneration
 from cou.steps import (
     ApplicationUpgradePlan,
@@ -560,10 +555,10 @@ def test_auxiliary_no_suitable_channel(model):
 
 
 def test_ceph_mon_app(model):
-    """Test the correctness of instantiating CephMonApplication."""
+    """Test the correctness of instantiating CephMon."""
     charm = "ceph-mon"
     machines = {"0": MagicMock(spec_set=COUMachine)}
-    app = CephMonApplication(
+    app = CephMon(
         name=charm,
         can_upgrade_to="",
         charm=charm,
@@ -597,7 +592,7 @@ def test_ceph_mon_upgrade_plan_xena_to_yoga(model):
     target = OpenStackRelease("yoga")
     charm = "ceph-mon"
     machines = {"0": MagicMock(spec_set=COUMachine)}
-    app = CephMonApplication(
+    app = CephMon(
         name=charm,
         can_upgrade_to="quincy/stable",
         charm=charm,
@@ -686,7 +681,7 @@ def test_ceph_mon_upgrade_plan_ussuri_to_victoria(model):
     target = OpenStackRelease("victoria")
     charm = "ceph-mon"
     machines = {"0": MagicMock(spec_set=COUMachine)}
-    app = CephMonApplication(
+    app = CephMon(
         name=charm,
         can_upgrade_to="quincy/stable",
         charm=charm,
@@ -766,10 +761,10 @@ def test_ceph_mon_upgrade_plan_ussuri_to_victoria(model):
 
 
 def test_ovn_principal(model):
-    """Test the correctness of instantiating OvnPrincipalApplication."""
+    """Test the correctness of instantiating OvnPrincipal."""
     charm = "ovn-central"
     machines = {"0": MagicMock(spec_set=COUMachine)}
-    app = OvnPrincipalApplication(
+    app = OvnPrincipal(
         name=charm,
         can_upgrade_to="22.06/stable",
         charm=charm,
@@ -798,7 +793,7 @@ def test_ovn_principal(model):
 
 
 def test_ovn_workload_ver_lower_than_22_principal(model):
-    """Test the OvnPrincipalApplication with lower version than 22."""
+    """Test the OvnPrincipal with lower version than 22."""
     target = OpenStackRelease("victoria")
     charm = "ovn-central"
     exp_msg = (
@@ -808,7 +803,7 @@ def test_ovn_workload_ver_lower_than_22_principal(model):
         "ovn-upgrade-2203.html"
     )
     machines = {"0": MagicMock(spec_set=COUMachine)}
-    app = OvnPrincipalApplication(
+    app = OvnPrincipal(
         name=charm,
         can_upgrade_to="22.03/stable",
         charm=charm,
@@ -835,7 +830,7 @@ def test_ovn_workload_ver_lower_than_22_principal(model):
 
 @pytest.mark.parametrize("channel", ["55.7", "19.03"])
 def test_ovn_no_compatible_os_release(channel, model):
-    """Test the OvnPrincipalApplication with not compatible os release."""
+    """Test the OvnPrincipal with not compatible os release."""
     charm = "ovn-central"
     machines = {"0": MagicMock(spec_set=COUMachine)}
     exp_msg = (
@@ -846,7 +841,7 @@ def test_ovn_no_compatible_os_release(channel, model):
     )
 
     with pytest.raises(ApplicationError, match=exp_msg):
-        OvnPrincipalApplication(
+        OvnPrincipal(
             name=charm,
             can_upgrade_to="quincy/stable",
             charm=charm,
@@ -869,11 +864,11 @@ def test_ovn_no_compatible_os_release(channel, model):
 
 
 def test_ovn_principal_upgrade_plan(model):
-    """Test generating plan for OvnPrincipalApplication."""
+    """Test generating plan for OvnPrincipal."""
     target = OpenStackRelease("victoria")
     charm = "ovn-central"
     machines = {"0": MagicMock(spec_set=COUMachine)}
-    app = OvnPrincipalApplication(
+    app = OvnPrincipal(
         name=charm,
         can_upgrade_to="22.06/stable",
         charm=charm,
@@ -949,11 +944,11 @@ def test_ovn_principal_upgrade_plan(model):
 
 
 def test_mysql_innodb_cluster_upgrade(model):
-    """Test generating plan for MysqlInnodbClusterApplication."""
+    """Test generating plan for MysqlInnodbCluster."""
     target = OpenStackRelease("victoria")
     charm = "mysql-innodb-cluster"
     machines = {"0": MagicMock(spec_set=COUMachine)}
-    app = MysqlInnodbClusterApplication(
+    app = MysqlInnodbCluster(
         name=charm,
         can_upgrade_to="9.0",
         charm=charm,

--- a/tests/unit/apps/test_auxiliary_subordinate.py
+++ b/tests/unit/apps/test_auxiliary_subordinate.py
@@ -18,8 +18,8 @@ from unittest.mock import MagicMock
 import pytest
 
 from cou.apps.auxiliary_subordinate import (
-    OpenStackAuxiliarySubordinateApplication,
-    OvnSubordinateApplication,
+    AuxiliarySubordinateApplication,
+    OvnSubordinate,
 )
 from cou.exceptions import ApplicationError
 from cou.steps import ApplicationUpgradePlan, PreUpgradeStep, UpgradeStep
@@ -32,7 +32,7 @@ from tests.unit.utils import assert_steps
 def test_auxiliary_subordinate(model):
     """Test auxiliary subordinate application."""
     machines = {"0": MagicMock(spec_set=COUMachine)}
-    app = OpenStackAuxiliarySubordinateApplication(
+    app = AuxiliarySubordinateApplication(
         name="keystone-mysql-router",
         can_upgrade_to="",
         charm="mysql-router",
@@ -66,7 +66,7 @@ def test_auxiliary_subordinate_upgrade_plan_to_victoria(model):
     """Test auxiliary subordinate application upgrade plan to victoria."""
     target = OpenStackRelease("victoria")
     machines = {"0": MagicMock(spec_set=COUMachine)}
-    app = OpenStackAuxiliarySubordinateApplication(
+    app = AuxiliarySubordinateApplication(
         name="keystone-mysql-router",
         can_upgrade_to="8.0/stable",
         charm="mysql-router",
@@ -104,9 +104,9 @@ def test_auxiliary_subordinate_upgrade_plan_to_victoria(model):
 
 
 def test_ovn_subordinate(model):
-    """Test the correctness of instantiating OvnSubordinateApplication."""
+    """Test the correctness of instantiating OvnSubordinate."""
     machines = {"0": MagicMock(spec_set=COUMachine)}
-    app = OvnSubordinateApplication(
+    app = OvnSubordinate(
         name="ovn-chassis",
         can_upgrade_to="22.03/stable",
         charm="ovn-chassis",
@@ -136,7 +136,7 @@ def test_ovn_subordinate(model):
 
 
 def test_ovn_workload_ver_lower_than_22_subordinate(model):
-    """Test the OvnSubordinateApplication with lower version than 22."""
+    """Test the OvnSubordinate with lower version than 22."""
     target = OpenStackRelease("victoria")
     machines = {"0": MagicMock(spec_set=COUMachine)}
     exp_msg = (
@@ -145,7 +145,7 @@ def test_ovn_workload_ver_lower_than_22_subordinate(model):
         "https://docs.openstack.org/charm-guide/latest/project/procedures/"
         "ovn-upgrade-2203.html"
     )
-    app = OvnSubordinateApplication(
+    app = OvnSubordinate(
         name="ovn-chassis",
         can_upgrade_to="22.03/stable",
         charm="ovn-chassis",
@@ -171,10 +171,10 @@ def test_ovn_workload_ver_lower_than_22_subordinate(model):
 
 
 def test_ovn_subordinate_upgrade_plan(model):
-    """Test generating plan for OvnSubordinateApplication."""
+    """Test generating plan for OvnSubordinate."""
     target = OpenStackRelease("victoria")
     machines = {"0": MagicMock(spec_set=COUMachine)}
-    app = OvnSubordinateApplication(
+    app = OvnSubordinate(
         name="ovn-chassis",
         can_upgrade_to="22.03/stable",
         charm="ovn-chassis",
@@ -214,14 +214,14 @@ def test_ovn_subordinate_upgrade_plan(model):
 
 
 def test_ovn_subordinate_upgrade_plan_cant_upgrade_charm(model):
-    """Test generating plan for OvnSubordinateApplication failing.
+    """Test generating plan for OvnSubordinate failing.
 
     The ovn chassis 22.03 is considered yoga. If it's not necessary to upgrade the charm code,
     there is no steps to upgrade.
     """
     target = OpenStackRelease("victoria")
     machines = {"0": MagicMock(spec_set=COUMachine)}
-    app = OvnSubordinateApplication(
+    app = OvnSubordinate(
         name="ovn-chassis",
         can_upgrade_to="",
         charm="ovn-chassis",
@@ -256,7 +256,7 @@ def test_ceph_dashboard_upgrade_plan_ussuri_to_victoria(model):
     """Test when ceph version remains the same between os releases."""
     target = OpenStackRelease("victoria")
     machines = {"0": MagicMock(spec_set=COUMachine)}
-    app = OpenStackAuxiliarySubordinateApplication(
+    app = AuxiliarySubordinateApplication(
         name="ceph-dashboard",
         can_upgrade_to="octopus/stable",
         charm="ceph-dashboard",
@@ -299,7 +299,7 @@ def test_ceph_dashboard_upgrade_plan_xena_to_yoga(model):
     """Test when ceph version changes between os releases."""
     target = OpenStackRelease("yoga")
     machines = {"0": MagicMock(spec_set=COUMachine)}
-    app = OpenStackAuxiliarySubordinateApplication(
+    app = AuxiliarySubordinateApplication(
         name="ceph-dashboard",
         can_upgrade_to="pacific/stable",
         charm="ceph-dashboard",

--- a/tests/unit/apps/test_channel_based.py
+++ b/tests/unit/apps/test_channel_based.py
@@ -12,7 +12,7 @@
 
 from unittest.mock import MagicMock
 
-from cou.apps.channel_based import OpenStackChannelBasedApplication
+from cou.apps.channel_based import ChannelBasedApplication
 from cou.steps import (
     ApplicationUpgradePlan,
     PostUpgradeStep,
@@ -37,7 +37,7 @@ def test_application_versionless(model):
             machine=machines["0"],
         )
     }
-    app = OpenStackChannelBasedApplication(
+    app = ChannelBasedApplication(
         name="glance-simplestreams-sync",
         can_upgrade_to="",
         charm="glance-simplestreams-sync",
@@ -61,9 +61,9 @@ def test_application_versionless(model):
 
 
 def test_application_gnocchi_ussuri(model):
-    """Test the Gnocchi OpenStackChannelBasedApplication with Ussuri."""
+    """Test the Gnocchi ChannelBasedApplication with Ussuri."""
     machines = {"0": MagicMock(spec_set=COUMachine)}
-    app = OpenStackChannelBasedApplication(
+    app = ChannelBasedApplication(
         name="gnocchi",
         can_upgrade_to="",
         charm="gnocchi",
@@ -92,13 +92,13 @@ def test_application_gnocchi_ussuri(model):
 
 
 def test_application_gnocchi_xena(model):
-    """Test the Gnocchi OpenStackChannelBasedApplication with Xena.
+    """Test the Gnocchi ChannelBasedApplication with Xena.
 
     The workload version is the same for xena and yoga, but current_os_release is based on
     the channel.
     """
     machines = {"0": MagicMock(spec_set=COUMachine)}
-    app = OpenStackChannelBasedApplication(
+    app = ChannelBasedApplication(
         name="gnocchi",
         can_upgrade_to="",
         charm="gnocchi",
@@ -124,13 +124,13 @@ def test_application_gnocchi_xena(model):
 
 
 def test_application_designate_bind_ussuri(model):
-    """Test the Designate-bind OpenStackChannelBasedApplication with Ussuri.
+    """Test the Designate-bind ChannelBasedApplication with Ussuri.
 
     The workload version is the same from ussuri to yoga, but current_os_release is based on
     the channel.
     """
     machines = {"0": MagicMock(spec_set=COUMachine)}
-    app = OpenStackChannelBasedApplication(
+    app = ChannelBasedApplication(
         name="designate-bind",
         can_upgrade_to="",
         charm="designate-bind",
@@ -159,10 +159,10 @@ def test_application_designate_bind_ussuri(model):
 
 
 def test_application_versionless_upgrade_plan_ussuri_to_victoria(model):
-    """Test generating plan for glance-simplestreams-sync (OpenStackChannelBasedApplication)."""
+    """Test generating plan for glance-simplestreams-sync (ChannelBasedApplication)."""
     target = OpenStackRelease("victoria")
     machines = {"0": MagicMock(spec_set=COUMachine)}
-    app = OpenStackChannelBasedApplication(
+    app = ChannelBasedApplication(
         name="glance-simplestreams-sync",
         can_upgrade_to="ussuri/stable",
         charm="glance-simplestreams-sync",
@@ -232,13 +232,13 @@ def test_application_versionless_upgrade_plan_ussuri_to_victoria(model):
 
 
 def test_application_gnocchi_upgrade_plan_ussuri_to_victoria(model):
-    """Test generating plan for Gnocchi (OpenStackChannelBasedApplication).
+    """Test generating plan for Gnocchi (ChannelBasedApplication).
 
     Updating Gnocchi from ussuri to victoria increases the workload version from 4.3.4 to 4.4.0.
     """
     target = OpenStackRelease("victoria")
     machines = {"0": MagicMock(spec_set=COUMachine)}
-    app = OpenStackChannelBasedApplication(
+    app = ChannelBasedApplication(
         name="gnocchi",
         can_upgrade_to="ussuri/stable",
         charm="gnocchi",
@@ -324,10 +324,10 @@ def test_application_gnocchi_upgrade_plan_ussuri_to_victoria(model):
 
 
 def test_application_designate_bind_upgrade_plan_ussuri_to_victoria(model):
-    """Test generating plan for Designate-bind (OpenStackChannelBasedApplication)."""
+    """Test generating plan for Designate-bind (ChannelBasedApplication)."""
     target = OpenStackRelease("victoria")
     machines = {"0": MagicMock(spec_set=COUMachine)}
-    app = OpenStackChannelBasedApplication(
+    app = ChannelBasedApplication(
         name="designate-bind",
         can_upgrade_to="ussuri/stable",
         charm="designate-bind",

--- a/tests/unit/apps/test_subordinate.py
+++ b/tests/unit/apps/test_subordinate.py
@@ -17,7 +17,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from cou.apps.subordinate import OpenStackSubordinateApplication
+from cou.apps.subordinate import SubordinateApplication
 from cou.exceptions import ApplicationError
 from cou.steps import ApplicationUpgradePlan, PreUpgradeStep, UpgradeStep
 from cou.utils.juju_utils import COUMachine, COUUnit
@@ -29,9 +29,9 @@ logger = logging.getLogger(__name__)
 
 
 def test_current_os_release(model):
-    """Test current_os_release for OpenStackSubordinateApplication."""
+    """Test current_os_release for SubordinateApplication."""
     machines = {"0": MagicMock(spec_set=COUMachine)}
-    app = OpenStackSubordinateApplication(
+    app = SubordinateApplication(
         name="keystone-ldap",
         can_upgrade_to="ussuri/stable",
         charm="keystone-ldap",
@@ -56,10 +56,10 @@ def test_current_os_release(model):
 
 
 def test_generate_upgrade_plan(model):
-    """Test generate upgrade plan for OpenStackSubordinateApplication."""
+    """Test generate upgrade plan for SubordinateApplication."""
     target = OpenStackRelease("victoria")
     machines = {"0": MagicMock(spec_set=COUMachine)}
-    app = OpenStackSubordinateApplication(
+    app = SubordinateApplication(
         name="keystone-ldap",
         can_upgrade_to="ussuri/stable",
         charm="keystone-ldap",
@@ -112,9 +112,9 @@ def test_generate_upgrade_plan(model):
     ],
 )
 def test_channel_valid(model, channel):
-    """Test successful validation of channel upgrade plan for OpenStackSubordinateApplication."""
+    """Test successful validation of channel upgrade plan for SubordinateApplication."""
     machines = {"0": MagicMock(spec_set=COUMachine)}
-    app = OpenStackSubordinateApplication(
+    app = SubordinateApplication(
         name="keystone-ldap",
         can_upgrade_to=channel,
         charm="keystone-ldap",
@@ -148,11 +148,11 @@ def test_channel_valid(model, channel):
     ],
 )
 def test_channel_setter_invalid(model, channel):
-    """Test unsuccessful validation of channel upgrade plan for OpenStackSubordinateApplication."""
+    """Test unsuccessful validation of channel upgrade plan for SubordinateApplication."""
     machines = {"0": MagicMock(spec_set=COUMachine)}
 
     with pytest.raises(ApplicationError):
-        OpenStackSubordinateApplication(
+        SubordinateApplication(
             name="keystone-ldap",
             can_upgrade_to=channel,
             charm="keystone-ldap",
@@ -183,10 +183,10 @@ def test_channel_setter_invalid(model, channel):
     ],
 )
 def test_generate_plan_ch_migration(model, channel):
-    """Test generate upgrade plan for OpenStackSubordinateApplication with charmhub migration."""
+    """Test generate upgrade plan for SubordinateApplication with charmhub migration."""
     target = OpenStackRelease("wallaby")
     machines = {"0": MagicMock(spec_set=COUMachine)}
-    app = OpenStackSubordinateApplication(
+    app = SubordinateApplication(
         name="keystone-ldap",
         can_upgrade_to="wallaby/stable",
         charm="keystone-ldap",
@@ -237,10 +237,10 @@ def test_generate_plan_ch_migration(model, channel):
     ],
 )
 def test_generate_plan_from_to(model, from_os, to_os):
-    """Test generate upgrade plan for OpenStackSubordinateApplication from to version."""
+    """Test generate upgrade plan for SubordinateApplication from to version."""
     target = OpenStackRelease(to_os)
     machines = {"0": MagicMock(spec_set=COUMachine)}
-    app = OpenStackSubordinateApplication(
+    app = SubordinateApplication(
         name="keystone-ldap",
         can_upgrade_to=f"{to_os}/stable",
         charm="keystone-ldap",
@@ -290,10 +290,10 @@ def test_generate_plan_from_to(model, from_os, to_os):
     ],
 )
 def test_generate_plan_in_same_version(model, from_to):
-    """Test generate upgrade plan for OpenStackSubordinateApplication in same version."""
+    """Test generate upgrade plan for SubordinateApplication in same version."""
     target = OpenStackRelease(from_to)
     machines = {"0": MagicMock(spec_set=COUMachine)}
-    app = OpenStackSubordinateApplication(
+    app = SubordinateApplication(
         name="keystone-ldap",
         can_upgrade_to=f"{from_to}/stable",
         charm="keystone-ldap",

--- a/tests/unit/steps/test_steps_plan.py
+++ b/tests/unit/steps/test_steps_plan.py
@@ -17,7 +17,7 @@ import pytest
 
 from cou.apps.base import OpenStackApplication
 from cou.apps.core import Keystone
-from cou.apps.subordinate import OpenStackSubordinateApplication
+from cou.apps.subordinate import SubordinateApplication
 from cou.exceptions import (
     DataPlaneCannotUpgrade,
     DataPlaneMachineFilterError,
@@ -174,7 +174,7 @@ async def test_generate_plan(model, cli_args):
         },
         workload_version="17.0.1",
     )
-    keystone_ldap = OpenStackSubordinateApplication(
+    keystone_ldap = SubordinateApplication(
         name="keystone-ldap",
         can_upgrade_to="ussuri/stable",
         charm="keystone-ldap",


### PR DESCRIPTION
Making the naming of the application more uniform and shorter (e.g. dropping "Application" or "OpenStack").