### PR TITLE
Convert `app.machines` and `app.units` to list instead of dict

### DIFF
--- a/cou/apps/auxiliary.py
+++ b/cou/apps/auxiliary.py
@@ -165,7 +165,7 @@ class CephMonApplication(OpenStackAuxiliaryApplication):
         :return: Step to check and set correct value for require-osd-release
         :rtype: PreUpgradeStep
         """
-        ceph_mon_unit, *_ = self.units.values()
+        ceph_mon_unit, *_ = self.units
         return PreUpgradeStep(
             description="Ensure require-osd-release option matches with ceph-osd version",
             coro=set_require_osd_release_option(ceph_mon_unit.name, self.model),
@@ -188,8 +188,9 @@ class OvnPrincipalApplication(OpenStackAuxiliaryApplication):
         :return: List of pre upgrade steps.
         :rtype: list[PreUpgradeStep]
         """
-        for unit in self.units.values():
+        for unit in self.units:
             validate_ovn_support(unit.workload_version)
+
         return super().pre_upgrade_steps(target, units)
 
 

--- a/cou/apps/base.py
+++ b/cou/apps/base.py
@@ -126,7 +126,7 @@ class OpenStackApplication(COUApplication):
                         "apps": machine.apps,
                         "az": machine.az,
                     }
-                    for machine in self.machines.values()
+                    for machine in self.machines
                 },
             }
         }

--- a/cou/apps/base.py
+++ b/cou/apps/base.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 import logging
 from collections import defaultdict
 from dataclasses import dataclass, field
-from typing import Any, Iterable, Optional
+from typing import Any, Optional
 
 import yaml
 
@@ -389,7 +389,7 @@ class OpenStackApplication(COUApplication):
         ]
 
     def post_upgrade_steps(
-        self, target: OpenStackRelease, units: Optional[Iterable[COUUnit]]
+        self, target: OpenStackRelease, units: Optional[list[COUUnit]]
     ) -> list[PostUpgradeStep]:
         """Post Upgrade steps planning.
 
@@ -398,7 +398,7 @@ class OpenStackApplication(COUApplication):
         :param target: OpenStack release as target to upgrade.
         :type target: OpenStackRelease
         :param units: Units to generate post upgrade plan
-        :type units: Optional[Iterable[COUUnit]]
+        :type units: Optional[list[COUUnit]]
         :return: List of post upgrade steps.
         :rtype: list[PostUpgradeStep]
         """
@@ -642,14 +642,14 @@ class OpenStackApplication(COUApplication):
         return UpgradeStep()
 
     def _get_reached_expected_target_step(
-        self, target: OpenStackRelease, units: Optional[Iterable[COUUnit]]
+        self, target: OpenStackRelease, units: Optional[list[COUUnit]]
     ) -> PostUpgradeStep:
         """Get post upgrade step to check if application workload has been upgraded.
 
         :param target: OpenStack release as target to upgrade.
         :type target: OpenStackRelease
         :param units: Units to generate post upgrade plan
-        :type units: Optional[Iterable[COUUnit]]
+        :type units: Optional[list[COUUnit]]
         :return: Post Upgrade step to check if application workload has been upgraded.
         :rtype: PostUpgradeStep
         """
@@ -665,14 +665,14 @@ class OpenStackApplication(COUApplication):
         )
 
     async def _verify_workload_upgrade(
-        self, target: OpenStackRelease, units: Iterable[COUUnit]
+        self, target: OpenStackRelease, units: list[COUUnit]
     ) -> None:
         """Check if an application has upgraded its workload version.
 
         :param target: OpenStack release as target to upgrade.
         :type target: OpenStackRelease
         :param units: Units to check if got upgraded
-        :type units: Iterable[COUUnit]
+        :type units: list[COUUnit]
         :raises ApplicationError: When the workload version of the charm doesn't upgrade.
         """
         status = await self.model.get_status()

--- a/cou/apps/base.py
+++ b/cou/apps/base.py
@@ -118,7 +118,7 @@ class OpenStackApplication(COUApplication):
                         "workload_version": unit.workload_version,
                         "os_version": str(self._get_latest_os_version(unit)),
                     }
-                    for unit in self.units.values()
+                    for unit in self.units
                 },
                 "machines": {
                     machine.machine_id: {
@@ -252,7 +252,7 @@ class OpenStackApplication(COUApplication):
         :rtype: OpenStackRelease
         """
         os_versions = defaultdict(list)
-        for unit in self.units.values():
+        for unit in self.units:
             os_version = self._get_latest_os_version(unit)
             os_versions[os_version].append(unit.name)
 
@@ -449,7 +449,8 @@ class OpenStackApplication(COUApplication):
         :rtype: PreUpgradeStep
         """
         if not units:
-            units = list(self.units.values())
+            units = self.units
+
         step = PreUpgradeStep(
             description=(
                 f"Upgrade software packages of '{self.name}' from the current APT repositories"
@@ -653,7 +654,8 @@ class OpenStackApplication(COUApplication):
         :rtype: PostUpgradeStep
         """
         if not units:
-            units = list(self.units.values())
+            units = self.units
+
         return PostUpgradeStep(
             description=(
                 f"Check if the workload of '{self.name}' has been upgraded on units: "

--- a/cou/apps/channel_based.py
+++ b/cou/apps/channel_based.py
@@ -58,7 +58,7 @@ class OpenStackChannelBasedApplication(OpenStackApplication):
         :return: True if is versionless, False otherwise.
         :rtype: bool
         """
-        return not all(unit.workload_version for unit in self.units.values())
+        return not all(unit.workload_version for unit in self.units)
 
     def post_upgrade_steps(
         self, target: OpenStackRelease, units: Optional[Iterable[COUUnit]]
@@ -77,4 +77,5 @@ class OpenStackChannelBasedApplication(OpenStackApplication):
         """
         if self.is_versionless:
             return []
+
         return super().post_upgrade_steps(target, units)

--- a/cou/apps/channel_based.py
+++ b/cou/apps/channel_based.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 """Channel based application class."""
 import logging
-from typing import Iterable, Optional
+from typing import Optional
 
 from cou.apps.base import OpenStackApplication
 from cou.apps.factory import AppFactory
@@ -61,7 +61,7 @@ class OpenStackChannelBasedApplication(OpenStackApplication):
         return not all(unit.workload_version for unit in self.units)
 
     def post_upgrade_steps(
-        self, target: OpenStackRelease, units: Optional[Iterable[COUUnit]]
+        self, target: OpenStackRelease, units: Optional[list[COUUnit]]
     ) -> list[PostUpgradeStep]:
         """Post Upgrade steps planning.
 
@@ -71,7 +71,7 @@ class OpenStackChannelBasedApplication(OpenStackApplication):
         :param target: OpenStack release as target to upgrade.
         :type target: OpenStackRelease
         :param units: Units to generate post upgrade plan
-        :type units: Optional[Iterable[COUUnit]]
+        :type units: Optional[list[COUUnit]]
         :return: List of post upgrade steps.
         :rtype: list[PostUpgradeStep]
         """

--- a/cou/apps/core.py
+++ b/cou/apps/core.py
@@ -76,7 +76,7 @@ class NovaCompute(OpenStackApplication):
         :rtype: list[UpgradeStep]
         """
         if not units:
-            units = list(self.units.values())
+            units = self.units
 
         app_steps = super().upgrade_steps(target, units, force)
         unit_steps = self._get_units_upgrade_steps(units, force)

--- a/cou/apps/subordinate.py
+++ b/cou/apps/subordinate.py
@@ -13,7 +13,7 @@
 #  limitations under the License.
 """Subordinate application class."""
 import logging
-from typing import Iterable, Optional
+from typing import Optional
 
 from cou.apps.base import OpenStackApplication
 from cou.apps.factory import AppFactory
@@ -58,14 +58,14 @@ class SubordinateBaseClass(OpenStackApplication):
         return [self._get_upgrade_charm_step(target)]
 
     def post_upgrade_steps(
-        self, target: OpenStackRelease, units: Optional[Iterable[COUUnit]]
+        self, target: OpenStackRelease, units: Optional[list[COUUnit]]
     ) -> list[PostUpgradeStep]:
         """Post Upgrade steps planning.
 
         :param target: OpenStack release as target to upgrade.
         :type target: OpenStackRelease
         :param units: Units to generate post upgrade plan
-        :type units: Optional[Iterable[COUUnit]]
+        :type units: Optional[list[COUUnit]]
         :return: List of post upgrade steps.
         :rtype: list[PostUpgradeStep]
         """
@@ -91,4 +91,5 @@ class OpenStackSubordinateApplication(SubordinateBaseClass):
                 self.name,
             )
             return OpenStackRelease("ussuri")
+
         return OpenStackRelease(self._get_track_from_channel(self.channel))

--- a/cou/steps/analyze.py
+++ b/cou/steps/analyze.py
@@ -79,12 +79,12 @@ class Analysis:
 
         control_plane, data_plane = [], []
         data_plane_machines = {
-            unit.machine for app in apps if is_data_plane(app) for unit in app.units.values()
+            unit.machine for app in apps if is_data_plane(app) for unit in app.units
         }
         for app in apps:
             if is_data_plane(app):
                 data_plane.append(app)
-            elif any(unit.machine in data_plane_machines for unit in app.units.values()):
+            elif any(unit.machine in data_plane_machines for unit in app.units):
                 data_plane.append(app)
             else:
                 control_plane.append(app)

--- a/cou/steps/analyze.py
+++ b/cou/steps/analyze.py
@@ -197,9 +197,7 @@ class Analysis:
         :rtype: dict[str, COUMachine]
         """
         return {
-            machine_id: app.machines[machine_id]
-            for app in self.apps_data_plane
-            for machine_id in app.machines
+            machine.machine_id: machine for app in self.apps_data_plane for machine in app.machines
         }
 
     @property
@@ -210,9 +208,9 @@ class Analysis:
         :rtype: dict[str, COUMachine]
         """
         return {
-            machine_id: app.machines[machine_id]
+            machine.machine_id: machine
             for app in self.apps_control_plane
-            for machine_id in app.machines
+            for machine in app.machines
         }
 
     @property

--- a/cou/steps/hypervisor.py
+++ b/cou/steps/hypervisor.py
@@ -142,7 +142,7 @@ class HypervisorUpgradePlanner:
         """
         azs = AZs()
         for app in self.apps:
-            for unit in app.units.values():
+            for unit in app.units:
                 # NOTE(rgildein): If there is no AZ, we will use empty string and all units will
                 #                 belong to a single group.
                 az = unit.machine.az or ""

--- a/cou/steps/plan.py
+++ b/cou/steps/plan.py
@@ -355,7 +355,7 @@ def _generate_data_plane_plan(
     nova_compute_machines = [
         unit.machine.machine_id
         for app in apps
-        for unit in app.units.values()
+        for unit in app.units
         if app.charm == "nova-compute"
         if unit.machine.machine_id not in hypervisors
     ]
@@ -469,7 +469,7 @@ async def _get_upgradable_hypervisors_machines(
     nova_compute_units = [
         unit
         for app in analysis_result.apps_data_plane
-        for unit in app.units.values()
+        for unit in app.units
         if app.charm == "nova-compute"
     ]
 

--- a/cou/steps/plan.py
+++ b/cou/steps/plan.py
@@ -366,7 +366,7 @@ def _generate_data_plane_plan(
             continue
 
         for machine in app.machines:
-            if machine in nova_compute_machines:
+            if machine.machine_id in nova_compute_machines:
                 hypervisor_apps.append(app)
                 break  # exiting machine for loop
 

--- a/cou/utils/juju_utils.py
+++ b/cou/utils/juju_utils.py
@@ -162,7 +162,7 @@ class COUApplication:
     charm: str
     channel: str
     config: dict[str, Any]
-    machines: dict[str, COUMachine]
+    machines: list[COUMachine]
     model: COUModel
     origin: str
     series: str
@@ -314,7 +314,7 @@ class COUModel:
             retry_backoff=DEFAULT_MODEL_RETRY_BACKOFF,
         )
 
-    @retry
+    # @retry
     async def get_applications(self) -> dict[str, COUApplication]:
         """Return list of applications with all relevant information.
 
@@ -334,7 +334,7 @@ class COUModel:
                 charm=model.applications[app].charm_name,
                 channel=status.charm_channel,
                 config=await model.applications[app].get_config(),
-                machines={unit.machine: machines[unit.machine] for unit in status.units.values()},
+                machines=[machines[unit.machine] for unit in status.units.values()],
                 model=self,
                 origin=status.charm.split(":")[0],
                 series=status.series,

--- a/cou/utils/juju_utils.py
+++ b/cou/utils/juju_utils.py
@@ -167,7 +167,7 @@ class COUApplication:
     origin: str
     series: str
     subordinate_to: list[str]
-    units: dict[str, COUUnit]
+    units: list[COUUnit]
     workload_version: str
 
     @property
@@ -339,10 +339,10 @@ class COUModel:
                 origin=status.charm.split(":")[0],
                 series=status.series,
                 subordinate_to=status.subordinate_to,
-                units={
-                    name: COUUnit(name, machines[unit.machine], unit.workload_version)
+                units=[
+                    COUUnit(name, machines[unit.machine], unit.workload_version)
                     for name, unit in status.units.items()
-                },
+                ],
                 workload_version=status.workload_version,
             )
             for app, status in full_status.applications.items()

--- a/tests/unit/apps/test_auxiliary.py
+++ b/tests/unit/apps/test_auxiliary.py
@@ -55,13 +55,13 @@ def test_auxiliary_app(model):
         origin="ch",
         series="focal",
         subordinate_to=[],
-        units={
-            "rabbitmq-server/0": COUUnit(
+        units=[
+            COUUnit(
                 name="rabbitmq-server/0",
                 workload_version="3.8",
                 machine=machines[0],
             )
-        },
+        ],
         workload_version="3.8",
     )
     assert app.channel == "3.8/stable"
@@ -87,13 +87,13 @@ def test_auxiliary_app_cs(model):
         origin="cs",
         series="focal",
         subordinate_to=[],
-        units={
-            "rabbitmq-server/0": COUUnit(
+        units=[
+            COUUnit(
                 name="rabbitmq-server/0",
                 workload_version="3.8",
                 machine=machines[0],
             )
-        },
+        ],
         workload_version="3.8",
     )
 
@@ -120,13 +120,13 @@ def test_auxiliary_upgrade_plan_ussuri_to_victoria_change_channel(model):
         origin="ch",
         series="focal",
         subordinate_to=[],
-        units={
-            "rabbitmq-server/0": COUUnit(
+        units=[
+            COUUnit(
                 name="rabbitmq-server/0",
                 workload_version="3.8",
                 machine=machines[0],
             )
-        },
+        ],
         workload_version="3.8",
     )
 
@@ -137,12 +137,12 @@ def test_auxiliary_upgrade_plan_ussuri_to_victoria_change_channel(model):
         description=f"Upgrade software packages of '{app.name}' from the current APT repositories",
         parallel=True,
     )
-    for unit in app.units.keys():
+    for unit in app.units:
         expected_upgrade_package_step.add_step(
             UnitUpgradeStep(
-                description=f"Upgrade software packages on unit {unit}",
+                description=f"Upgrade software packages on unit {unit.name}",
                 parallel=False,
-                coro=app_utils.upgrade_packages(unit, model, None),
+                coro=app_utils.upgrade_packages(unit.name, model, None),
             )
         )
 
@@ -177,10 +177,10 @@ def test_auxiliary_upgrade_plan_ussuri_to_victoria_change_channel(model):
         PostUpgradeStep(
             description=(
                 f"Check if the workload of '{app.name}' has been upgraded on units: "
-                f"{', '.join([unit for unit in app.units.keys()])}"
+                f"{', '.join(unit.name for unit in app.units)}"
             ),
             parallel=False,
-            coro=app._verify_workload_upgrade(target, app.units.values()),
+            coro=app._verify_workload_upgrade(target, app.units),
         ),
     ]
     add_steps(expected_plan, upgrade_steps)
@@ -204,13 +204,13 @@ def test_auxiliary_upgrade_plan_ussuri_to_victoria(model):
         origin="ch",
         series="focal",
         subordinate_to=[],
-        units={
-            "rabbitmq-server/0": COUUnit(
+        units=[
+            COUUnit(
                 name="rabbitmq-server/0",
                 workload_version="3.9",
                 machine=machines[0],
             )
-        },
+        ],
         workload_version="3.9",
     )
 
@@ -221,7 +221,7 @@ def test_auxiliary_upgrade_plan_ussuri_to_victoria(model):
         description=f"Upgrade software packages of '{app.name}' from the current APT repositories",
         parallel=True,
     )
