### PR TITLE
Add relations parameter to COUApplication

### DIFF
--- a/cou/apps/base.py
+++ b/cou/apps/base.py
@@ -128,6 +128,7 @@ class OpenStackApplication(COUApplication):
                     }
                     for machine in self.machines.values()
                 },
+                "relations": self.relations,
             }
         }
 

--- a/cou/apps/factory.py
+++ b/cou/apps/factory.py
@@ -45,6 +45,8 @@ class AppFactory:
         # pylint: disable=too-many-arguments
         if is_charm_supported(app.charm):
             app_class = cls.charms.get(app.charm, OpenStackApplication)
+            # Note (rgildein): We cannot use dataclasses.asdict because of the libjuju model
+            #                  defined in COUModel.
             return app_class(
                 name=app.name,
                 can_upgrade_to=app.can_upgrade_to,
@@ -58,6 +60,7 @@ class AppFactory:
                 subordinate_to=app.subordinate_to,
                 units=app.units,
                 workload_version=app.workload_version,
+                relations=app.relations,
             )
 
         logger.debug(

--- a/cou/utils/juju_utils.py
+++ b/cou/utils/juju_utils.py
@@ -169,6 +169,7 @@ class COUApplication:
     subordinate_to: list[str]
     units: dict[str, COUUnit]
     workload_version: str
+    relations: dict[str, list[str]]
 
     @property
     def is_subordinate(self) -> bool:
@@ -344,6 +345,7 @@ class COUModel:
                     for name, unit in status.units.items()
                 },
                 workload_version=status.workload_version,
+                relations=status.relations,
             )
             for app, status in full_status.applications.items()
         }

--- a/tests/unit/apps/test_auxiliary.py
+++ b/tests/unit/apps/test_auxiliary.py
@@ -58,6 +58,7 @@ def test_auxiliary_app(model):
             )
         },
         workload_version="3.8",
+        relations={},
     )
     assert app.channel == "3.8/stable"
     assert app.is_valid_track(app.channel) is True
@@ -90,6 +91,7 @@ def test_auxiliary_app_cs(model):
             )
         },
         workload_version="3.8",
+        relations={},
     )
 
     assert app.channel == "stable"
@@ -123,6 +125,7 @@ def test_auxiliary_upgrade_plan_ussuri_to_victoria_change_channel(model):
             )
         },
         workload_version="3.8",
+        relations={},
     )
 
     expected_plan = ApplicationUpgradePlan(
@@ -207,6 +210,7 @@ def test_auxiliary_upgrade_plan_ussuri_to_victoria(model):
             )
         },
         workload_version="3.9",
+        relations={},
     )
 
     expected_plan = ApplicationUpgradePlan(
@@ -286,6 +290,7 @@ def test_auxiliary_upgrade_plan_ussuri_to_victoria_ch_migration(model):
             )
         },
         workload_version="3.8",
+        relations={},
     )
 
     expected_plan = ApplicationUpgradePlan(
@@ -377,6 +382,7 @@ def test_auxiliary_upgrade_plan_unknown_track(model):
                 )
             },
             workload_version="3.8",
+            relations={},
         )
 
 
@@ -406,6 +412,7 @@ def test_auxiliary_app_unknown_version_raise_ApplicationError(model):
             )
         },
         workload_version=version,
+        relations={},
     )
     with pytest.raises(ApplicationError, match=exp_msg):
         app._get_latest_os_version(app.units[f"{charm}/0"])
@@ -442,6 +449,7 @@ def test_auxiliary_raise_error_unknown_series(model):
                 )
             },
             workload_version="3.8",
+            relations={},
         )
 
 
@@ -473,6 +481,7 @@ def test_auxiliary_raise_error_os_not_on_lookup(current_os_release, model):
             )
         },
         workload_version="3.8",
+        relations={},
     )
 
     with pytest.raises(ApplicationError):
@@ -510,6 +519,7 @@ def test_auxiliary_raise_halt_upgrade(model):
             )
         },
         workload_version="3.8",
+        relations={},
     )
 
     with pytest.raises(HaltUpgradePlanGeneration, match=exp_msg):
@@ -548,6 +558,7 @@ def test_auxiliary_no_suitable_channel(model):
             )
         },
         workload_version="3.8",
