### PR TITLE
Fix lint of documentation

### DIFF
--- a/docs/how-to/different-model.rst
+++ b/docs/how-to/different-model.rst
@@ -29,5 +29,5 @@ configuration files.
 
 .. LINKS
 .. _python-libjuju: https://github.com/juju/python-libjuju
-.. _Juju environment variables: https://juju.is/docs/juju/environment-variables#heading--jujudata
+.. _Juju environment variables: https://juju.is/docs/juju/environment-variables
 .. _JUJU_DATA: https://juju.is/docs/juju/environment-variables#heading--jujudata


### PR DESCRIPTION
- url was complaining that Anchor 'heading--jujudata' not found