### PR TITLE
Add post-upgrade steps for whole upgrade plan

### DIFF
--- a/cou/apps/auxiliary.py
+++ b/cou/apps/auxiliary.py
@@ -168,7 +168,7 @@ class CephMon(AuxiliaryApplication):
         """
         ceph_mon_unit, *_ = self.units.values()
         return PreUpgradeStep(
-            description="Ensure require-osd-release option matches with ceph-osd version",
+            description="Ensure the 'require-osd-release' option matches the 'ceph-osd' version",
             coro=set_require_osd_release_option(ceph_mon_unit.name, self.model),
         )
 

--- a/cou/exceptions.py
+++ b/cou/exceptions.py
@@ -126,6 +126,10 @@ class OutOfSupportRange(COUException):
     """COU exception when the release or series is out of the current supporting range."""
 
 
+class NotSupported(COUException):
+    """COU exception when upgrading a deployment is not supported."""
+
+
 class WaitForApplicationsTimeout(COUException):
     """Waiting for applications hit timeout error."""
 

--- a/cou/exceptions.py
+++ b/cou/exceptions.py
@@ -126,10 +126,6 @@ class OutOfSupportRange(COUException):
     """COU exception when the release or series is out of the current supporting range."""
 
 
-class NotSupported(COUException):
-    """COU exception when upgrading a deployment is not supported."""
-
-
 class WaitForApplicationsTimeout(COUException):
     """Waiting for applications hit timeout error."""
 

--- a/cou/steps/__init__.py
+++ b/cou/steps/__init__.py
@@ -251,6 +251,15 @@ class BaseStep:
 
         self._sub_steps.append(step)
 
+    def add_steps(self, steps: Iterable[BaseStep]) -> None:
+        """Add multiple steps.
+
+        :param steps: Sequence of BaseStep to be added as sub step.
+        :type steps: Iterable[BaseStep]
+        """
+        for step in steps:
+            self.add_step(step)
+
     def cancel(self, safe: bool = True) -> None:
         """Cancel step and all its sub steps.
 

--- a/cou/steps/__init__.py
+++ b/cou/steps/__init__.py
@@ -254,7 +254,7 @@ class BaseStep:
     def add_steps(self, steps: Iterable[BaseStep]) -> None:
         """Add multiple steps.
 
-        :param steps: Sequence of BaseStep to be added as sub step.
+        :param steps: Sequence of BaseStep to be added as sub steps.
         :type steps: Iterable[BaseStep]
         """
         for step in steps:

--- a/cou/steps/plan.py
+++ b/cou/steps/plan.py
@@ -392,7 +392,8 @@ def _get_ceph_mon_post_upgrade_steps(apps: list[OpenStackApplication]) -> list[P
         unit = list(app.units.values())[0]  # getting the first unit, since we don't care which one
         steps.append(
             PostUpgradeStep(
-                "Ensure the 'require-osd-release' option matches the 'ceph-osd' version",
+                f"Ensure the 'require-osd-release' option in '{app.name}' matches the 'ceph-osd' "
+                "version",
                 coro=set_require_osd_release_option(unit.name, app.model),
             )
         )

--- a/tests/unit/apps/test_auxiliary.py
+++ b/tests/unit/apps/test_auxiliary.py
@@ -636,7 +636,7 @@ def test_ceph_mon_upgrade_plan_xena_to_yoga(model):
             coro=model.upgrade_charm(app.name, "pacific/stable", switch=None),
         ),
         PreUpgradeStep(
-            description="Ensure require-osd-release option matches with ceph-osd version",
+            description="Ensure the 'require-osd-release' option matches the 'ceph-osd' version",
             parallel=False,
             coro=app_utils.set_require_osd_release_option("ceph-mon/0", model),
         ),
@@ -725,7 +725,7 @@ def test_ceph_mon_upgrade_plan_ussuri_to_victoria(model):
             coro=model.upgrade_charm(app.name, "octopus/stable", switch=None),
         ),
         PreUpgradeStep(
-            description="Ensure require-osd-release option matches with ceph-osd version",
+            description="Ensure the 'require-osd-release' option matches the 'ceph-osd' version",
             parallel=False,
             coro=app_utils.set_require_osd_release_option("ceph-mon/0", model),
         ),