+        relations={},
     )
 
     with pytest.raises(ApplicationError, match=exp_msg):
@@ -577,6 +588,7 @@ def test_ceph_mon_app(model):
             )
         },
         workload_version="16.2.0",
+        relations={},
     )
 
     assert app.channel == "pacific/stable"
@@ -611,6 +623,7 @@ def test_ceph_mon_upgrade_plan_xena_to_yoga(model):
             )
         },
         workload_version="16.2.0",
+        relations={},
     )
 
     expected_plan = ApplicationUpgradePlan(
@@ -700,6 +713,7 @@ def test_ceph_mon_upgrade_plan_ussuri_to_victoria(model):
             )
         },
         workload_version="15.2.0",
+        relations={},
     )
 
     expected_plan = ApplicationUpgradePlan(
@@ -783,6 +797,7 @@ def test_ovn_principal(model):
             )
         },
         workload_version="22.03",
+        relations={},
     )
     assert app.channel == "22.03/stable"
     assert app.os_origin == "distro"
@@ -822,6 +837,7 @@ def test_ovn_workload_ver_lower_than_22_principal(model):
             )
         },
         workload_version="20.03.2",
+        relations={},
     )
 
     with pytest.raises(ApplicationError, match=exp_msg):
@@ -860,6 +876,7 @@ def test_ovn_no_compatible_os_release(channel, model):
                 )
             },
             workload_version="22.03",
+            relations={},
         )
 
 
@@ -887,6 +904,7 @@ def test_ovn_principal_upgrade_plan(model):
             )
         },
         workload_version="22.03",
+        relations={},
     )
 
     expected_plan = ApplicationUpgradePlan(
@@ -967,6 +985,7 @@ def test_mysql_innodb_cluster_upgrade(model):
             )
         },
         workload_version="8.0",
+        relations={},
     )
 
     expected_plan = ApplicationUpgradePlan(

--- a/tests/unit/apps/test_auxiliary_subordinate.py
+++ b/tests/unit/apps/test_auxiliary_subordinate.py
@@ -51,6 +51,7 @@ def test_auxiliary_subordinate(model):
             )
         },
         workload_version="8.0",
+        relations={},
     )
 
     assert app.channel == "8.0/stable"
@@ -85,6 +86,7 @@ def test_auxiliary_subordinate_upgrade_plan_to_victoria(model):
             )
         },
         workload_version="8.0",
+        relations={},
     )
 
     expected_plan = ApplicationUpgradePlan(
@@ -125,6 +127,7 @@ def test_ovn_subordinate(model):
             )
         },
         workload_version="22.3",
+        relations={},
     )
 
     assert app.channel == "22.03/stable"
@@ -164,6 +167,7 @@ def test_ovn_workload_ver_lower_than_22_subordinate(model):
             )
         },
         workload_version="20.3",
+        relations={},
     )
 
     with pytest.raises(ApplicationError, match=exp_msg):
@@ -193,6 +197,7 @@ def test_ovn_subordinate_upgrade_plan(model):
             )
         },
         workload_version="22.3",
+        relations={},
     )
 
     expected_plan = ApplicationUpgradePlan(
@@ -240,6 +245,7 @@ def test_ovn_subordinate_upgrade_plan_cant_upgrade_charm(model):
             )
         },
         workload_version="22.3",
+        relations={},
     )
 
     expected_plan = ApplicationUpgradePlan(
@@ -275,6 +281,7 @@ def test_ceph_dashboard_upgrade_plan_ussuri_to_victoria(model):
             )
         },
         workload_version="15.2.0",
+        relations={},
     )
 
     expected_plan = ApplicationUpgradePlan(
@@ -318,6 +325,7 @@ def test_ceph_dashboard_upgrade_plan_xena_to_yoga(model):
             )
         },
         workload_version="16.2.0",
+        relations={},
     )
 
     expected_plan = ApplicationUpgradePlan(

--- a/tests/unit/apps/test_base.py
+++ b/tests/unit/apps/test_base.py
@@ -40,6 +40,7 @@ def test_openstack_application_magic_functions(model):
         subordinate_to=[],
         units={},
         workload_version="1",
+        relations={},
     )
 
     assert hash(app) == hash("test-app(app)")