-    for unit in app.units.values():
+    for unit in app.units:
         upgrade_packages.add_step(
             UnitUpgradeStep(
                 description=f"Upgrade software packages on unit {unit.name}",
@@ -255,10 +255,10 @@ def test_auxiliary_upgrade_plan_ussuri_to_victoria(model):
         PostUpgradeStep(
             description=(
                 f"Check if the workload of '{app.name}' has been upgraded on units: "
-                f"{', '.join([unit for unit in app.units.keys()])}"
+                f"{', '.join(unit.name for unit in app.units)}"
             ),
             parallel=False,
-            coro=app._verify_workload_upgrade(target, app.units.values()),
+            coro=app._verify_workload_upgrade(target, app.units),
         ),
     ]
     add_steps(expected_plan, upgrade_steps)
@@ -283,13 +283,13 @@ def test_auxiliary_upgrade_plan_ussuri_to_victoria_ch_migration(model):
         origin="cs",
         series="focal",
         subordinate_to=[],
-        units={
-            "rabbitmq-server/0": COUUnit(
+        units=[
+            COUUnit(
                 name="rabbitmq-server/0",
                 workload_version="3.8",
                 machine=machines[0],
             )
-        },
+        ],
         workload_version="3.8",
     )
 
@@ -300,7 +300,7 @@ def test_auxiliary_upgrade_plan_ussuri_to_victoria_ch_migration(model):
         description=f"Upgrade software packages of '{app.name}' from the current APT repositories",
         parallel=True,
     )
-    for unit in app.units.values():
+    for unit in app.units:
         upgrade_packages.add_step(
             UnitUpgradeStep(
                 description=f"Upgrade software packages on unit {unit.name}",
@@ -339,10 +339,10 @@ def test_auxiliary_upgrade_plan_ussuri_to_victoria_ch_migration(model):
         PostUpgradeStep(
             description=(
                 f"Check if the workload of '{app.name}' has been upgraded on units: "
-                f"{', '.join([unit for unit in app.units.keys()])}"
+                f"{', '.join(unit.name for unit in app.units)}"
             ),
             parallel=False,
-            coro=app._verify_workload_upgrade(target, app.units.values()),
+            coro=app._verify_workload_upgrade(target, app.units),
         ),
     ]
     add_steps(expected_plan, upgrade_steps)
@@ -374,13 +374,13 @@ def test_auxiliary_upgrade_plan_unknown_track(model):
             origin="ch",
             series="focal",
             subordinate_to=[],
-            units={
-                "rabbitmq-server/0": COUUnit(
+            units=[
+                COUUnit(
                     name="rabbitmq-server/0",
                     workload_version="3.8",
                     machine=machines[0],
                 )
-            },
+            ],
             workload_version="3.8",
         )
 
@@ -403,17 +403,17 @@ def test_auxiliary_app_unknown_version_raise_ApplicationError(model):
         origin="ch",
         series="focal",
         subordinate_to=[],
-        units={
-            f"{charm}/0": COUUnit(
+        units=[
+            COUUnit(
                 name=f"{charm}/0",
                 workload_version=version,
                 machine=machines[0],
             )
-        },
+        ],
         workload_version=version,
     )
     with pytest.raises(ApplicationError, match=exp_msg):
-        app._get_latest_os_version(app.units[f"{charm}/0"])
+        app._get_latest_os_version(app.units[0])
 
 
 def test_auxiliary_raise_error_unknown_series(model):
@@ -439,13 +439,13 @@ def test_auxiliary_raise_error_unknown_series(model):
             origin="ch",
             series=series,
             subordinate_to=[],
-            units={
-                "rabbitmq-server/0": COUUnit(
+            units=[
+                COUUnit(
                     name="rabbitmq-server/0",
                     workload_version="3.8",
                     machine=machines[0],
                 )
-            },
+            ],
             workload_version="3.8",
         )
 
@@ -470,13 +470,13 @@ def test_auxiliary_raise_error_os_not_on_lookup(current_os_release, model):
         origin="ch",
         series="focal",
         subordinate_to=[],
-        units={
-            "rabbitmq-server/0": COUUnit(
+        units=[
+            COUUnit(
                 name="rabbitmq-server/0",
                 workload_version="3.8",
                 machine=machines[0],
             )
-        },
+        ],
         workload_version="3.8",
     )
 
@@ -507,13 +507,13 @@ def test_auxiliary_raise_halt_upgrade(model):
         origin="ch",
         series="focal",
         subordinate_to=[],
-        units={
-            f"{charm}/0": COUUnit(
+        units=[
+            COUUnit(
                 name=f"{charm}/0",
                 workload_version="3.8",
                 machine=machines[0],
             )
-        },
+        ],
         workload_version="3.8",
     )
 
@@ -545,13 +545,13 @@ def test_auxiliary_no_suitable_channel(model):
         origin="ch",
         series="focal",
         subordinate_to=[],
-        units={
-            f"{charm}/0": COUUnit(
+        units=[
+            COUUnit(
                 name=f"{charm}/0",
                 workload_version="3.8",
                 machine=machines[0],
             )
-        },
+        ],
         workload_version="3.8",
     )
 
@@ -574,19 +574,19 @@ def test_ceph_mon_app(model):
         origin="ch",
         series="focal",
         subordinate_to=[],
-        units={
-            f"{charm}/0": COUUnit(
+        units=[
+            COUUnit(
                 name=f"{charm}/0",
                 workload_version="16.2.0",
                 machine=machines[0],
             )
-        },
+        ],
         workload_version="16.2.0",
     )
 
     assert app.channel == "pacific/stable"
     assert app.os_origin == "cloud:focal-xena"
-    assert app._get_latest_os_version(app.units[f"{charm}/0"]) == OpenStackRelease("xena")
+    assert app._get_latest_os_version(app.units[0]) == OpenStackRelease("xena")
     assert app.apt_source_codename == "xena"
     assert app.channel_codename == "xena"
     assert app.is_subordinate is False
@@ -608,13 +608,13 @@ def test_ceph_mon_upgrade_plan_xena_to_yoga(model):
         origin="ch",
         series="focal",
         subordinate_to=[],
-        units={
-            f"{charm}/0": COUUnit(
+        units=[
+            COUUnit(
                 name=f"{charm}/0",
                 workload_version="16.2.0",
                 machine=machines[0],
             )
-        },
+        ],
         workload_version="16.2.0",
     )
 
@@ -625,7 +625,7 @@ def test_ceph_mon_upgrade_plan_xena_to_yoga(model):
         description=f"Upgrade software packages of '{app.name}' from the current APT repositories",
         parallel=True,
     )
-    for unit in app.units.values():
+    for unit in app.units:
         upgrade_packages.add_step(
             UnitUpgradeStep(
                 description=f"Upgrade software packages on unit {unit.name}",
@@ -668,10 +668,10 @@ def test_ceph_mon_upgrade_plan_xena_to_yoga(model):
         PostUpgradeStep(
             description=(
                 f"Check if the workload of '{app.name}' has been upgraded on units: "
-                f"{', '.join([unit for unit in app.units.keys()])}"
+                f"{', '.join(unit.name for unit in app.units)}"
             ),
             parallel=False,
-            coro=app._verify_workload_upgrade(target, app.units.values()),
+            coro=app._verify_workload_upgrade(target, app.units),
         ),
     ]
     add_steps(expected_plan, upgrade_steps)
@@ -697,13 +697,13 @@ def test_ceph_mon_upgrade_plan_ussuri_to_victoria(model):
         origin="ch",
         series="focal",
         subordinate_to=[],
-        units={
-            f"{charm}/0": COUUnit(
+        units=[
+            COUUnit(
                 name=f"{charm}/0",
                 workload_version="15.2.0",
                 machine=machines[0],
             )
-        },
+        ],
         workload_version="15.2.0",
     )
 
@@ -714,7 +714,7 @@ def test_ceph_mon_upgrade_plan_ussuri_to_victoria(model):
         description=f"Upgrade software packages of '{app.name}' from the current APT repositories",
         parallel=True,
     )
-    for unit in app.units.values():
+    for unit in app.units:
         upgrade_packages.add_step(
             UnitUpgradeStep(
                 description=f"Upgrade software packages on unit {unit.name}",
@@ -752,10 +752,10 @@ def test_ceph_mon_upgrade_plan_ussuri_to_victoria(model):
         PostUpgradeStep(
             description=(
                 f"Check if the workload of '{app.name}' has been upgraded on units: "
-                f"{', '.join([unit for unit in app.units.keys()])}"
+                f"{', '.join(unit.name for unit in app.units)}"
             ),
             parallel=False,
-            coro=app._verify_workload_upgrade(target, app.units.values()),
+            coro=app._verify_workload_upgrade(target, app.units),
         ),
     ]
     add_steps(expected_plan, upgrade_steps)
@@ -780,13 +780,13 @@ def test_ovn_principal(model):
         origin="ch",
         series="focal",
         subordinate_to=[],
-        units={
-            f"{charm}/0": COUUnit(
+        units=[
+            COUUnit(
                 name=f"{charm}/0",
                 workload_version="22.03",
                 machine=machines[0],
             )
-        },
+        ],
         workload_version="22.03",
     )
     assert app.channel == "22.03/stable"
@@ -819,13 +819,13 @@ def test_ovn_workload_ver_lower_than_22_principal(model):
         origin="ch",
         series="focal",
         subordinate_to=[],
-        units={
-            f"{charm}/0": COUUnit(
+        units=[
+            COUUnit(
                 name=f"{charm}/0",
                 workload_version="20.03.2",
                 machine=machines[0],
             )
-        },
+        ],
         workload_version="20.03.2",
     )
 
@@ -857,13 +857,13 @@ def test_ovn_no_compatible_os_release(channel, model):
             origin="ch",
             series="focal",
             subordinate_to=[],
-            units={
-                f"{charm}/0": COUUnit(
+            units=[
+                COUUnit(
                     name=f"{charm}/0",
                     workload_version="22.03",
                     machine=machines[0],
                 )
-            },
+            ],
             workload_version="22.03",
         )
 
@@ -884,13 +884,13 @@ def test_ovn_principal_upgrade_plan(model):
         origin="ch",
         series="focal",
         subordinate_to=[],
-        units={
-            f"{charm}/0": COUUnit(
+        units=[
+            COUUnit(
                 name=f"{charm}/0",
                 workload_version="22.03",
                 machine=machines[0],
             )
-        },
+        ],
         workload_version="22.03",
     )
 
@@ -902,7 +902,7 @@ def test_ovn_principal_upgrade_plan(model):
         description=f"Upgrade software packages of '{app.name}' from the current APT repositories",
         parallel=True,
     )
-    for unit in app.units.values():
+    for unit in app.units:
         upgrade_packages.add_step(
             UnitUpgradeStep(
                 description=f"Upgrade software packages on unit {unit.name}",
@@ -935,10 +935,10 @@ def test_ovn_principal_upgrade_plan(model):
         PostUpgradeStep(
             description=(
                 f"Check if the workload of '{app.name}' has been upgraded on units: "
-                f"{', '.join([unit for unit in app.units.keys()])}"
+                f"{', '.join(unit.name for unit in app.units)}"
             ),
             parallel=False,
-            coro=app._verify_workload_upgrade(target, app.units.values()),
+            coro=app._verify_workload_upgrade(target, app.units),
         ),
     ]
     add_steps(expected_plan, upgrade_steps)
@@ -964,13 +964,13 @@ def test_mysql_innodb_cluster_upgrade(model):
         origin="ch",
         series="focal",
         subordinate_to=[],
-        units={
-            f"{charm}/0": COUUnit(
+        units=[
+            COUUnit(
                 name=f"{charm}/0",
                 workload_version="8.0",
                 machine=machines[0],
             )
-        },
+        ],
         workload_version="8.0",
     )
 
@@ -981,7 +981,7 @@ def test_mysql_innodb_cluster_upgrade(model):
         description=f"Upgrade software packages of '{app.name}' from the current APT repositories",
         parallel=True,
     )
