### PR TITLE
Revert "fix zaza.model.run_on_unit"

### DIFF
--- a/tests/functional/tests/model.py
+++ b/tests/functional/tests/model.py
@@ -58,8 +58,7 @@ class COUModelTest(unittest.TestCase):
         test_file = "test.txt"
         path = f"/tmp/{test_file}"
         exp_path = os.path.join(tmp_dir, test_file)
-        zaza.sync_wrapper(self.model.connect)()
-        zaza.sync_wrapper(self.model._model.units[TESTED_UNIT].run)(f"echo 'test' > {path}")
+        zaza.model.run_on_unit(unit_name=TESTED_UNIT, command=f"echo 'test' > {path}")
 
         zaza.sync_wrapper(self.model.scp_from_unit)(TESTED_UNIT, path, tmp_dir)
         self.assertTrue(os.path.exists(exp_path))


### PR DESCRIPTION
Reverts canonical/charmed-openstack-upgrader#257

Since the issue [#649](https://github.com/openstack-charmers/zaza/issues/649) was fixed.