@@ -76,6 +77,7 @@ def test_application_get_latest_os_version_failed(mock_find_compatible_versions,
         subordinate_to=[],
         units={f"{app_name}/0": unit},
         workload_version=unit.workload_version,
+        relations={},
     )
 
     with pytest.raises(ApplicationError, match=exp_error):
@@ -129,6 +131,7 @@ def test_set_action_managed_upgrade(charm_config, enable, exp_description, model
         subordinate_to=[],
         units={},
         workload_version="1",
+        relations={},
     )
 
     step = app._set_action_managed_upgrade(enable)
@@ -164,6 +167,7 @@ def test_get_pause_unit_step(model):
         subordinate_to=[],
         units={f"{unit.name}": unit},
         workload_version="1",
+        relations={},
     )
 
     step = app._get_pause_unit_step(unit)
@@ -197,6 +201,7 @@ def test_get_resume_unit_step(model):
         subordinate_to=[],
         units={f"{app_name}/0": unit},
         workload_version="1",
+        relations={},
     )
 
     step = app._get_resume_unit_step(unit)
@@ -232,6 +237,7 @@ def test_get_openstack_upgrade_step(model):
         subordinate_to=[],
         units={f"{app_name}/0": unit},
         workload_version="1",
+        relations={},
     )
 
     step = app._get_openstack_upgrade_step(unit)
@@ -257,7 +263,19 @@ def test_get_upgrade_current_release_packages_step(mock_upgrade_packages, units,
     }
 
     app = OpenStackApplication(
-        app_name, "", charm, channel, {}, {}, model, "ch", "focal", [], app_units, "21.0.1"
+        name=app_name,
+        can_upgrade_to="",
+        charm=charm,
+        channel=channel,
+        config={},
+        machines={},
+        model=model,
+        origin="ch",
+        series="focal",
+        subordinate_to=[],
+        units=app_units,
+        workload_version="21.0.1",
+        relations={},
     )
 
     expected_calls = (
@@ -289,7 +307,19 @@ def test_get_reached_expected_target_step(mock_workload_upgrade, units, model):
     app_units = {f"my_app/{unit}": COUUnit(f"my_app/{unit}", mock, mock) for unit in range(3)}
 
     app = OpenStackApplication(
-        app_name, "", charm, channel, {}, {}, model, "ch", "focal", [], app_units, "21.0.1"
+        name=app_name,
+        can_upgrade_to="",
+        charm=charm,
+        channel=channel,
+        config={},
+        machines={},
+        model=model,
+        origin="ch",
+        series="focal",
+        subordinate_to=[],
+        units=app_units,
+        workload_version="21.0.1",
+        relations={},
     )
 
     expected_calls = [call(target, units)] if units else [call(target, list(app.units.values()))]
@@ -304,7 +334,19 @@ def test_check_auto_restarts(_, config):
     """Test function to verify that enable-auto-restarts is disabled."""
     app_name = "app"
     app = OpenStackApplication(
-        app_name, "", app_name, "stable", config, {}, MagicMock(), "ch", "focal", [], {}, "1"
+        name=app_name,
+        can_upgrade_to="",
+        charm=app_name,
+        channel="stable",
+        config=config,
+        machines={},
+        model=MagicMock(),
+        origin="ch",
+        series="focal",
+        subordinate_to=[],
+        units={},
+        workload_version="1",
+        relations={},
     )
 
     app._check_auto_restarts()
@@ -321,7 +363,19 @@ def test_check_auto_restarts_error(_):
     )
     config = {"enable-auto-restarts": {"value": False}}
     app = OpenStackApplication(
-        app_name, "", app_name, "stable", config, {}, MagicMock(), "ch", "focal", [], {}, "1"
+        name=app_name,
+        can_upgrade_to="",
+        charm=app_name,
+        channel="stable",
+        config=config,
+        machines={},
+        model=MagicMock(),
+        origin="ch",
+        series="focal",
+        subordinate_to=[],
+        units={},
+        workload_version="1",
+        relations={},
     )
 
     with pytest.raises(ApplicationError, match=exp_error_msg):