-    for unit in app.units.values():
+    for unit in app.units:
         upgrade_packages.add_step(
             UnitUpgradeStep(
                 description=f"Upgrade software packages on unit {unit.name}",
@@ -1014,10 +1014,10 @@ def test_mysql_innodb_cluster_upgrade(model):
         PostUpgradeStep(
             description=(
                 f"Check if the workload of '{app.name}' has been upgraded on units: "
-                f"{', '.join([unit for unit in app.units.keys()])}"
+                f"{', '.join(unit.name for unit in app.units)}"
             ),
             parallel=False,
-            coro=app._verify_workload_upgrade(target, app.units.values()),
+            coro=app._verify_workload_upgrade(target, app.units),
         ),
     ]
     add_steps(expected_plan, upgrade_steps)

--- a/tests/unit/apps/test_auxiliary.py
+++ b/tests/unit/apps/test_auxiliary.py
@@ -43,7 +43,7 @@ def test_auxiliary_app(model):
     The version 3.8 on rabbitmq can be from ussuri to yoga. In that case it will be
     set as yoga.
     """
-    machines = {"0": MagicMock(spec_set=COUMachine)}
+    machines = [MagicMock(spec_set=COUMachine)]
     app = RabbitMQServer(
         name="rabbitmq-server",
         can_upgrade_to="",
@@ -59,7 +59,7 @@ def test_auxiliary_app(model):
             "rabbitmq-server/0": COUUnit(
                 name="rabbitmq-server/0",
                 workload_version="3.8",
-                machine=machines["0"],
+                machine=machines[0],
             )
         },
         workload_version="3.8",
@@ -75,7 +75,7 @@ def test_auxiliary_app(model):
 
 def test_auxiliary_app_cs(model):
     """Test auxiliary application from charm store."""
-    machines = {"0": MagicMock(spec_set=COUMachine)}
+    machines = [MagicMock(spec_set=COUMachine)]
     app = RabbitMQServer(
         name="rabbitmq-server",
         can_upgrade_to="",
@@ -91,7 +91,7 @@ def test_auxiliary_app_cs(model):
             "rabbitmq-server/0": COUUnit(
                 name="rabbitmq-server/0",
                 workload_version="3.8",
-                machine=machines["0"],
+                machine=machines[0],
             )
         },
         workload_version="3.8",
@@ -108,7 +108,7 @@ def test_auxiliary_app_cs(model):
 def test_auxiliary_upgrade_plan_ussuri_to_victoria_change_channel(model):
     """Test auxiliary upgrade plan from Ussuri to Victoria with change of channel."""
     target = OpenStackRelease("victoria")
-    machines = {"0": MagicMock(spec_set=COUMachine)}
+    machines = [MagicMock(spec_set=COUMachine)]
     app = RabbitMQServer(
         name="rabbitmq-server",
         can_upgrade_to="3.9/stable",
@@ -124,7 +124,7 @@ def test_auxiliary_upgrade_plan_ussuri_to_victoria_change_channel(model):
             "rabbitmq-server/0": COUUnit(
                 name="rabbitmq-server/0",
                 workload_version="3.8",
-                machine=machines["0"],
+                machine=machines[0],
             )
         },
         workload_version="3.8",
@@ -192,7 +192,7 @@ def test_auxiliary_upgrade_plan_ussuri_to_victoria_change_channel(model):
 def test_auxiliary_upgrade_plan_ussuri_to_victoria(model):
     """Test auxiliary upgrade plan from Ussuri to Victoria."""
     target = OpenStackRelease("victoria")
-    machines = {"0": MagicMock(spec_set=COUMachine)}
+    machines = [MagicMock(spec_set=COUMachine)]
     app = RabbitMQServer(
         name="rabbitmq-server",
         can_upgrade_to="3.9/stable",
@@ -208,7 +208,7 @@ def test_auxiliary_upgrade_plan_ussuri_to_victoria(model):
             "rabbitmq-server/0": COUUnit(
                 name="rabbitmq-server/0",
                 workload_version="3.9",
-                machine=machines["0"],
+                machine=machines[0],
             )
         },
         workload_version="3.9",
@@ -271,7 +271,7 @@ def test_auxiliary_upgrade_plan_ussuri_to_victoria(model):
 def test_auxiliary_upgrade_plan_ussuri_to_victoria_ch_migration(model):
     """Test auxiliary upgrade plan from Ussuri to Victoria with migration to charmhub."""
     target = OpenStackRelease("victoria")
-    machines = {"0": MagicMock(spec_set=COUMachine)}
+    machines = [MagicMock(spec_set=COUMachine)]
     app = RabbitMQServer(
         name="rabbitmq-server",
         can_upgrade_to="3.9/stable",
@@ -287,7 +287,7 @@ def test_auxiliary_upgrade_plan_ussuri_to_victoria_ch_migration(model):
             "rabbitmq-server/0": COUUnit(
                 name="rabbitmq-server/0",
                 workload_version="3.8",
-                machine=machines["0"],
+                machine=machines[0],
             )
         },
         workload_version="3.8",
@@ -361,7 +361,7 @@ def test_auxiliary_upgrade_plan_unknown_track(model):
         "https://docs.openstack.org/charm-guide/latest/project/charm-delivery.html "
         "to see if you are using the right track."
     )
-    machines = {"0": MagicMock(spec_set=COUMachine)}
+    machines = [MagicMock(spec_set=COUMachine)]
     with pytest.raises(ApplicationError, match=exp_msg):
         RabbitMQServer(
             name="rabbitmq-server",
@@ -378,7 +378,7 @@ def test_auxiliary_upgrade_plan_unknown_track(model):
                 "rabbitmq-server/0": COUUnit(
                     name="rabbitmq-server/0",
                     workload_version="3.8",
-                    machine=machines["0"],
+                    machine=machines[0],
                 )
             },
             workload_version="3.8",
@@ -391,7 +391,7 @@ def test_auxiliary_app_unknown_version_raise_ApplicationError(model):
     charm = "rabbitmq-server"
     exp_msg = f"'{charm}' with workload version {version} has no compatible OpenStack release."
 
-    machines = {"0": MagicMock(spec_set=COUMachine)}
+    machines = [MagicMock(spec_set=COUMachine)]
     app = RabbitMQServer(
         name=charm,
         can_upgrade_to="3.8/stable",
@@ -407,7 +407,7 @@ def test_auxiliary_app_unknown_version_raise_ApplicationError(model):
             f"{charm}/0": COUUnit(
                 name=f"{charm}/0",
                 workload_version=version,
-                machine=machines["0"],
+                machine=machines[0],
             )
         },
         workload_version=version,
@@ -426,7 +426,7 @@ def test_auxiliary_raise_error_unknown_series(model):
         "https://docs.openstack.org/charm-guide/latest/project/charm-delivery.html "
         "to see if you are using the right track."
     )
-    machines = {"0": MagicMock(spec_set=COUMachine)}
+    machines = [MagicMock(spec_set=COUMachine)]
     with pytest.raises(ApplicationError, match=exp_msg):
         RabbitMQServer(
             name="rabbitmq-server",
@@ -443,7 +443,7 @@ def test_auxiliary_raise_error_unknown_series(model):
                 "rabbitmq-server/0": COUUnit(
                     name="rabbitmq-server/0",
                     workload_version="3.8",
-                    machine=machines["0"],
+                    machine=machines[0],
                 )
             },
             workload_version="3.8",
@@ -458,7 +458,7 @@ def test_auxiliary_raise_error_os_not_on_lookup(current_os_release, model):
     """
     current_os_release.return_value = OpenStackRelease("diablo")
 
-    machines = {"0": MagicMock(spec_set=COUMachine)}
+    machines = [MagicMock(spec_set=COUMachine)]
     app = RabbitMQServer(
         name="rabbitmq-server",
         can_upgrade_to="",
@@ -474,7 +474,7 @@ def test_auxiliary_raise_error_os_not_on_lookup(current_os_release, model):
             "rabbitmq-server/0": COUUnit(
                 name="rabbitmq-server/0",
                 workload_version="3.8",
-                machine=machines["0"],
+                machine=machines[0],
             )
         },
         workload_version="3.8",
@@ -495,7 +495,7 @@ def test_auxiliary_raise_halt_upgrade(model):
         f"Application '{charm}' already configured for release equal or greater than {target}. "
         "Ignoring."
     )
-    machines = {"0": MagicMock(spec_set=COUMachine)}
+    machines = [MagicMock(spec_set=COUMachine)]
     app = RabbitMQServer(
         name=charm,
         can_upgrade_to="",
@@ -511,7 +511,7 @@ def test_auxiliary_raise_halt_upgrade(model):
             f"{charm}/0": COUUnit(
                 name=f"{charm}/0",
                 workload_version="3.8",
-                machine=machines["0"],
+                machine=machines[0],
             )
         },
         workload_version="3.8",
@@ -533,7 +533,7 @@ def test_auxiliary_no_suitable_channel(model):
         "Please take a look at the documentation: "
         "https://docs.openstack.org/charm-guide/latest/project/charm-delivery.html"
     )
-    machines = {"0": MagicMock(spec_set=COUMachine)}
+    machines = [MagicMock(spec_set=COUMachine)]
     app = RabbitMQServer(
         name=charm,
         can_upgrade_to="",
@@ -549,7 +549,7 @@ def test_auxiliary_no_suitable_channel(model):
             f"{charm}/0": COUUnit(
                 name=f"{charm}/0",
                 workload_version="3.8",
-                machine=machines["0"],
+                machine=machines[0],
             )
         },
         workload_version="3.8",
@@ -562,7 +562,7 @@ def test_auxiliary_no_suitable_channel(model):
 def test_ceph_mon_app(model):
     """Test the correctness of instantiating CephMonApplication."""
     charm = "ceph-mon"
-    machines = {"0": MagicMock(spec_set=COUMachine)}
+    machines = [MagicMock(spec_set=COUMachine)]
     app = CephMonApplication(
         name=charm,
         can_upgrade_to="",
@@ -578,7 +578,7 @@ def test_ceph_mon_app(model):
             f"{charm}/0": COUUnit(
                 name=f"{charm}/0",
                 workload_version="16.2.0",
-                machine=machines["0"],
+                machine=machines[0],
             )
         },
         workload_version="16.2.0",
@@ -596,7 +596,7 @@ def test_ceph_mon_upgrade_plan_xena_to_yoga(model):
     """Test when ceph version changes between os releases."""
     target = OpenStackRelease("yoga")
     charm = "ceph-mon"
-    machines = {"0": MagicMock(spec_set=COUMachine)}
+    machines = [MagicMock(spec_set=COUMachine)]
     app = CephMonApplication(
         name=charm,
         can_upgrade_to="quincy/stable",
@@ -612,7 +612,7 @@ def test_ceph_mon_upgrade_plan_xena_to_yoga(model):
             f"{charm}/0": COUUnit(
                 name=f"{charm}/0",
                 workload_version="16.2.0",
-                machine=machines["0"],
+                machine=machines[0],
             )
         },
         workload_version="16.2.0",
@@ -685,7 +685,7 @@ def test_ceph_mon_upgrade_plan_ussuri_to_victoria(model):
     """Test when ceph version remains the same between os releases."""
     target = OpenStackRelease("victoria")
     charm = "ceph-mon"
-    machines = {"0": MagicMock(spec_set=COUMachine)}
+    machines = [MagicMock(spec_set=COUMachine)]
     app = CephMonApplication(
         name=charm,
         can_upgrade_to="quincy/stable",
@@ -701,7 +701,7 @@ def test_ceph_mon_upgrade_plan_ussuri_to_victoria(model):
             f"{charm}/0": COUUnit(
                 name=f"{charm}/0",
                 workload_version="15.2.0",
-                machine=machines["0"],
+                machine=machines[0],
             )
         },
         workload_version="15.2.0",
@@ -768,7 +768,7 @@ def test_ceph_mon_upgrade_plan_ussuri_to_victoria(model):
 def test_ovn_principal(model):
     """Test the correctness of instantiating OvnPrincipalApplication."""
     charm = "ovn-central"
-    machines = {"0": MagicMock(spec_set=COUMachine)}
+    machines = [MagicMock(spec_set=COUMachine)]
     app = OvnPrincipalApplication(
         name=charm,
         can_upgrade_to="22.06/stable",
@@ -784,7 +784,7 @@ def test_ovn_principal(model):
             f"{charm}/0": COUUnit(
                 name=f"{charm}/0",
                 workload_version="22.03",
-                machine=machines["0"],
+                machine=machines[0],
             )
         },
         workload_version="22.03",
@@ -807,7 +807,7 @@ def test_ovn_workload_ver_lower_than_22_principal(model):
         "https://docs.openstack.org/charm-guide/latest/project/procedures/"
         "ovn-upgrade-2203.html"
     )
-    machines = {"0": MagicMock(spec_set=COUMachine)}
+    machines = [MagicMock(spec_set=COUMachine)]
     app = OvnPrincipalApplication(
         name=charm,
         can_upgrade_to="22.03/stable",
@@ -823,7 +823,7 @@ def test_ovn_workload_ver_lower_than_22_principal(model):
             f"{charm}/0": COUUnit(
                 name=f"{charm}/0",
                 workload_version="20.03.2",
-                machine=machines["0"],
+                machine=machines[0],
             )
         },
         workload_version="20.03.2",
@@ -837,7 +837,7 @@ def test_ovn_workload_ver_lower_than_22_principal(model):
 def test_ovn_no_compatible_os_release(channel, model):
     """Test the OvnPrincipalApplication with not compatible os release."""
     charm = "ovn-central"
-    machines = {"0": MagicMock(spec_set=COUMachine)}
+    machines = [MagicMock(spec_set=COUMachine)]
     exp_msg = (
         f"Channel: {channel} for charm '{charm}' on series 'focal' is currently "
         "not supported in this tool. Please take a look at the documentation: "
@@ -861,7 +861,7 @@ def test_ovn_no_compatible_os_release(channel, model):
                 f"{charm}/0": COUUnit(
                     name=f"{charm}/0",
                     workload_version="22.03",
-                    machine=machines["0"],
+                    machine=machines[0],
                 )
             },
             workload_version="22.03",
@@ -872,7 +872,7 @@ def test_ovn_principal_upgrade_plan(model):
     """Test generating plan for OvnPrincipalApplication."""
     target = OpenStackRelease("victoria")
     charm = "ovn-central"
-    machines = {"0": MagicMock(spec_set=COUMachine)}
+    machines = [MagicMock(spec_set=COUMachine)]
     app = OvnPrincipalApplication(
         name=charm,
         can_upgrade_to="22.06/stable",
@@ -888,7 +888,7 @@ def test_ovn_principal_upgrade_plan(model):
             f"{charm}/0": COUUnit(
                 name=f"{charm}/0",
                 workload_version="22.03",
-                machine=machines["0"],
+                machine=machines[0],
             )
         },
         workload_version="22.03",
@@ -952,7 +952,7 @@ def test_mysql_innodb_cluster_upgrade(model):
     """Test generating plan for MysqlInnodbClusterApplication."""
     target = OpenStackRelease("victoria")
     charm = "mysql-innodb-cluster"
-    machines = {"0": MagicMock(spec_set=COUMachine)}
+    machines = [MagicMock(spec_set=COUMachine)]
     app = MysqlInnodbClusterApplication(
         name=charm,
         can_upgrade_to="9.0",
@@ -968,7 +968,7 @@ def test_mysql_innodb_cluster_upgrade(model):
             f"{charm}/0": COUUnit(
                 name=f"{charm}/0",
                 workload_version="8.0",
-                machine=machines["0"],
+                machine=machines[0],
             )
         },
         workload_version="8.0",

--- a/tests/unit/apps/test_auxiliary_subordinate.py
+++ b/tests/unit/apps/test_auxiliary_subordinate.py
@@ -31,7 +31,7 @@ from tests.unit.utils import assert_steps
 
 def test_auxiliary_subordinate(model):
     """Test auxiliary subordinate application."""