--- a/tests/unit/steps/test_steps.py
+++ b/tests/unit/steps/test_steps.py
@@ -256,7 +256,8 @@ def test_step_add_steps():
     exp_sub_steps = 3
     plan = BaseStep(description="plan")
     plan.add_steps(
-        BaseStep(description=f"sub-step-{i}", coro=mock_coro()) for i in range(exp_sub_steps)
+        [BaseStep(description=f"sub-step-{i}", coro=mock_coro()) for i in range(exp_sub_steps)]
+        + [BaseStep(description="empty-step")]  # we also check that empty step will be not added
     )
 
     assert len(plan.sub_steps) == exp_sub_steps

--- a/tests/unit/steps/test_steps.py
+++ b/tests/unit/steps/test_steps.py
@@ -257,7 +257,7 @@ def test_step_add_steps():
     plan = BaseStep(description="plan")
     plan.add_steps(
         [BaseStep(description=f"sub-step-{i}", coro=mock_coro()) for i in range(exp_sub_steps)]
-        + [BaseStep(description="empty-step")]  # we also check that empty step will be not added
+        + [BaseStep(description="empty-step")]  # we also check that empty step will not be added
     )
 
     assert len(plan.sub_steps) == exp_sub_steps

--- a/tests/unit/steps/test_steps.py
+++ b/tests/unit/steps/test_steps.py
@@ -251,6 +251,17 @@ def test_step_add_step_failed():
         plan.add_step(MagicMock())
 
 
+def test_step_add_steps():
+    """Test BaseStep adding sub steps at once."""
+    exp_sub_steps = 3
+    plan = BaseStep(description="plan")
+    plan.add_steps(
+        BaseStep(description=f"sub-step-{i}", coro=mock_coro()) for i in range(exp_sub_steps)
+    )
+
+    assert len(plan.sub_steps) == exp_sub_steps
+
+
 def test_step_cancel_safe():
     """Test step safe cancel."""
     plan = BaseStep(description="plan")

--- a/tests/unit/steps/test_steps_plan.py
+++ b/tests/unit/steps/test_steps_plan.py
@@ -821,14 +821,14 @@ def test_get_ceph_mon_post_upgrade_steps_multiple(model):
 
     exp_steps = 2 * [
         PostUpgradeStep(
-            "Ensure the 'require-osd-release' option matches the 'ceph-osd' version",
-            coro=app_utils.set_require_osd_release_option("cpeh-mon/0", model),
+            "Ensure the 'require-osd-release' option in 'ceph-mon' matches the 'ceph-osd' version",
+            coro=app_utils.set_require_osd_release_option("ceph-mon/0", model),
         )
     ]
 
-    step = cou_plan._get_ceph_mon_post_upgrade_steps([ceph_mon, ceph_mon])
+    steps = cou_plan._get_ceph_mon_post_upgrade_steps([ceph_mon, ceph_mon])
 
-    assert step == exp_steps
+    assert steps == exp_steps
 
 
 @patch("cou.steps.plan.create_upgrade_group")

--- a/tests/unit/steps/test_steps_plan.py
+++ b/tests/unit/steps/test_steps_plan.py
@@ -772,7 +772,7 @@ def test_get_post_upgrade_steps_empty(mock_get_ceph_mon_post_upgrade_steps, upgr
 @pytest.mark.parametrize("upgrade_group", [DATA_PLANE, None])
 @patch("cou.steps.plan._get_ceph_mon_post_upgrade_steps")
 def test_get_post_upgrade_steps_ceph_mon(mock_get_ceph_mon_post_upgrade_steps, upgrade_group):
-    """Test get post upgrad steps including ceph-mon."""
+    """Test get post upgrade steps including ceph-mon."""
     args = MagicMock(spec_set=CLIargs)()
     args.upgrade_group = upgrade_group
     analysis_result = MagicMock(spec_set=Analysis)()


### PR DESCRIPTION
Adding ceph-mon post-upgrade step to ensure require-osd-release option matches with ceph-osd version. Add also add_steps function to BaseStep so we can easily add more steps at once.