@@ -337,7 +391,19 @@ def test_check_application_target(current_os_release, apt_source_codename, _):
     release = OpenStackRelease("ussuri")
     app_name = "app"
     app = OpenStackApplication(
-        app_name, "", app_name, "stable", {}, {}, MagicMock(), "ch", "focal", [], {}, "1"
+        name=app_name,
+        can_upgrade_to="",
+        charm=app_name,
+        channel="stable",
+        config={},
+        machines={},
+        model=MagicMock(),
+        origin="ch",
+        series="focal",
+        subordinate_to=[],
+        units={},
+        workload_version="1",
+        relations={},
     )
     current_os_release.return_value = apt_source_codename.return_value = release
 
@@ -356,7 +422,19 @@ def test_check_application_target_error(current_os_release, apt_source_codename,
         f"{target}. Ignoring."
     )
     app = OpenStackApplication(
-        app_name, "", app_name, "stable", {}, {}, MagicMock(), "ch", "focal", [], {}, "1"
+        name=app_name,
+        can_upgrade_to="",
+        charm=app_name,
+        channel="stable",
+        config={},
+        machines={},
+        model=MagicMock(),
+        origin="ch",
+        series="focal",
+        subordinate_to=[],
+        units={},
+        workload_version="1",
+        relations={},
     )
     current_os_release.return_value = apt_source_codename.return_value = target
 

--- a/tests/unit/apps/test_channel_based.py
+++ b/tests/unit/apps/test_channel_based.py
@@ -53,6 +53,7 @@ def test_application_versionless(model):
         subordinate_to=[],
         units=units,
         workload_version="",
+        relations={},
     )
 
     assert app.current_os_release == "ussuri"
@@ -85,6 +86,7 @@ def test_application_gnocchi_ussuri(model):
             )
         },
         workload_version="4.3.4",
+        relations={},
     )
 
     assert app.current_os_release == "ussuri"
@@ -117,6 +119,7 @@ def test_application_gnocchi_xena(model):
             )
         },
         workload_version="4.4.1",
+        relations={},
     )
 
     assert app.current_os_release == "xena"
@@ -152,6 +155,7 @@ def test_application_designate_bind_ussuri(model):
             )
         },
         workload_version="9.16.1",
+        relations={},
     )
 
     assert app.current_os_release == "ussuri"
@@ -181,6 +185,7 @@ def test_application_versionless_upgrade_plan_ussuri_to_victoria(model):
             )
         },
         workload_version="",
+        relations={},
     )
 
     expected_plan = ApplicationUpgradePlan(
@@ -260,6 +265,7 @@ def test_application_gnocchi_upgrade_plan_ussuri_to_victoria(model):
             )
         },
         workload_version="4.3.4",
+        relations={},
     )
 
     expected_plan = ApplicationUpgradePlan(
@@ -349,6 +355,7 @@ def test_application_designate_bind_upgrade_plan_ussuri_to_victoria(model):
             )
         },
         workload_version="9.16.1",
+        relations={},
     )
 
     expected_plan = ApplicationUpgradePlan(

--- a/tests/unit/apps/test_core.py
+++ b/tests/unit/apps/test_core.py
@@ -81,6 +81,7 @@ def test_application_different_wl(model):
         subordinate_to=[],
         units=units,
         workload_version="18.1.0",
+        relations={},
     )
 
     with pytest.raises(MismatchedOpenStackVersions, match=exp_error_msg):
@@ -109,6 +110,7 @@ def test_application_no_origin_config(model):
             )
         },
         workload_version="18.1.0",
+        relations={},
     )
 
     assert app.os_origin == ""
@@ -137,6 +139,7 @@ def test_application_empty_origin_config(model):
             )
         },
         workload_version="18.1.0",
+        relations={},
     )
 
     assert app.apt_source_codename is None
@@ -169,6 +172,7 @@ def test_application_unexpected_channel(model):
             )
         },
         workload_version="19.1.0",
+        relations={},
     )
 
     with pytest.raises(ApplicationError, match=exp_msg):
@@ -202,6 +206,7 @@ def test_application_unknown_source(source_value, model):
             )
         },
         workload_version="19.1.0",
+        relations={},
     )
 
     with pytest.raises(ApplicationError, match=exp_msg):
@@ -235,6 +240,7 @@ async def test_application_verify_workload_upgrade(model):
             )
         },
         workload_version="17.1.0",