-    machines = {"0": MagicMock(spec_set=COUMachine)}
+    machines = [MagicMock(spec_set=COUMachine)]
     app = OpenStackAuxiliarySubordinateApplication(
         name="keystone-mysql-router",
         can_upgrade_to="",
@@ -47,7 +47,7 @@ def test_auxiliary_subordinate(model):
             "keystone-mysql-router/0": COUUnit(
                 name="keystone-mysql-router/0",
                 workload_version="8.0",
-                machine=machines["0"],
+                machine=machines[0],
             )
         },
         workload_version="8.0",
@@ -65,7 +65,7 @@ def test_auxiliary_subordinate(model):
 def test_auxiliary_subordinate_upgrade_plan_to_victoria(model):
     """Test auxiliary subordinate application upgrade plan to victoria."""
     target = OpenStackRelease("victoria")
-    machines = {"0": MagicMock(spec_set=COUMachine)}
+    machines = [MagicMock(spec_set=COUMachine)]
     app = OpenStackAuxiliarySubordinateApplication(
         name="keystone-mysql-router",
         can_upgrade_to="8.0/stable",
@@ -81,7 +81,7 @@ def test_auxiliary_subordinate_upgrade_plan_to_victoria(model):
             "keystone-mysql-router/0": COUUnit(
                 name="keystone-mysql-router/0",
                 workload_version="8.0",
-                machine=machines["0"],
+                machine=machines[0],
             )
         },
         workload_version="8.0",
@@ -105,7 +105,7 @@ def test_auxiliary_subordinate_upgrade_plan_to_victoria(model):
 
 def test_ovn_subordinate(model):
     """Test the correctness of instantiating OvnSubordinateApplication."""
-    machines = {"0": MagicMock(spec_set=COUMachine)}
+    machines = [MagicMock(spec_set=COUMachine)]
     app = OvnSubordinateApplication(
         name="ovn-chassis",
         can_upgrade_to="22.03/stable",
@@ -121,7 +121,7 @@ def test_ovn_subordinate(model):
             "ovn-chassis/0": COUUnit(
                 name="ovn-chassis/0",
                 workload_version="22.03",
-                machine=machines["0"],
+                machine=machines[0],
             )
         },
         workload_version="22.3",
@@ -138,7 +138,7 @@ def test_ovn_subordinate(model):
 def test_ovn_workload_ver_lower_than_22_subordinate(model):
     """Test the OvnSubordinateApplication with lower version than 22."""
     target = OpenStackRelease("victoria")
-    machines = {"0": MagicMock(spec_set=COUMachine)}
+    machines = [MagicMock(spec_set=COUMachine)]
     exp_msg = (
         "OVN versions lower than 22.03 are not supported. It's necessary to upgrade "
         "OVN to 22.03 before upgrading the cloud. Follow the instructions at: "
@@ -160,7 +160,7 @@ def test_ovn_workload_ver_lower_than_22_subordinate(model):
             "ovn-chassis/0": COUUnit(
                 name="ovn-chassis/0",
                 workload_version="20.03",
-                machine=machines["0"],
+                machine=machines[0],
             )
         },
         workload_version="20.3",
@@ -173,7 +173,7 @@ def test_ovn_workload_ver_lower_than_22_subordinate(model):
 def test_ovn_subordinate_upgrade_plan(model):
     """Test generating plan for OvnSubordinateApplication."""
     target = OpenStackRelease("victoria")
-    machines = {"0": MagicMock(spec_set=COUMachine)}
+    machines = [MagicMock(spec_set=COUMachine)]
     app = OvnSubordinateApplication(
         name="ovn-chassis",
         can_upgrade_to="22.03/stable",
@@ -189,7 +189,7 @@ def test_ovn_subordinate_upgrade_plan(model):
             "ovn-chassis/0": COUUnit(
                 name="ovn-chassis/0",
                 workload_version="22.03",
-                machine=machines["0"],
+                machine=machines[0],
             )
         },
         workload_version="22.3",
@@ -220,7 +220,7 @@ def test_ovn_subordinate_upgrade_plan_cant_upgrade_charm(model):
     there is no steps to upgrade.
     """
     target = OpenStackRelease("victoria")
-    machines = {"0": MagicMock(spec_set=COUMachine)}
+    machines = [MagicMock(spec_set=COUMachine)]
     app = OvnSubordinateApplication(
         name="ovn-chassis",
         can_upgrade_to="",
@@ -236,7 +236,7 @@ def test_ovn_subordinate_upgrade_plan_cant_upgrade_charm(model):
             "ovn-chassis/0": COUUnit(
                 name="ovn-chassis/0",
                 workload_version="22.03",
-                machine=machines["0"],
+                machine=machines[0],
             )
         },
         workload_version="22.3",
@@ -255,7 +255,7 @@ def test_ovn_subordinate_upgrade_plan_cant_upgrade_charm(model):
 def test_ceph_dashboard_upgrade_plan_ussuri_to_victoria(model):
     """Test when ceph version remains the same between os releases."""
     target = OpenStackRelease("victoria")
-    machines = {"0": MagicMock(spec_set=COUMachine)}
+    machines = [MagicMock(spec_set=COUMachine)]
     app = OpenStackAuxiliarySubordinateApplication(
         name="ceph-dashboard",
         can_upgrade_to="octopus/stable",
@@ -271,7 +271,7 @@ def test_ceph_dashboard_upgrade_plan_ussuri_to_victoria(model):
             "ceph-dashboard/0": COUUnit(
                 name="ceph-dashboard/0",
                 workload_version="15.2.0",
-                machine=machines["0"],
+                machine=machines[0],
             )
         },
         workload_version="15.2.0",
@@ -298,7 +298,7 @@ def test_ceph_dashboard_upgrade_plan_ussuri_to_victoria(model):
 def test_ceph_dashboard_upgrade_plan_xena_to_yoga(model):
     """Test when ceph version changes between os releases."""
     target = OpenStackRelease("yoga")
-    machines = {"0": MagicMock(spec_set=COUMachine)}
+    machines = [MagicMock(spec_set=COUMachine)]
     app = OpenStackAuxiliarySubordinateApplication(
         name="ceph-dashboard",
         can_upgrade_to="pacific/stable",
@@ -314,7 +314,7 @@ def test_ceph_dashboard_upgrade_plan_xena_to_yoga(model):
             "ceph-dashboard/0": COUUnit(
                 name="ceph-dashboard/0",
                 workload_version="16.2.0",
-                machine=machines["0"],
+                machine=machines[0],
             )
         },
         workload_version="16.2.0",

--- a/tests/unit/apps/test_auxiliary_subordinate.py
+++ b/tests/unit/apps/test_auxiliary_subordinate.py
@@ -43,13 +43,13 @@ def test_auxiliary_subordinate(model):
         origin="ch",
         series="focal",
         subordinate_to=["keystone"],
-        units={
-            "keystone-mysql-router/0": COUUnit(
+        units=[
+            COUUnit(
                 name="keystone-mysql-router/0",
                 workload_version="8.0",
                 machine=machines[0],
             )
-        },
+        ],
         workload_version="8.0",
     )
 
@@ -77,13 +77,13 @@ def test_auxiliary_subordinate_upgrade_plan_to_victoria(model):
         origin="ch",
         series="focal",
         subordinate_to=["keystone"],
-        units={
-            "keystone-mysql-router/0": COUUnit(
+        units=[
+            COUUnit(
                 name="keystone-mysql-router/0",
                 workload_version="8.0",
                 machine=machines[0],
             )
-        },
+        ],
         workload_version="8.0",
     )
 
@@ -117,13 +117,13 @@ def test_ovn_subordinate(model):
         origin="ch",
         series="focal",
         subordinate_to=["nova-compute"],
-        units={
-            "ovn-chassis/0": COUUnit(
+        units=[
+            COUUnit(
                 name="ovn-chassis/0",
                 workload_version="22.03",
                 machine=machines[0],
             )
-        },
+        ],
         workload_version="22.3",
     )
 
@@ -156,13 +156,13 @@ def test_ovn_workload_ver_lower_than_22_subordinate(model):
         origin="ch",
         series="focal",
         subordinate_to=["nova-compute"],
-        units={
-            "ovn-chassis/0": COUUnit(
+        units=[
+            COUUnit(
                 name="ovn-chassis/0",
                 workload_version="20.03",
                 machine=machines[0],
             )
-        },
+        ],
         workload_version="20.3",
     )
 
@@ -185,13 +185,13 @@ def test_ovn_subordinate_upgrade_plan(model):
         origin="ch",
         series="focal",
         subordinate_to=["nova-compute"],
-        units={
-            "ovn-chassis/0": COUUnit(
+        units=[
+            COUUnit(
                 name="ovn-chassis/0",
                 workload_version="22.03",
                 machine=machines[0],
             )
-        },
+        ],
         workload_version="22.3",
     )
 
@@ -232,13 +232,13 @@ def test_ovn_subordinate_upgrade_plan_cant_upgrade_charm(model):
         origin="ch",
         series="focal",
         subordinate_to=["nova-compute"],
-        units={
-            "ovn-chassis/0": COUUnit(
+        units=[
+            COUUnit(
                 name="ovn-chassis/0",
                 workload_version="22.03",
                 machine=machines[0],
             )
-        },
+        ],
         workload_version="22.3",
     )
 
@@ -267,13 +267,13 @@ def test_ceph_dashboard_upgrade_plan_ussuri_to_victoria(model):
         origin="ch",
         series="focal",
         subordinate_to=["nova-compute"],
-        units={
-            "ceph-dashboard/0": COUUnit(
+        units=[
+            COUUnit(
                 name="ceph-dashboard/0",
                 workload_version="15.2.0",
                 machine=machines[0],
             )
-        },
+        ],
         workload_version="15.2.0",
     )
 
@@ -310,13 +310,13 @@ def test_ceph_dashboard_upgrade_plan_xena_to_yoga(model):
         origin="ch",
         series="focal",
         subordinate_to=["nova-compute"],
-        units={
-            "ceph-dashboard/0": COUUnit(
+        units=[
+            COUUnit(
                 name="ceph-dashboard/0",
                 workload_version="16.2.0",
                 machine=machines[0],
             )
-        },
+        ],
         workload_version="16.2.0",
     )
 

--- a/tests/unit/apps/test_base.py
+++ b/tests/unit/apps/test_base.py
@@ -139,11 +139,11 @@ def test_get_pause_unit_step(model):
     charm = "app"
     app_name = "my_app"
     channel = "ussuri/stable"
-    machines = {"0": MagicMock(spec_set=COUMachine)}
+    machines = [MagicMock(spec_set=COUMachine)]
     unit = COUUnit(
         name=f"{app_name}/0",
         workload_version="1",
-        machine=machines["0"],
+        machine=machines[0],
     )
     expected_upgrade_step = UnitUpgradeStep(
         description=f"Pause the unit: '{unit.name}'.",
@@ -174,11 +174,11 @@ def test_get_resume_unit_step(model):
     charm = "app"
     app_name = "my_app"
     channel = "ussuri/stable"
-    machines = {"0": MagicMock(spec_set=COUMachine)}
+    machines = [MagicMock(spec_set=COUMachine)]
     unit = COUUnit(
         name=f"{app_name}/0",
         workload_version="1",
-        machine=machines["0"],
+        machine=machines[0],
     )
     expected_upgrade_step = UnitUpgradeStep(
         description=f"Resume the unit: '{unit.name}'.",
@@ -207,11 +207,11 @@ def test_get_openstack_upgrade_step(model):
     charm = "app"
     app_name = "my_app"
     channel = "ussuri/stable"
-    machines = {"0": MagicMock(spec_set=COUMachine)}
+    machines = [MagicMock(spec_set=COUMachine)]
     unit = COUUnit(
         name=f"{app_name}/0",
         workload_version="1",
-        machine=machines["0"],
+        machine=machines[0],
     )
     expected_upgrade_step = UnitUpgradeStep(
         description=f"Upgrade the unit: '{unit.name}'.",

--- a/tests/unit/apps/test_base.py
+++ b/tests/unit/apps/test_base.py
@@ -33,12 +33,12 @@ def test_openstack_application_magic_functions(model):
         charm="app",
         channel="stable",
         config={},
-        machines={},
+        machines=[],
         model=model,
         origin="ch",
         series="focal",
         subordinate_to=[],
-        units={},
+        units=[],
         workload_version="1",
     )
 
@@ -69,12 +69,12 @@ def test_application_get_latest_os_version_failed(mock_find_compatible_versions,
         charm=charm,
         channel="stable",
         config={},
-        machines={},
+        machines=[],
         model=model,
         origin="ch",
         series="focal",
         subordinate_to=[],
-        units={f"{app_name}/0": unit},
+        units=[unit],
         workload_version=unit.workload_version,
     )
 
@@ -122,12 +122,12 @@ def test_set_action_managed_upgrade(charm_config, enable, exp_description, model
         charm=charm,
         channel=channel,
         config=charm_config,
-        machines={},
+        machines=[],
         model=model,
         origin="ch",
         series="focal",
         subordinate_to=[],
-        units={},
+        units=[],
         workload_version="1",
     )
 
@@ -139,11 +139,11 @@ def test_get_pause_unit_step(model):
     charm = "app"
     app_name = "my_app"
     channel = "ussuri/stable"
-    machines = [MagicMock(spec_set=COUMachine)]
+    machine = MagicMock(spec_set=COUMachine)
     unit = COUUnit(
         name=f"{app_name}/0",
         workload_version="1",
-        machine=machines[0],
+        machine=machine,
     )
     expected_upgrade_step = UnitUpgradeStep(
         description=f"Pause the unit: '{unit.name}'.",
@@ -157,12 +157,12 @@ def test_get_pause_unit_step(model):
         charm=charm,
         channel=channel,
         config={},
-        machines=machines,
+        machines=[machine],
         model=model,
         origin="ch",
         series="focal",
         subordinate_to=[],
-        units={f"{unit.name}": unit},
+        units=[unit],
         workload_version="1",
     )
 
@@ -174,11 +174,11 @@ def test_get_resume_unit_step(model):
     charm = "app"
     app_name = "my_app"
     channel = "ussuri/stable"
-    machines = [MagicMock(spec_set=COUMachine)]
+    machine = MagicMock(spec_set=COUMachine)
     unit = COUUnit(
         name=f"{app_name}/0",
         workload_version="1",
-        machine=machines[0],
+        machine=machine,
     )
     expected_upgrade_step = UnitUpgradeStep(
         description=f"Resume the unit: '{unit.name}'.",
@@ -190,12 +190,12 @@ def test_get_resume_unit_step(model):
         charm=charm,
         channel=channel,
         config={},
-        machines=machines,
+        machines=[machine],
         model=model,
         origin="ch",
         series="focal",
         subordinate_to=[],
-        units={f"{app_name}/0": unit},
+        units=[unit],
         workload_version="1",
     )
 
@@ -207,11 +207,11 @@ def test_get_openstack_upgrade_step(model):
     charm = "app"
     app_name = "my_app"
     channel = "ussuri/stable"
-    machines = [MagicMock(spec_set=COUMachine)]
+    machine = MagicMock(spec_set=COUMachine)
     unit = COUUnit(
         name=f"{app_name}/0",
         workload_version="1",
-        machine=machines[0],
+        machine=machine,
     )
     expected_upgrade_step = UnitUpgradeStep(
         description=f"Upgrade the unit: '{unit.name}'.",
@@ -225,12 +225,12 @@ def test_get_openstack_upgrade_step(model):
         charm=charm,
         channel=channel,
         config={},
-        machines=machines,
+        machines=[machine],
         model=model,
         origin="ch",
         series="focal",
         subordinate_to=[],
-        units={f"{app_name}/0": unit},
+        units=[unit],
         workload_version="1",
     )
 
@@ -252,9 +252,7 @@ def test_get_upgrade_current_release_packages_step(mock_upgrade_packages, units,
     charm = "app"
     app_name = "my_app"
     channel = "ussuri/stable"
-    app_units = {
-        f"my_app/{unit}": COUUnit(f"my_app/{unit}", MagicMock(), MagicMock()) for unit in range(3)
-    }
+    app_units = [COUUnit(f"my_app/{unit}", MagicMock(), MagicMock()) for unit in range(3)]
 
     app = OpenStackApplication(
         app_name, "", charm, channel, {}, {}, model, "ch", "focal", [], app_units, "21.0.1"
@@ -263,7 +261,7 @@ def test_get_upgrade_current_release_packages_step(mock_upgrade_packages, units,
     expected_calls = (
         [call(unit.name, model, None) for unit in units]
         if units
-        else [call(unit.name, model, None) for unit in app_units.values()]
+        else [call(unit.name, model, None) for unit in app_units]
     )
 
     app._get_upgrade_current_release_packages_step(units)
@@ -286,13 +284,13 @@ def test_get_reached_expected_target_step(mock_workload_upgrade, units, model):
     charm = "app"
     app_name = "my_app"
     channel = "ussuri/stable"
-    app_units = {f"my_app/{unit}": COUUnit(f"my_app/{unit}", mock, mock) for unit in range(3)}
+    app_units = [COUUnit(f"my_app/{unit}", mock, mock) for unit in range(3)]
 
     app = OpenStackApplication(
         app_name, "", charm, channel, {}, {}, model, "ch", "focal", [], app_units, "21.0.1"
     )
 
-    expected_calls = [call(target, units)] if units else [call(target, list(app.units.values()))]
+    expected_calls = [call(target, units)] if units else [call(target, app.units)]
 
     app._get_reached_expected_target_step(target, units)
     mock_workload_upgrade.assert_has_calls(expected_calls)

--- a/tests/unit/apps/test_channel_based.py
+++ b/tests/unit/apps/test_channel_based.py
@@ -54,6 +54,34 @@ def test_application_versionless(model):
     assert app._get_latest_os_version(units[0]) == app.channel_codename
 
 
+def test_versionless_post_upgrade_steps(model):
+    """Test application without version generating post-upgrade steps."""
+    target = OpenStackRelease("victoria")
+    machines = [MagicMock(spec_set=COUMachine)]
+    units = [COUUnit("glance-simplestreams-sync/0", machines[0], "")]
+    app = OpenStackChannelBasedApplication(
+        name="glance-simplestreams-sync",
+        can_upgrade_to="",
+        charm="glance-simplestreams-sync",
+        channel="ussuri/stable",
+        config={
+            "openstack-origin": {"value": "distro"},
+            "action-managed-upgrade": {"value": True},
+        },
+        machines=machines,
+        model=model,
+        origin="ch",
+        series="focal",
+        subordinate_to=[],
+        units=units,
+        workload_version="",
+    )
+
+    assert (
+        app.post_upgrade_steps(target, None) == []
+    ), "versionless app should not generate post-upgrade stpes"
+
+
 def test_application_gnocchi_ussuri(model):
     """Test the Gnocchi OpenStackChannelBasedApplication with Ussuri."""
     machines = [MagicMock(spec_set=COUMachine)]

--- a/tests/unit/apps/test_channel_based.py
+++ b/tests/unit/apps/test_channel_based.py
@@ -29,12 +29,12 @@ from tests.unit.utils import assert_steps
 
 def test_application_versionless(model):
     """Test application without version."""
-    machines = {"0": MagicMock(spec_set=COUMachine)}
+    machines = [MagicMock(spec_set=COUMachine)]
     units = {
         "glance-simplestreams-sync/0": COUUnit(
             name="glance-simplestreams-sync/0",
             workload_version="",
-            machine=machines["0"],
+            machine=machines[0],
         )
     }
     app = OpenStackChannelBasedApplication(
@@ -62,7 +62,7 @@ def test_application_versionless(model):
 
 def test_application_gnocchi_ussuri(model):
     """Test the Gnocchi OpenStackChannelBasedApplication with Ussuri."""
-    machines = {"0": MagicMock(spec_set=COUMachine)}
+    machines = [MagicMock(spec_set=COUMachine)]
     app = OpenStackChannelBasedApplication(
         name="gnocchi",
         can_upgrade_to="",
@@ -81,7 +81,7 @@ def test_application_gnocchi_ussuri(model):
             "gnocchi/0": COUUnit(
                 name="gnocchi/0",
                 workload_version="4.3.4",
-                machine=machines["0"],
+                machine=machines[0],
             )
         },
         workload_version="4.3.4",
@@ -97,7 +97,7 @@ def test_application_gnocchi_xena(model):
     The workload version is the same for xena and yoga, but current_os_release is based on
     the channel.
     """