+        relations={},
     )
 
     # workload version changed from ussuri to victoria
@@ -277,6 +283,7 @@ async def test_application_verify_workload_upgrade_fail(model):
             )
         },
         workload_version="17.1.0",
+        relations={},
     )
 
     # workload version didn't change from ussuri to victoria
@@ -319,6 +326,7 @@ def test_upgrade_plan_ussuri_to_victoria(model):
             for unit in range(3)
         },
         workload_version="17.1.0",
+        relations={},
     )
     expected_plan = ApplicationUpgradePlan(
         description=f"Upgrade plan for '{app.name}' to {target}"
@@ -409,6 +417,7 @@ def test_upgrade_plan_ussuri_to_victoria_ch_migration(model):
             for unit in range(3)
         },
         workload_version="17.1.0",
+        relations={},
     )
     expected_plan = ApplicationUpgradePlan(
         description=f"Upgrade plan for '{app.name}' to {target}"
@@ -502,6 +511,7 @@ def test_upgrade_plan_channel_on_next_os_release(model):
             for unit in range(3)
         },
         workload_version="17.1.0",
+        relations={},
     )
     expected_plan = ApplicationUpgradePlan(
         description=f"Upgrade plan for '{app.name}' to {target}"
@@ -586,6 +596,7 @@ def test_upgrade_plan_origin_already_on_next_openstack_release(model):
             for unit in range(3)
         },
         workload_version="17.1.0",
+        relations={},
     )
     expected_plan = ApplicationUpgradePlan(
         description=f"Upgrade plan for '{app.name}' to {target}"
@@ -670,6 +681,7 @@ def test_upgrade_plan_application_already_upgraded(model):
             for unit in range(3)
         },
         workload_version="19.1.0",
+        relations={},
     )
 
     # victoria is lesser than wallaby, so application should not generate a plan.
@@ -704,6 +716,7 @@ def test_upgrade_plan_application_already_disable_action_managed(model):
             for unit in range(3)
         },
         workload_version="17.1.0",
+        relations={},
     )
     expected_plan = ApplicationUpgradePlan(
         description=f"Upgrade plan for '{app.name}' to {target}"
@@ -843,7 +856,19 @@ def _generate_nova_compute_app(model):
         for unit_num in range(3)
     }
     app = NovaCompute(
-        app_name, "", charm, channel, {}, {}, model, "cs", "focal", [], units, "21.0.1"
+        name=app_name,
+        can_upgrade_to="",
+        charm=charm,
+        channel=channel,
+        config={},
+        machines={},
+        model=model,
+        origin="cs",
+        series="focal",
+        subordinate_to=[],
+        units=units,
+        workload_version="21.0.1",
+        relations={},
     )
 
     return app
@@ -911,6 +936,7 @@ def test_nova_compute_upgrade_plan(model):
         subordinate_to=[],
         units=units,
         workload_version="21.0.0",
+        relations={},
     )
 
     plan = nova_compute.generate_upgrade_plan(target, False)
@@ -964,6 +990,7 @@ def test_nova_compute_upgrade_plan_single_unit(model):
         subordinate_to=[],
         units=units,
         workload_version="21.0.0",
+        relations={},
     )
 
     plan = nova_compute.generate_upgrade_plan(target, False, units=[units["nova-compute/0"]])
@@ -1013,6 +1040,7 @@ def test_cinder_upgrade_plan(model):
         subordinate_to=[],
         units=units,
         workload_version="16.4.2",
+        relations={},
     )
 
     plan = cinder.generate_upgrade_plan(target, False)
@@ -1066,6 +1094,7 @@ def test_cinder_upgrade_plan_single_unit(model):
         subordinate_to=[],
         units=units,
         workload_version="16.4.2",
+        relations={},
     )
 
     plan = cinder.generate_upgrade_plan(target, False, [units["cinder/0"]])

--- a/tests/unit/apps/test_subordinate.py
+++ b/tests/unit/apps/test_subordinate.py
@@ -50,6 +50,7 @@ def test_current_os_release(model):
             )
         },
         workload_version="18.1.0",
+        relations={},
     )
 
     assert app.current_os_release == OpenStackRelease("ussuri")
@@ -78,6 +79,7 @@ def test_generate_upgrade_plan(model):
             )
         },
         workload_version="18.1.0",
+        relations={},
     )
     expected_plan = ApplicationUpgradePlan(
         description=f"Upgrade plan for '{app.name}' to {target}"
@@ -133,6 +135,7 @@ def test_channel_valid(model, channel):
             )
         },
         workload_version="18.1.0",
+        relations={},
     )
 
     assert app.channel == channel
@@ -171,6 +174,7 @@ def test_channel_setter_invalid(model, channel):
                 )
             },
             workload_version="18.1.0",
+            relations={},
         )
 
 
@@ -205,6 +209,7 @@ def test_generate_plan_ch_migration(model, channel):
             )
         },
         workload_version="18.1.0",
+        relations={},
     )
     expected_plan = ApplicationUpgradePlan(
         description=f"Upgrade plan for '{app.name}' to {target}"
@@ -259,6 +264,7 @@ def test_generate_plan_from_to(model, from_os, to_os):
             )
         },
         workload_version="18.1.0",
+        relations={},
     )
     expected_plan = ApplicationUpgradePlan(description=f"Upgrade plan for '{app.name}' to {to_os}")
     upgrade_steps = [
@@ -312,6 +318,7 @@ def test_generate_plan_in_same_version(model, from_to):
             )
         },
         workload_version="18.1.0",
+        relations={},
     )
     expected_plan = ApplicationUpgradePlan(
         description=f"Upgrade plan for '{app.name}' to {from_to}"

--- a/tests/unit/steps/test_hypervisor.py
+++ b/tests/unit/steps/test_hypervisor.py
@@ -250,6 +250,7 @@ def test_hypervisor_upgrade_plan(model):
             )
         },
         workload_version="16.4.2",
+        relations={},
     )
     nova_compute = NovaCompute(
         name="nova-compute",
@@ -271,6 +272,7 @@ def test_hypervisor_upgrade_plan(model):
             for unit in range(3)
         },
         workload_version="21.0.0",
+        relations={},
     )
 
     planner = HypervisorUpgradePlanner([cinder, nova_compute])

--- a/tests/unit/steps/test_steps_analyze.py
+++ b/tests/unit/steps/test_steps_analyze.py
@@ -72,6 +72,11 @@ def test_analysis_dump(model):
               id: '2'
               apps: !!python/tuple []
               az: null
+          relations:
+            cluster:
+            - keystone
+            identity-service:
+            - cinder
 
         cinder:
           model_name: test_model
@@ -114,6 +119,13 @@ def test_analysis_dump(model):
               id: '2'
               apps: !!python/tuple []
               az: null
+          relations:
+            amqp:
+            - rabbitmq-server
+            cluster:
+            - cinder
+            identity-service:
+            - keystone
 
         rabbitmq-server:
           model_name: test_model
@@ -138,6 +150,11 @@ def test_analysis_dump(model):
               id: '0'
               apps: !!python/tuple []
               az: null
+          relations:
+            amqp:
+            - cinder
+            cluster:
+            - rabbitmq-server
         Data Plane:
 
         Current minimum OS release in the cloud: ussuri
@@ -164,6 +181,7 @@ def test_analysis_dump(model):
             for unit in range(3)
         },
         workload_version="17.0.1",
+        relations={"cluster": ["keystone"], "identity-service": ["cinder"]},
     )
     rabbitmq_server = RabbitMQServer(
         name="rabbitmq-server",
@@ -184,6 +202,7 @@ def test_analysis_dump(model):
             )
         },
         workload_version="3.8",
+        relations={"amqp": ["cinder"], "cluster": ["rabbitmq-server"]},
     )
     cinder = OpenStackApplication(
         name="cinder",
@@ -205,6 +224,11 @@ def test_analysis_dump(model):
             for unit in range(3)
         },
         workload_version="16.4.2",
+        relations={
+            "amqp": ["rabbitmq-server"],
+            "cluster": ["cinder"],
+            "identity-service": ["keystone"],
+        },
     )
     result = analyze.Analysis(
         model=model,
@@ -271,6 +295,7 @@ async def test_analysis_create(mock_split_apps, mock_populate, model):
             )
         },
         workload_version="17.1.0",