-    machines = {"0": MagicMock(spec_set=COUMachine)}
+    machines = [MagicMock(spec_set=COUMachine)]
     app = OpenStackChannelBasedApplication(
         name="gnocchi",
         can_upgrade_to="",
@@ -113,7 +113,7 @@ def test_application_gnocchi_xena(model):
             "gnocchi/0": COUUnit(
                 name="gnocchi/0",
                 workload_version="4.4.1",
-                machine=machines["0"],
+                machine=machines[0],
             )
         },
         workload_version="4.4.1",
@@ -129,7 +129,7 @@ def test_application_designate_bind_ussuri(model):
     The workload version is the same from ussuri to yoga, but current_os_release is based on
     the channel.
     """
-    machines = {"0": MagicMock(spec_set=COUMachine)}
+    machines = [MagicMock(spec_set=COUMachine)]
     app = OpenStackChannelBasedApplication(
         name="designate-bind",
         can_upgrade_to="",
@@ -148,7 +148,7 @@ def test_application_designate_bind_ussuri(model):
             "designate-bind/0": COUUnit(
                 name="designate-bind/0",
                 workload_version="9.16.1",
-                machine=machines["0"],
+                machine=machines[0],
             )
         },
         workload_version="9.16.1",
@@ -161,7 +161,7 @@ def test_application_designate_bind_ussuri(model):
 def test_application_versionless_upgrade_plan_ussuri_to_victoria(model):
     """Test generating plan for glance-simplestreams-sync (OpenStackChannelBasedApplication)."""
     target = OpenStackRelease("victoria")
-    machines = {"0": MagicMock(spec_set=COUMachine)}
+    machines = [MagicMock(spec_set=COUMachine)]
     app = OpenStackChannelBasedApplication(
         name="glance-simplestreams-sync",
         can_upgrade_to="ussuri/stable",
@@ -177,7 +177,7 @@ def test_application_versionless_upgrade_plan_ussuri_to_victoria(model):
             "glance-simplestreams-sync/0": COUUnit(
                 name="glance-simplestreams-sync/0",
                 workload_version="",
-                machine=machines["0"],
+                machine=machines[0],
             )
         },
         workload_version="",
@@ -237,7 +237,7 @@ def test_application_gnocchi_upgrade_plan_ussuri_to_victoria(model):
     Updating Gnocchi from ussuri to victoria increases the workload version from 4.3.4 to 4.4.0.
     """
     target = OpenStackRelease("victoria")
-    machines = {"0": MagicMock(spec_set=COUMachine)}
+    machines = [MagicMock(spec_set=COUMachine)]
     app = OpenStackChannelBasedApplication(
         name="gnocchi",
         can_upgrade_to="ussuri/stable",
@@ -256,7 +256,7 @@ def test_application_gnocchi_upgrade_plan_ussuri_to_victoria(model):
             "gnocchi/0": COUUnit(
                 name="gnocchi/0",
                 workload_version="4.3.4",
-                machine=machines["0"],
+                machine=machines[0],
             )
         },
         workload_version="4.3.4",
@@ -326,7 +326,7 @@ def test_application_gnocchi_upgrade_plan_ussuri_to_victoria(model):
 def test_application_designate_bind_upgrade_plan_ussuri_to_victoria(model):
     """Test generating plan for Designate-bind (OpenStackChannelBasedApplication)."""
     target = OpenStackRelease("victoria")
-    machines = {"0": MagicMock(spec_set=COUMachine)}
+    machines = [MagicMock(spec_set=COUMachine)]
     app = OpenStackChannelBasedApplication(
         name="designate-bind",
         can_upgrade_to="ussuri/stable",
@@ -345,7 +345,7 @@ def test_application_designate_bind_upgrade_plan_ussuri_to_victoria(model):
             "designate-bind/0": COUUnit(
                 name="designate-bind/0",
                 workload_version="9.16.1",
-                machine=machines["0"],
+                machine=machines[0],
             )
         },
         workload_version="9.16.1",

--- a/tests/unit/apps/test_core.py
+++ b/tests/unit/apps/test_core.py
@@ -45,26 +45,26 @@ def test_application_different_wl(model):
         "This is not currently handled."
     )
 
-    machines = {
-        "0": MagicMock(spec_set=COUMachine),
-        "1": MagicMock(spec_set=COUMachine),
-        "2": MagicMock(spec_set=COUMachine),
-    }
+    machines = [
+        MagicMock(spec_set=COUMachine),
+        MagicMock(spec_set=COUMachine),
+        MagicMock(spec_set=COUMachine),
+    ]
     units = {
         "keystone/0": COUUnit(
             name="keystone/0",
             workload_version="17.0.1",
-            machine=machines["0"],
+            machine=machines[0],
         ),
         "keystone/1": COUUnit(
             name="keystone/1",
             workload_version="17.0.1",
-            machine=machines["1"],
+            machine=machines[1],
         ),
         "keystone/2": COUUnit(
             name="keystone/2",
             workload_version="18.1.0",
-            machine=machines["2"],
+            machine=machines[2],
         ),
     }
     app = Keystone(
@@ -88,7 +88,7 @@ def test_application_different_wl(model):
 
 def test_application_no_origin_config(model):
     """Test Keystone application without origin."""
-    machines = {"0": MagicMock(spec_set=COUMachine)}
+    machines = [MagicMock(spec_set=COUMachine)]
     app = Keystone(
         name="keystone",
         can_upgrade_to="ussuri/stable",
@@ -104,7 +104,7 @@ def test_application_no_origin_config(model):
             "keystone/0": COUUnit(
                 name="keystone/0",
                 workload_version="18.0.1",
-                machine=machines["0"],
+                machine=machines[0],
             )
         },
         workload_version="18.1.0",
@@ -116,7 +116,7 @@ def test_application_no_origin_config(model):
 
 def test_application_empty_origin_config(model):
     """Test Keystone application with empty origin."""
-    machines = {"0": MagicMock(spec_set=COUMachine)}
+    machines = [MagicMock(spec_set=COUMachine)]
     app = Keystone(
         name="keystone",
         can_upgrade_to="ussuri/stable",
@@ -132,7 +132,7 @@ def test_application_empty_origin_config(model):
             "keystone/0": COUUnit(
                 name="keystone/0",
                 workload_version="18.0.1",
-                machine=machines["0"],
+                machine=machines[0],
             )
         },
         workload_version="18.1.0",
@@ -148,7 +148,7 @@ def test_application_unexpected_channel(model):
         "'keystone' has unexpected channel: 'ussuri/stable' for the current workload version "
         "and OpenStack release: 'wallaby'. Possible channels are: wallaby/stable"
     )
-    machines = {"0": MagicMock(spec_set=COUMachine)}
+    machines = [MagicMock(spec_set=COUMachine)]
     app = Keystone(
         name="keystone",
         can_upgrade_to="ussuri/stable",
@@ -164,7 +164,7 @@ def test_application_unexpected_channel(model):
             "keystone/0": COUUnit(
                 name="keystone/0",
                 workload_version="19.0.1",
-                machine=machines["0"],
+                machine=machines[0],
             )
         },
         workload_version="19.1.0",
@@ -180,7 +180,7 @@ def test_application_unexpected_channel(model):
 )
 def test_application_unknown_source(source_value, model):
     """Test Keystone application with unknown source."""
-    machines = {"0": MagicMock(spec_set=COUMachine)}
+    machines = [MagicMock(spec_set=COUMachine)]
     exp_msg = f"'keystone' has an invalid 'source': {source_value}"
     app = Keystone(
         name="keystone",
@@ -197,7 +197,7 @@ def test_application_unknown_source(source_value, model):
             "keystone/0": COUUnit(
                 name="keystone/0",
                 workload_version="19.0.1",
-                machine=machines["0"],
+                machine=machines[0],
             )
         },
         workload_version="19.1.0",
@@ -211,7 +211,7 @@ def test_application_unknown_source(source_value, model):
 async def test_application_verify_workload_upgrade(model):
     """Test Kyestone application check successful upgrade."""
     target = OpenStackRelease("victoria")
-    machines = {"0": MagicMock(spec_set=COUMachine)}
+    machines = [MagicMock(spec_set=COUMachine)]
     app = Keystone(
         name="keystone",
         can_upgrade_to="ussuri/stable",
@@ -230,7 +230,7 @@ async def test_application_verify_workload_upgrade(model):
             "keystone/0": COUUnit(
                 name="keystone/0",
                 workload_version="17.0.1",
-                machine=machines["0"],
+                machine=machines[0],
             )
         },
         workload_version="17.1.0",
@@ -253,7 +253,7 @@ async def test_application_verify_workload_upgrade_fail(model):
     """Test Kyestone application check unsuccessful upgrade."""
     target = OpenStackRelease("victoria")
     exp_msg = "Cannot upgrade units 'keystone/0' to victoria."
-    machines = {"0": MagicMock(spec_set=COUMachine)}
+    machines = [MagicMock(spec_set=COUMachine)]
     app = Keystone(
         name="keystone",
         can_upgrade_to="ussuri/stable",
@@ -272,7 +272,7 @@ async def test_application_verify_workload_upgrade_fail(model):
             "keystone/0": COUUnit(
                 name="keystone/0",
                 workload_version="17.0.1",
-                machine=machines["0"],
+                machine=machines[0],
             )
         },
         workload_version="17.1.0",
@@ -294,7 +294,7 @@ async def test_application_verify_workload_upgrade_fail(model):
 def test_upgrade_plan_ussuri_to_victoria(model):
     """Test generate plan to upgrade Keystone from Ussuri to Victoria."""
     target = OpenStackRelease("victoria")
-    machines = {"0": MagicMock(spec_set=COUMachine)}
+    machines = [MagicMock(spec_set=COUMachine)]
     app = Keystone(
         name="keystone",
         can_upgrade_to="ussuri/stable",
@@ -313,7 +313,7 @@ def test_upgrade_plan_ussuri_to_victoria(model):
             f"keystone/{unit}": COUUnit(
                 name=f"keystone/{unit}",
                 workload_version="17.0.1",
-                machine=machines["0"],
+                machine=machines[0],
             )
             for unit in range(3)
         },
@@ -384,7 +384,7 @@ def test_upgrade_plan_ussuri_to_victoria(model):
 def test_upgrade_plan_ussuri_to_victoria_ch_migration(model):
     """Test generate plan to upgrade Keystone from Ussuri to Victoria with charmhub migration."""
     target = OpenStackRelease("victoria")
-    machines = {"0": MagicMock(spec_set=COUMachine)}
+    machines = [MagicMock(spec_set=COUMachine)]
     app = Keystone(
         name="keystone",
         can_upgrade_to="ussuri/stable",
@@ -403,7 +403,7 @@ def test_upgrade_plan_ussuri_to_victoria_ch_migration(model):
             f"keystone/{unit}": COUUnit(
                 name=f"keystone/{unit}",
                 workload_version="17.0.1",
-                machine=machines["0"],
+                machine=machines[0],
             )
             for unit in range(3)
         },
@@ -477,7 +477,7 @@ def test_upgrade_plan_channel_on_next_os_release(model):
     The app channel it's already on next OpenStack release.
     """
     target = OpenStackRelease("victoria")
-    machines = {"0": MagicMock(spec_set=COUMachine)}
+    machines = [MagicMock(spec_set=COUMachine)]
     app = Keystone(
         name="keystone",
         can_upgrade_to="victoria/stable",
@@ -496,7 +496,7 @@ def test_upgrade_plan_channel_on_next_os_release(model):
             f"keystone/{unit}": COUUnit(
                 name=f"keystone/{unit}",
                 workload_version="17.0.1",
-                machine=machines["0"],
+                machine=machines[0],
             )
             for unit in range(3)
         },
@@ -561,7 +561,7 @@ def test_upgrade_plan_origin_already_on_next_openstack_release(model):
     The app config option openstack-origin it's already on next OpenStack release.
     """
     target = OpenStackRelease("victoria")
-    machines = {"0": MagicMock(spec_set=COUMachine)}
+    machines = [MagicMock(spec_set=COUMachine)]
     app = Keystone(
         name="keystone",
         can_upgrade_to="ussuri/stable",
@@ -580,7 +580,7 @@ def test_upgrade_plan_origin_already_on_next_openstack_release(model):
             f"keystone/{unit}": COUUnit(
                 name=f"keystone/{unit}",
                 workload_version="17.0.1",
-                machine=machines["0"],
+                machine=machines[0],
             )
             for unit in range(3)
         },
@@ -645,7 +645,7 @@ def test_upgrade_plan_application_already_upgraded(model):
         "than victoria. Ignoring."
     )
     target = OpenStackRelease("victoria")
-    machines = {"0": MagicMock(spec_set=COUMachine)}
+    machines = [MagicMock(spec_set=COUMachine)]
     app = Keystone(
         name="keystone",
         can_upgrade_to="",
@@ -664,7 +664,7 @@ def test_upgrade_plan_application_already_upgraded(model):
             f"keystone/{unit}": COUUnit(
                 name=f"keystone/{unit}",
                 workload_version="19.0.1",
-                machine=machines["0"],
+                machine=machines[0],
             )
             for unit in range(3)
         },
@@ -679,7 +679,7 @@ def test_upgrade_plan_application_already_upgraded(model):
 def test_upgrade_plan_application_already_disable_action_managed(model):
     """Test generate plan to upgrade Keystone with managed upgrade disabled."""
     target = OpenStackRelease("victoria")
-    machines = {"0": MagicMock(spec_set=COUMachine)}
+    machines = [MagicMock(spec_set=COUMachine)]
     app = Keystone(
         name="keystone",
         can_upgrade_to="ussuri/stable",
@@ -698,7 +698,7 @@ def test_upgrade_plan_application_already_disable_action_managed(model):
             f"keystone/{unit}": COUUnit(
                 name=f"keystone/{unit}",
                 workload_version="17.0.1",
-                machine=machines["0"],
+                machine=machines[0],
             )
             for unit in range(3)
         },
@@ -919,12 +919,12 @@ def test_nova_compute_upgrade_plan(model):
         Check if the workload of 'nova-compute' has been upgraded on units: nova-compute/0, nova-compute/1, nova-compute/2
     """  # noqa: E501 line too long
     )
-    machines = {f"{i}": generate_cou_machine(f"{i}", f"az-{i}") for i in range(3)}
+    machines = [generate_cou_machine(f"{i}", f"az-{i}") for i in range(3)]
     units = {
         f"nova-compute/{unit}": COUUnit(
             name=f"nova-compute/{unit}",
             workload_version="21.0.0",
-            machine=machines[f"{unit}"],
+            machine=machines[unit],
         )
         for unit in range(3)
     }
@@ -972,12 +972,12 @@ def test_nova_compute_upgrade_plan_single_unit(model):
         Check if the workload of 'nova-compute' has been upgraded on units: nova-compute/0
     """
     )
-    machines = {f"{i}": generate_cou_machine(f"{i}", f"az-{i}") for i in range(3)}
+    machines = [generate_cou_machine(f"{i}", f"az-{i}") for i in range(3)]
     units = {
         f"nova-compute/{unit}": COUUnit(
             name=f"nova-compute/{unit}",
             workload_version="21.0.0",
-            machine=machines[f"{unit}"],
+            machine=machines[unit],
         )
         for unit in range(3)
     }

--- a/tests/unit/apps/test_subordinate.py
+++ b/tests/unit/apps/test_subordinate.py
@@ -42,13 +42,7 @@ def test_current_os_release(model):
         origin="ch",
         series="focal",
         subordinate_to=["nova-compute"],
-        units={
-            "keystone-ldap/0": COUUnit(
-                name="keystone-ldap/0",
-                workload_version="18.1.0",
-                machine=machines[0],
-            )
-        },
+        units=[COUUnit(name="keystone-ldap/0", workload_version="18.1.0", machine=machines[0])],
         workload_version="18.1.0",
     )
 
@@ -70,13 +64,7 @@ def test_generate_upgrade_plan(model):
         origin="ch",
         series="focal",
         subordinate_to=["nova-compute"],
-        units={
-            "keystone-ldap/0": COUUnit(
-                name="keystone-ldap/0",
-                workload_version="18.1.0",
-                machine=machines[0],
-            )
-        },
+        units=[COUUnit(name="keystone-ldap/0", workload_version="18.1.0", machine=machines[0])],
         workload_version="18.1.0",
     )
     expected_plan = ApplicationUpgradePlan(
@@ -125,13 +113,7 @@ def test_channel_valid(model, channel):
         origin="ch",
         series="focal",
         subordinate_to=["nova-compute"],
-        units={
-            "keystone-ldap/0": COUUnit(
-                name="keystone-ldap/0",
-                workload_version="18.1.0",
-                machine=machines[0],
-            )
-        },
+        units=[COUUnit(name="keystone-ldap/0", workload_version="18.1.0", machine=machines[0])],
         workload_version="18.1.0",
     )
 
@@ -163,13 +145,9 @@ def test_channel_setter_invalid(model, channel):
             origin="ch",
             series="focal",
             subordinate_to=["nova-compute"],
-            units={
-                "keystone-ldap/0": COUUnit(
-                    name="keystone-ldap/0",
-                    workload_version="18.1.0",
-                    machine=machines[0],
-                )
-            },
+            units=[
+                COUUnit(name="keystone-ldap/0", workload_version="18.1.0", machine=machines[0])
+            ],
             workload_version="18.1.0",
         )
 
@@ -197,13 +175,7 @@ def test_generate_plan_ch_migration(model, channel):
         origin="cs",
         series="focal",
         subordinate_to=["nova-compute"],
-        units={
-            "keystone-ldap/0": COUUnit(
-                name="keystone-ldap/0",
-                workload_version="18.1.0",
-                machine=machines[0],
-            )
-        },
+        units=[COUUnit(name="keystone-ldap/0", workload_version="18.1.0", machine=machines[0])],
         workload_version="18.1.0",
     )
     expected_plan = ApplicationUpgradePlan(
@@ -251,13 +223,7 @@ def test_generate_plan_from_to(model, from_os, to_os):
         origin="ch",
         series="focal",
         subordinate_to=["nova-compute"],
-        units={
-            "keystone-ldap/0": COUUnit(
-                name="keystone-ldap/0",
-                workload_version="18.1.0",
-                machine=machines[0],
-            )
-        },
+        units=[COUUnit(name="keystone-ldap/0", workload_version="18.1.0", machine=machines[0])],
         workload_version="18.1.0",
     )
     expected_plan = ApplicationUpgradePlan(description=f"Upgrade plan for '{app.name}' to {to_os}")
@@ -304,13 +270,7 @@ def test_generate_plan_in_same_version(model, from_to):
         origin="ch",
         series="focal",
         subordinate_to=["nova-compute"],
-        units={
-            "keystone-ldap/0": COUUnit(
-                name="keystone-ldap/0",
-                workload_version="18.1.0",
-                machine=machines[0],
-            )
-        },
+        units=[COUUnit(name="keystone-ldap/0", workload_version="18.1.0", machine=machines[0])],
         workload_version="18.1.0",
     )
     expected_plan = ApplicationUpgradePlan(

--- a/tests/unit/apps/test_subordinate.py
+++ b/tests/unit/apps/test_subordinate.py
@@ -30,7 +30,7 @@ logger = logging.getLogger(__name__)
 
 def test_current_os_release(model):
     """Test current_os_release for OpenStackSubordinateApplication."""
-    machines = {"0": MagicMock(spec_set=COUMachine)}
+    machines = [MagicMock(spec_set=COUMachine)]
     app = OpenStackSubordinateApplication(
         name="keystone-ldap",
         can_upgrade_to="ussuri/stable",
@@ -46,7 +46,7 @@ def test_current_os_release(model):
             "keystone-ldap/0": COUUnit(
                 name="keystone-ldap/0",
                 workload_version="18.1.0",
-                machine=machines["0"],
+                machine=machines[0],
             )
         },
         workload_version="18.1.0",
@@ -58,7 +58,7 @@ def test_current_os_release(model):
 def test_generate_upgrade_plan(model):
     """Test generate upgrade plan for OpenStackSubordinateApplication."""
     target = OpenStackRelease("victoria")
-    machines = {"0": MagicMock(spec_set=COUMachine)}
+    machines = [MagicMock(spec_set=COUMachine)]
     app = OpenStackSubordinateApplication(
         name="keystone-ldap",
         can_upgrade_to="ussuri/stable",
@@ -74,7 +74,7 @@ def test_generate_upgrade_plan(model):
             "keystone-ldap/0": COUUnit(
                 name="keystone-ldap/0",
                 workload_version="18.1.0",
-                machine=machines["0"],
+                machine=machines[0],
             )
         },
         workload_version="18.1.0",
@@ -113,7 +113,7 @@ def test_generate_upgrade_plan(model):
 )
 def test_channel_valid(model, channel):
     """Test successful validation of channel upgrade plan for OpenStackSubordinateApplication."""
-    machines = {"0": MagicMock(spec_set=COUMachine)}
+    machines = [MagicMock(spec_set=COUMachine)]
     app = OpenStackSubordinateApplication(
         name="keystone-ldap",
         can_upgrade_to=channel,
@@ -129,7 +129,7 @@ def test_channel_valid(model, channel):
             "keystone-ldap/0": COUUnit(
                 name="keystone-ldap/0",
                 workload_version="18.1.0",
-                machine=machines["0"],
+                machine=machines[0],
             )
         },
         workload_version="18.1.0",
@@ -149,7 +149,7 @@ def test_channel_valid(model, channel):
 )
 def test_channel_setter_invalid(model, channel):
     """Test unsuccessful validation of channel upgrade plan for OpenStackSubordinateApplication."""
-    machines = {"0": MagicMock(spec_set=COUMachine)}
+    machines = [MagicMock(spec_set=COUMachine)]
 
     with pytest.raises(ApplicationError):
         OpenStackSubordinateApplication(
@@ -167,7 +167,7 @@ def test_channel_setter_invalid(model, channel):
                 "keystone-ldap/0": COUUnit(
                     name="keystone-ldap/0",
                     workload_version="18.1.0",
-                    machine=machines["0"],
+                    machine=machines[0],
                 )
             },
             workload_version="18.1.0",
@@ -185,7 +185,7 @@ def test_channel_setter_invalid(model, channel):
 def test_generate_plan_ch_migration(model, channel):
     """Test generate upgrade plan for OpenStackSubordinateApplication with charmhub migration."""
     target = OpenStackRelease("wallaby")
-    machines = {"0": MagicMock(spec_set=COUMachine)}
+    machines = [MagicMock(spec_set=COUMachine)]
     app = OpenStackSubordinateApplication(
         name="keystone-ldap",
         can_upgrade_to="wallaby/stable",
@@ -201,7 +201,7 @@ def test_generate_plan_ch_migration(model, channel):
             "keystone-ldap/0": COUUnit(
                 name="keystone-ldap/0",
                 workload_version="18.1.0",
-                machine=machines["0"],
+                machine=machines[0],
             )
         },
         workload_version="18.1.0",
@@ -239,7 +239,7 @@ def test_generate_plan_ch_migration(model, channel):
 def test_generate_plan_from_to(model, from_os, to_os):
     """Test generate upgrade plan for OpenStackSubordinateApplication from to version."""
     target = OpenStackRelease(to_os)
-    machines = {"0": MagicMock(spec_set=COUMachine)}
+    machines = [MagicMock(spec_set=COUMachine)]
     app = OpenStackSubordinateApplication(
         name="keystone-ldap",
         can_upgrade_to=f"{to_os}/stable",
@@ -255,7 +255,7 @@ def test_generate_plan_from_to(model, from_os, to_os):
             "keystone-ldap/0": COUUnit(
                 name="keystone-ldap/0",
                 workload_version="18.1.0",
-                machine=machines["0"],
+                machine=machines[0],
             )
         },
         workload_version="18.1.0",