+        relations={},
     )
     rabbitmq_server = RabbitMQServer(
         name="rabbitmq-server",
@@ -291,6 +316,7 @@ async def test_analysis_create(mock_split_apps, mock_populate, model):
             )
         },
         workload_version="3.8",
+        relations={},
     )
     cinder = OpenStackApplication(
         name="cinder",
@@ -311,6 +337,7 @@ async def test_analysis_create(mock_split_apps, mock_populate, model):
             )
         },
         workload_version="16.4.2",
+        relations={},
     )
     exp_apps = [keystone, rabbitmq_server, cinder]
     mock_populate.return_value = exp_apps
@@ -349,6 +376,7 @@ async def test_analysis_detect_current_cloud_os_release_different_releases(model
             )
         },
         workload_version="19.1.0",
+        relations={},
     )
     rabbitmq_server = RabbitMQServer(
         name="rabbitmq-server",
@@ -369,6 +397,7 @@ async def test_analysis_detect_current_cloud_os_release_different_releases(model
             )
         },
         workload_version="3.8",
+        relations={},
     )
     cinder = OpenStackApplication(
         name="cinder",
@@ -389,6 +418,7 @@ async def test_analysis_detect_current_cloud_os_release_different_releases(model
             )
         },
         workload_version="16.4.2",
+        relations={},
     )
     result = analyze.Analysis(
         model=model,
@@ -423,6 +453,7 @@ async def test_analysis_detect_current_cloud_series_different_series(model):
             )
         },
         workload_version="17.1.0",
+        relations={},
     )
     rabbitmq_server = RabbitMQServer(
         name="rabbitmq-server",
@@ -443,6 +474,7 @@ async def test_analysis_detect_current_cloud_series_different_series(model):
             )
         },
         workload_version="3.8",
+        relations={},
     )
     cinder = OpenStackApplication(
         name="cinder",
@@ -463,6 +495,7 @@ async def test_analysis_detect_current_cloud_series_different_series(model):
             )
         },
         workload_version="16.4.2",
+        relations={},
     )
     result = analyze.Analysis(
         model=model,
@@ -548,6 +581,7 @@ async def test_analysis_machines(model):
             )
         },
         workload_version="17.1.0",
+        relations={},
     )
     rabbitmq_server = RabbitMQServer(
         name="rabbitmq-server",
@@ -568,6 +602,7 @@ async def test_analysis_machines(model):
             )
         },
         workload_version="3.8",
+        relations={},
     )
     cinder = OpenStackApplication(
         name="cinder",
@@ -588,6 +623,7 @@ async def test_analysis_machines(model):
             )
         },
         workload_version="16.4.2",
+        relations={},
     )
     nova_compute = OpenStackApplication(
         name="nova-compute",
@@ -609,6 +645,7 @@ async def test_analysis_machines(model):
             for unit in range(3)
         },
         workload_version="21.0.0",
+        relations={},
     )
 
     result = analyze.Analysis(

--- a/tests/unit/steps/test_steps_plan.py
+++ b/tests/unit/steps/test_steps_plan.py
@@ -173,6 +173,7 @@ async def test_generate_plan(model, cli_args):
             )
         },
         workload_version="17.0.1",
+        relations={},
     )
     keystone_ldap = SubordinateApplication(
         name="keystone-ldap",
@@ -193,6 +194,7 @@ async def test_generate_plan(model, cli_args):
             )
         },
         workload_version="17.0.1",
+        relations={},
     )
     cinder = OpenStackApplication(
         name="cinder",
@@ -216,6 +218,7 @@ async def test_generate_plan(model, cli_args):
             )
         },
         workload_version="16.4.2",
+        relations={},
     )
 
     analysis_result = Analysis(

--- a/tests/unit/utils/test_juju_utils.py
+++ b/tests/unit/utils/test_juju_utils.py
@@ -687,6 +687,7 @@ async def test_get_applications(mock_get_machines, mock_get_status, mocked_model
                 for name, unit in exp_units[app].items()
             },
             workload_version=status.workload_version,
+            relations=status.relations,
         )
         for app, status in full_status_apps.items()
     }


### PR DESCRIPTION
The relations obtained from application status can be easily used to get name of related applications. For example, we will use it in ceph-osd to get related ceph-mon app.
e.g. `ceph_mon.relations == {'mon': ['ceph-mon']}`