@@ -292,7 +292,7 @@ def test_generate_plan_from_to(model, from_os, to_os):
 def test_generate_plan_in_same_version(model, from_to):
     """Test generate upgrade plan for OpenStackSubordinateApplication in same version."""
     target = OpenStackRelease(from_to)
-    machines = {"0": MagicMock(spec_set=COUMachine)}
+    machines = [MagicMock(spec_set=COUMachine)]
     app = OpenStackSubordinateApplication(
         name="keystone-ldap",
         can_upgrade_to=f"{from_to}/stable",
@@ -308,7 +308,7 @@ def test_generate_plan_in_same_version(model, from_to):
             "keystone-ldap/0": COUUnit(
                 name="keystone-ldap/0",
                 workload_version="18.1.0",
-                machine=machines["0"],
+                machine=machines[0],
             )
         },
         workload_version="18.1.0",

--- a/tests/unit/steps/test_hypervisor.py
+++ b/tests/unit/steps/test_hypervisor.py
@@ -137,10 +137,10 @@ def test_hypervisor_azs_grouping():
 
     app1 = MagicMock(spec_set=COUApplication)()
     app1.name = "app1"
-    app1.units = {name: unit for name, unit in units.items() if name.startswith("app1")}
+    app1.units = [unit for name, unit in units.items() if name.startswith("app1")]
     app2 = MagicMock(spec_set=COUApplication)()
     app2.name = "app2"
-    app1.units = {name: unit for name, unit in units.items() if name.startswith("app2")}
+    app2.units = [unit for name, unit in units.items() if name.startswith("app2")]
 
     exp_azs = AZs()
     exp_azs["az0"].app_units["app1"] = [units["app1/0"], units["app1/1"]]
@@ -237,13 +237,7 @@ def test_hypervisor_upgrade_plan(model):
         origin="ch",
         series="focal",
         subordinate_to=[],
-        units={
-            "cinder/0": COUUnit(
-                name="cinder/0",
-                workload_version="16.4.2",
-                machine=machines[0],
-            )
-        },
+        units=[COUUnit(name="cinder/0", workload_version="16.4.2", machine=machines[0])],
         workload_version="16.4.2",
     )
     nova_compute = NovaCompute(
@@ -257,14 +251,10 @@ def test_hypervisor_upgrade_plan(model):
         origin="ch",
         series="focal",
         subordinate_to=[],
-        units={
-            f"nova-compute/{unit}": COUUnit(
-                name=f"nova-compute/{unit}",
-                workload_version="21.0.0",
-                machine=machines[unit],
-            )
-            for unit in range(3)
-        },
+        units=[
+            COUUnit(name=f"nova-compute/{i}", workload_version="21.0.0", machine=machines[i])
+            for i in range(3)
+        ],
         workload_version="21.0.0",
     )
 

--- a/tests/unit/steps/test_hypervisor.py
+++ b/tests/unit/steps/test_hypervisor.py
@@ -120,19 +120,19 @@ def test_hypervisor_azs_grouping():
     5        started  10.10.10.6   host5          ubuntu@22.04  az2 Running
     ```
     """
-    machines = {f"{i}": COUMachine(f"{i}", (), f"az{i//2}") for i in range(6)}
+    machines = [COUMachine(f"{i}", (), f"az{i//2}") for i in range(6)]
     units = {
         # app1
-        "app1/0": COUUnit("app1/0", machines["0"], ""),
-        "app1/1": COUUnit("app1/1", machines["1"], ""),
-        "app1/2": COUUnit("app1/2", machines["2"], ""),
-        "app1/3": COUUnit("app1/3", machines["3"], ""),
-        "app1/4": COUUnit("app1/4", machines["4"], ""),
-        "app1/5": COUUnit("app1/5", machines["5"], ""),
+        "app1/0": COUUnit("app1/0", machines[0], ""),
+        "app1/1": COUUnit("app1/1", machines[1], ""),
+        "app1/2": COUUnit("app1/2", machines[2], ""),
+        "app1/3": COUUnit("app1/3", machines[3], ""),
+        "app1/4": COUUnit("app1/4", machines[4], ""),
+        "app1/5": COUUnit("app1/5", machines[5], ""),
         # app2
-        "app2/0": COUUnit("app2/0", machines["0"], ""),
-        "app2/1": COUUnit("app2/1", machines["2"], ""),
-        "app2/2": COUUnit("app2/2", machines["4"], ""),
+        "app2/0": COUUnit("app2/0", machines[0], ""),
+        "app2/1": COUUnit("app2/1", machines[2], ""),
+        "app2/2": COUUnit("app2/2", machines[4], ""),
     }
 
     app1 = MagicMock(spec_set=COUApplication)()
@@ -222,7 +222,7 @@ def test_hypervisor_upgrade_plan(model):
             Check if the workload of 'nova-compute' has been upgraded on units: nova-compute/2
     """
     )
-    machines = {f"{i}": generate_cou_machine(f"{i}", f"az-{i}") for i in range(3)}
+    machines = [generate_cou_machine(f"{i}", f"az-{i}") for i in range(3)]
     cinder = OpenStackApplication(
         name="cinder",
         can_upgrade_to="ussuri/stable",
@@ -232,7 +232,7 @@ def test_hypervisor_upgrade_plan(model):
             "openstack-origin": {"value": "distro"},
             "action-managed-upgrade": {"value": False},
         },
-        machines={"0": machines["0"]},
+        machines=machines[:1],
         model=model,
         origin="ch",
         series="focal",
@@ -241,7 +241,7 @@ def test_hypervisor_upgrade_plan(model):
             "cinder/0": COUUnit(
                 name="cinder/0",
                 workload_version="16.4.2",
-                machine=machines["0"],
+                machine=machines[0],
             )
         },
         workload_version="16.4.2",
@@ -261,7 +261,7 @@ def test_hypervisor_upgrade_plan(model):
             f"nova-compute/{unit}": COUUnit(
                 name=f"nova-compute/{unit}",
                 workload_version="21.0.0",
-                machine=machines[f"{unit}"],
+                machine=machines[unit],
             )
             for unit in range(3)
         },

--- a/tests/unit/steps/test_steps_analyze.py
+++ b/tests/unit/steps/test_steps_analyze.py
@@ -145,7 +145,7 @@ def test_analysis_dump(model):
         Current minimum Ubuntu series in the cloud: focal
         """
     )
-    machines = {f"{i}": generate_cou_machine(f"{i}") for i in range(3)}
+    machines = [generate_cou_machine(f"{i}") for i in range(3)]
     keystone = Keystone(
         name="keystone",
         can_upgrade_to="ussuri/stable",
@@ -159,7 +159,7 @@ def test_analysis_dump(model):
         subordinate_to=[],
         units={
             f"keystone/{unit}": COUUnit(
-                name=f"keystone/{unit}", workload_version="17.0.1", machine=machines[f"{unit}"]
+                name=f"keystone/{unit}", workload_version="17.0.1", machine=machines[unit]
             )
             for unit in range(3)
         },
@@ -171,7 +171,7 @@ def test_analysis_dump(model):
         charm="rabbitmq-server",
         channel="3.8/stable",
         config={"source": {"value": "distro"}},
-        machines={"0": machines["0"]},
+        machines=machines[:1],
         model=model,
         origin="ch",
         series="focal",
@@ -180,7 +180,7 @@ def test_analysis_dump(model):
             "rabbitmq-server/0": COUUnit(
                 name="rabbitmq-server/0",
                 workload_version="3.8",
-                machine=machines["0"],
+                machine=machines[0],
             )
         },
         workload_version="3.8",
@@ -200,7 +200,7 @@ def test_analysis_dump(model):
             f"cinder/{unit}": COUUnit(
                 name=f"cinder/{unit}",
                 workload_version="16.4.2",
-                machine=machines[f"{unit}"],
+                machine=machines[unit],
             )
             for unit in range(3)
         },
@@ -251,7 +251,7 @@ async def test_populate_model(mock_create, model):
 )
 async def test_analysis_create(mock_split_apps, mock_populate, model):
     """Test analysis object creation."""
-    machines = {"0": MagicMock(spec_set=COUMachine)}
+    machines = [MagicMock(spec_set=COUMachine)]
     keystone = Keystone(
         name="keystone",
         can_upgrade_to="ussuri/stable",
@@ -267,7 +267,7 @@ async def test_analysis_create(mock_split_apps, mock_populate, model):
             "keystone/0": COUUnit(
                 name="keystone/0",
                 workload_version="17.1.0",
-                machine=machines["0"],
+                machine=machines[0],
             )
         },
         workload_version="17.1.0",
@@ -287,7 +287,7 @@ async def test_analysis_create(mock_split_apps, mock_populate, model):
             "rabbitmq-server/0": COUUnit(
                 name="rabbitmq-server/0",
                 workload_version="3.8",
-                machine=machines["0"],
+                machine=machines[0],
             )
         },
         workload_version="3.8",
@@ -307,7 +307,7 @@ async def test_analysis_create(mock_split_apps, mock_populate, model):
             "cinder/0": COUUnit(
                 name="cinder/0",
                 workload_version="16.4.2",
-                machine=machines["0"],
+                machine=machines[0],
             )
         },
         workload_version="16.4.2",
@@ -329,7 +329,7 @@ async def test_analysis_create(mock_split_apps, mock_populate, model):
 
 @pytest.mark.asyncio
 async def test_analysis_detect_current_cloud_os_release_different_releases(model):
-    machines = {"0": MagicMock(spec_set=COUMachine)}
+    machines = [MagicMock(spec_set=COUMachine)]
     keystone = Keystone(
         name="keystone",
         can_upgrade_to="wallaby/stable",
@@ -345,7 +345,7 @@ async def test_analysis_detect_current_cloud_os_release_different_releases(model
             "keystone/0": COUUnit(
                 name="keystone/0",
                 workload_version="19.1.0",
-                machine=machines["0"],
+                machine=machines[0],
             )
         },
         workload_version="19.1.0",
@@ -365,7 +365,7 @@ async def test_analysis_detect_current_cloud_os_release_different_releases(model
             "rabbitmq-server/0": COUUnit(
                 name="rabbitmq-server/0",
                 workload_version="3.8",
-                machine=machines["0"],
+                machine=machines[0],
             )
         },
         workload_version="3.8",
@@ -385,7 +385,7 @@ async def test_analysis_detect_current_cloud_os_release_different_releases(model
             "cinder/0": COUUnit(
                 name="cinder/0",
                 workload_version="16.4.2",
-                machine=machines["0"],
+                machine=machines[0],
             )
         },
         workload_version="16.4.2",
@@ -403,7 +403,7 @@ async def test_analysis_detect_current_cloud_os_release_different_releases(model
 @pytest.mark.asyncio
 async def test_analysis_detect_current_cloud_series_different_series(model):
     """Check current_cloud_series getting lowest series in apps."""
-    machines = {"0": MagicMock(spec_set=COUMachine)}
+    machines = [MagicMock(spec_set=COUMachine)]
     keystone = Keystone(
         name="keystone",
         can_upgrade_to="ussuri/stable",
@@ -419,7 +419,7 @@ async def test_analysis_detect_current_cloud_series_different_series(model):
             "keystone/0": COUUnit(
                 name="keystone/0",
                 workload_version="17.1.0",
-                machine=machines["0"],
+                machine=machines[0],
             )
         },
         workload_version="17.1.0",
@@ -439,7 +439,7 @@ async def test_analysis_detect_current_cloud_series_different_series(model):
             "rabbitmq-server/0": COUUnit(
                 name="rabbitmq-server/0",
                 workload_version="3.8",
-                machine=machines["0"],
+                machine=machines[0],
             )
         },
         workload_version="3.8",
@@ -459,7 +459,7 @@ async def test_analysis_detect_current_cloud_series_different_series(model):
             "cinder/0": COUUnit(
                 name="cinder/0",
                 workload_version="16.4.2",
-                machine=machines["0"],
+                machine=machines[0],
             )
         },
         workload_version="16.4.2",
@@ -521,21 +521,14 @@ def test_split_apps(exp_control_plane, exp_data_plane):
 @pytest.mark.asyncio
 async def test_analysis_machines(model):
     """Test splitting of dataplane and control plane machines."""
-    machines = {
-        "0": MagicMock(spec_set=COUMachine),
-        "1": MagicMock(spec_set=COUMachine),
-        "2": MagicMock(spec_set=COUMachine),
-        "3": MagicMock(spec_set=COUMachine),
-        "4": MagicMock(spec_set=COUMachine),
-        "5": MagicMock(spec_set=COUMachine),
-    }
+    machines = [generate_cou_machine(f"{i}", f"az-{i}") for i in range(6)]
     keystone = Keystone(
         name="keystone",
         can_upgrade_to="ussuri/stable",
         charm="keystone",
         channel="ussuri/stable",
         config={"source": {"value": "distro"}},
-        machines={"3": machines["3"]},
+        machines=[machines[3]],
         model=model,
         origin="ch",
         series="focal",
@@ -544,7 +537,7 @@ async def test_analysis_machines(model):
             "keystone/0": COUUnit(
                 name="keystone/0",
                 workload_version="17.1.0",
-                machine=machines["3"],
+                machine=machines[3],
             )
         },
         workload_version="17.1.0",
@@ -555,7 +548,7 @@ async def test_analysis_machines(model):
         charm="rabbitmq-server",
         channel="3.8/stable",
         config={"source": {"value": "distro"}},
-        machines={"4": machines["4"]},
+        machines=[machines[4]],
         model=model,
         origin="ch",
         series="focal",
@@ -564,7 +557,7 @@ async def test_analysis_machines(model):
             "rabbitmq-server/0": COUUnit(
                 name="rabbitmq-server/0",
                 workload_version="3.8",
-                machine=machines["4"],
+                machine=machines[4],
             )
         },
         workload_version="3.8",
@@ -575,7 +568,7 @@ async def test_analysis_machines(model):
         charm="cinder",
         channel="ussuri/stable",
         config={"source": {"value": "distro"}},
-        machines={"5": machines["5"]},
+        machines=[machines[5]],
         model=model,
         origin="ch",
         series="focal",
@@ -584,7 +577,7 @@ async def test_analysis_machines(model):
             "cinder/0": COUUnit(
                 name="cinder/0",
                 workload_version="16.4.2",
-                machine=machines["5"],
+                machine=machines[5],
             )
         },
         workload_version="16.4.2",
@@ -595,7 +588,7 @@ async def test_analysis_machines(model):
         charm="nova-compute",
         channel="ussuri/stable",
         config={"source": {"value": "distro"}},
-        machines={f"{i}": machines[f"{i}"] for i in range(3)},
+        machines=machines[:3],
         model=model,
         origin="ch",
         series="focal",
@@ -604,7 +597,7 @@ async def test_analysis_machines(model):
             f"nova-compute/{unit}": COUUnit(
                 name=f"nova-compute/{unit}",
                 workload_version="21.0.0",
-                machine=machines[f"{unit}"],
+                machine=machines[unit],
             )
             for unit in range(3)
         },
@@ -617,8 +610,8 @@ async def test_analysis_machines(model):
         apps_data_plane=[nova_compute],
     )
 
-    expected_control_plane_machines = {f"{i}": machines[f"{i}"] for i in range(3, 6)}  # 3, 4, 5
-    expected_data_plane_machines = {f"{i}": machines[f"{i}"] for i in range(3)}  # 0, 1, 2
+    expected_control_plane_machines = {f"{i}": machines[i] for i in range(3, 6)}  # 3, 4, 5
+    expected_data_plane_machines = {f"{i}": machines[i] for i in range(3)}  # 0, 1, 2
 
     assert result.control_plane_machines == expected_control_plane_machines
     assert result.data_plane_machines == expected_data_plane_machines

--- a/tests/unit/steps/test_steps_analyze.py
+++ b/tests/unit/steps/test_steps_analyze.py
@@ -157,12 +157,10 @@ def test_analysis_dump(model):
         origin="ch",
         series="focal",
         subordinate_to=[],
-        units={
-            f"keystone/{unit}": COUUnit(
-                name=f"keystone/{unit}", workload_version="17.0.1", machine=machines[unit]
-            )
-            for unit in range(3)
-        },
+        units=[
+            COUUnit(name=f"keystone/{i}", workload_version="17.0.1", machine=machines[i])
+            for i in range(3)
+        ],
         workload_version="17.0.1",
     )
     rabbitmq_server = RabbitMQServer(
@@ -176,13 +174,7 @@ def test_analysis_dump(model):
         origin="ch",
         series="focal",
         subordinate_to=[],
-        units={
-            "rabbitmq-server/0": COUUnit(
-                name="rabbitmq-server/0",
-                workload_version="3.8",
-                machine=machines[0],
-            )
-        },
+        units=[COUUnit(name="rabbitmq-server/0", workload_version="3.8", machine=machines[0])],
         workload_version="3.8",
     )
     cinder = OpenStackApplication(
@@ -196,14 +188,10 @@ def test_analysis_dump(model):
         origin="ch",
         series="focal",
         subordinate_to=[],
-        units={
-            f"cinder/{unit}": COUUnit(
-                name=f"cinder/{unit}",
-                workload_version="16.4.2",
-                machine=machines[unit],
-            )
-            for unit in range(3)
-        },
+        units=[
+            COUUnit(name=f"cinder/{i}", workload_version="16.4.2", machine=machines[i])
+            for i in range(3)
+        ],
         workload_version="16.4.2",
     )
     result = analyze.Analysis(
@@ -263,13 +251,7 @@ async def test_analysis_create(mock_split_apps, mock_populate, model):
         origin="ch",
         series="focal",
         subordinate_to=[],
-        units={
-            "keystone/0": COUUnit(
-                name="keystone/0",
-                workload_version="17.1.0",
-                machine=machines[0],
-            )
-        },
+        units=[COUUnit(name="keystone/0", workload_version="17.1.0", machine=machines[0])],
         workload_version="17.1.0",
     )
     rabbitmq_server = RabbitMQServer(
@@ -283,13 +265,7 @@ async def test_analysis_create(mock_split_apps, mock_populate, model):
         origin="ch",
         series="focal",
         subordinate_to=[],
-        units={
-            "rabbitmq-server/0": COUUnit(
-                name="rabbitmq-server/0",
-                workload_version="3.8",
-                machine=machines[0],
-            )
-        },
+        units=[COUUnit(name="rabbitmq-server/0", workload_version="3.8", machine=machines[0])],
         workload_version="3.8",
     )
     cinder = OpenStackApplication(
@@ -303,13 +279,7 @@ async def test_analysis_create(mock_split_apps, mock_populate, model):
         origin="ch",
         series="focal",
         subordinate_to=[],
-        units={
-            "cinder/0": COUUnit(
-                name="cinder/0",
-                workload_version="16.4.2",
-                machine=machines[0],
-            )
-        },
+        units=[COUUnit(name="cinder/0", workload_version="16.4.2", machine=machines[0])],
         workload_version="16.4.2",
     )
     exp_apps = [keystone, rabbitmq_server, cinder]
@@ -341,13 +311,7 @@ async def test_analysis_detect_current_cloud_os_release_different_releases(model
         origin="ch",
         series="focal",
         subordinate_to=[],
-        units={
-            "keystone/0": COUUnit(
-                name="keystone/0",
-                workload_version="19.1.0",
-                machine=machines[0],
-            )
-        },
+        units=[COUUnit(name="keystone/0", workload_version="19.1.0", machine=machines[0])],
         workload_version="19.1.0",
     )
     rabbitmq_server = RabbitMQServer(
@@ -361,13 +325,7 @@ async def test_analysis_detect_current_cloud_os_release_different_releases(model
         origin="ch",
         series="focal",
         subordinate_to=[],
-        units={
-            "rabbitmq-server/0": COUUnit(
-                name="rabbitmq-server/0",
-                workload_version="3.8",
-                machine=machines[0],
-            )
-        },
+        units=[COUUnit(name="rabbitmq-server/0", workload_version="3.8", machine=machines[0])],
         workload_version="3.8",
     )
     cinder = OpenStackApplication(
@@ -381,13 +339,7 @@ async def test_analysis_detect_current_cloud_os_release_different_releases(model
         origin="ch",
         series="focal",
         subordinate_to=[],
-        units={
-            "cinder/0": COUUnit(
-                name="cinder/0",
-                workload_version="16.4.2",
-                machine=machines[0],
-            )
-        },
+        units=[COUUnit(name="cinder/0", workload_version="16.4.2", machine=machines[0])],
         workload_version="16.4.2",
     )
     result = analyze.Analysis(
@@ -415,13 +367,7 @@ async def test_analysis_detect_current_cloud_series_different_series(model):
         origin="ch",
         series="focal",
         subordinate_to=[],
-        units={
-            "keystone/0": COUUnit(
-                name="keystone/0",
-                workload_version="17.1.0",
-                machine=machines[0],
-            )
-        },
+        units=[COUUnit(name="keystone/0", workload_version="17.1.0", machine=machines[0])],
         workload_version="17.1.0",
     )
     rabbitmq_server = RabbitMQServer(
@@ -435,13 +381,7 @@ async def test_analysis_detect_current_cloud_series_different_series(model):
         origin="ch",
         series="focal",
         subordinate_to=[],
-        units={
-            "rabbitmq-server/0": COUUnit(
-                name="rabbitmq-server/0",
-                workload_version="3.8",
-                machine=machines[0],
-            )
-        },
+        units=[COUUnit(name="rabbitmq-server/0", workload_version="3.8", machine=machines[0])],
         workload_version="3.8",
     )
     cinder = OpenStackApplication(
@@ -455,13 +395,7 @@ async def test_analysis_detect_current_cloud_series_different_series(model):
         origin="ch",
         series="bionic",  # change cinder to Bionic series
         subordinate_to=[],
-        units={
-            "cinder/0": COUUnit(
-                name="cinder/0",
-                workload_version="16.4.2",
-                machine=machines[0],
-            )
-        },
+        units=[COUUnit(name="cinder/0", workload_version="16.4.2", machine=machines[0])],
         workload_version="16.4.2",
     )
     result = analyze.Analysis(
@@ -491,22 +425,22 @@ def _unit(machine_id):
     "exp_control_plane, exp_data_plane",
     [
         (
-            [_app("keystone", {"0": _unit("0"), "1": _unit("1"), "2": _unit("2")})],
-            [_app("ceph-osd", {"3": _unit("3"), "4": _unit("4"), "5": _unit("5")})],
+            [_app("keystone", [_unit("0"), _unit("1"), _unit("2")])],
+            [_app("ceph-osd", [_unit("3"), _unit("4"), _unit("5")])],
         ),
         (
             [],
             [
-                _app("nova-compute", {"0": _unit("0"), "1": _unit("1"), "2": _unit("2")}),
-                _app("keystone", {"0": _unit("0"), "1": _unit("1"), "2": _unit("2")}),
-                _app("ceph-osd", {"3": _unit("3"), "4": _unit("4"), "5": _unit("5")}),
+                _app("nova-compute", [_unit("0"), _unit("1"), _unit("2")]),
+                _app("keystone", [_unit("0"), _unit("1"), _unit("2")]),
+                _app("ceph-osd", [_unit("3"), _unit("4"), _unit("5")]),
             ],
         ),
         (
-            [_app("keystone", {"6": _unit("6"), "7": _unit("7"), "8": _unit("8")})],
+            [_app("keystone", [_unit("6"), _unit("7"), _unit("8")])],
             [
-                _app("nova-compute", {"0": _unit("0"), "1": _unit("1"), "2": _unit("2")}),
-                _app("ceph-osd", {"3": _unit("3"), "4": _unit("4"), "5": _unit("5")}),
+                _app("nova-compute", [_unit("0"), _unit("1"), _unit("2")]),
+                _app("ceph-osd", [_unit("3"), _unit("4"), _unit("5")]),
             ],
         ),
     ],
@@ -533,13 +467,7 @@ async def test_analysis_machines(model):
         origin="ch",
         series="focal",
         subordinate_to=[],
-        units={
-            "keystone/0": COUUnit(
-                name="keystone/0",
-                workload_version="17.1.0",
-                machine=machines[3],
-            )
-        },
+        units=[COUUnit(name="keystone/0", workload_version="17.1.0", machine=machines[3])],
         workload_version="17.1.0",
     )
     rabbitmq_server = RabbitMQServer(
@@ -553,13 +481,7 @@ async def test_analysis_machines(model):
         origin="ch",
         series="focal",
         subordinate_to=[],
-        units={
-            "rabbitmq-server/0": COUUnit(
-                name="rabbitmq-server/0",
-                workload_version="3.8",
-                machine=machines[4],
-            )
-        },
+        units=[COUUnit(name="rabbitmq-server/0", workload_version="3.8", machine=machines[4])],
         workload_version="3.8",
     )
     cinder = OpenStackApplication(
@@ -573,13 +495,7 @@ async def test_analysis_machines(model):
         origin="ch",
         series="focal",
         subordinate_to=[],
-        units={
-            "cinder/0": COUUnit(
-                name="cinder/0",
-                workload_version="16.4.2",
-                machine=machines[5],
-            )
-        },
+        units=[COUUnit(name="cinder/0", workload_version="16.4.2", machine=machines[5])],
         workload_version="16.4.2",
     )
     nova_compute = OpenStackApplication(
@@ -593,14 +509,10 @@ async def test_analysis_machines(model):
         origin="ch",
         series="focal",
         subordinate_to=[],
-        units={
-            f"nova-compute/{unit}": COUUnit(
-                name=f"nova-compute/{unit}",
-                workload_version="21.0.0",
-                machine=machines[unit],
-            )
-            for unit in range(3)
-        },
+        units=[
+            COUUnit(name=f"nova-compute/{i}", workload_version="21.0.0", machine=machines[i])
+            for i in range(3)
+        ],
         workload_version="21.0.0",
     )
 

--- a/tests/unit/steps/test_steps_plan.py
+++ b/tests/unit/steps/test_steps_plan.py
@@ -41,7 +41,7 @@ from cou.utils import app_utils
 from cou.utils.juju_utils import COUMachine, COUUnit
 from cou.utils.openstack import OpenStackRelease
 from tests.unit.apps.utils import add_steps
-from tests.unit.utils import assert_steps
+from tests.unit.utils import assert_steps, generate_cou_machine
 
 
 def generate_expected_upgrade_plan_principal(app, target, model):
@@ -150,7 +150,7 @@ async def test_generate_plan(model, cli_args):
     cli_args.force = False
     target = OpenStackRelease("victoria")
     # keystone = Keystone()
-    machines = {"0": MagicMock(spec_set=COUMachine)}
+    machines = [generate_cou_machine("0", "az-1")]
     keystone = Keystone(
         name="keystone",
         can_upgrade_to="ussuri/stable",
@@ -160,7 +160,7 @@ async def test_generate_plan(model, cli_args):
             "openstack-origin": {"value": "distro"},
             "action-managed-upgrade": {"value": True},
         },
-        machines={},
+        machines=machines,
         model=model,
         origin="ch",
         series="focal",
@@ -169,7 +169,7 @@ async def test_generate_plan(model, cli_args):
             "keystone/0": COUUnit(
                 name="keystone/0",
                 workload_version="17.0.1",
-                machine=machines["0"],
+                machine=machines[0],
             )
         },
         workload_version="17.0.1",
@@ -189,7 +189,7 @@ async def test_generate_plan(model, cli_args):
             "keystone-ldap/0": COUUnit(
                 name="keystone-ldap/0",
                 workload_version="17.0.1",
-                machine=machines["0"],
+                machine=machines[0],
             )
         },
         workload_version="17.0.1",
@@ -212,7 +212,7 @@ async def test_generate_plan(model, cli_args):
             "cinder/0": COUUnit(
                 name="cinder/0",
                 workload_version="16.4.2",
-                machine=machines["0"],
+                machine=machines[0],
             )
         },
         workload_version="16.4.2",

--- a/tests/unit/utils/test_juju_utils.py
+++ b/tests/unit/utils/test_juju_utils.py
@@ -680,10 +680,10 @@ async def test_get_applications(mock_get_machines, mock_get_status, mocked_model
             origin=status.charm.split(":")[0],
             series=status.series,
             subordinate_to=status.subordinate_to,
-            units={
-                name: juju_utils.COUUnit(name, exp_machines[unit.machine], unit.workload_version)
+            units=[
+                juju_utils.COUUnit(name, exp_machines[unit.machine], unit.workload_version)
                 for name, unit in exp_units[app].items()
-            },
+            ],
             workload_version=status.workload_version,
         )
         for app, status in full_status_apps.items()

--- a/tests/unit/utils/test_juju_utils.py
+++ b/tests/unit/utils/test_juju_utils.py
@@ -675,9 +675,7 @@ async def test_get_applications(mock_get_machines, mock_get_status, mocked_model
             charm=mocked_model.applications[app].charm_name,
             channel=status.charm_channel,
             config=mocked_model.applications[app].get_config.return_value,
-            machines={
-                unit.machine: exp_machines[unit.machine] for unit in exp_units[app].values()
-            },
+            machines=[exp_machines[unit.machine] for unit in exp_units[app].values()],
             model=model,
             origin=status.charm.split(":")[0],
             series=status.series,


### PR DESCRIPTION
We actually never used `app.machines` or `app.units` as dictionaries, but we're always converting values to list. That's why I think we should use list directly and make our life easier.
With change to lists, I found out that we did not cover the generation plan for post-upgrade steps for versionless applications.  