### PR TITLE
Auxiliary upgrade using all-in-one also when units are passed

### DIFF
--- a/cou/apps/auxiliary.py
+++ b/cou/apps/auxiliary.py
@@ -19,7 +19,7 @@ from cou.apps import LONG_IDLE_TIMEOUT
 from cou.apps.base import OpenStackApplication
 from cou.apps.factory import AppFactory
 from cou.exceptions import ApplicationError
-from cou.steps import PreUpgradeStep
+from cou.steps import ApplicationUpgradePlan, PreUpgradeStep
 from cou.utils.app_utils import set_require_osd_release_option, validate_ovn_support
 from cou.utils.juju_utils import COUUnit
 from cou.utils.openstack import (
@@ -121,6 +121,31 @@ class AuxiliaryApplication(OpenStackApplication):
         compatible_os_releases = TRACK_TO_OPENSTACK_MAPPING[(self.charm, self.series, track)]
         # channel setter already validate if it is a valid channel.
         return max(compatible_os_releases)
+
+    def generate_upgrade_plan(
+        self,
+        target: OpenStackRelease,
+        force: bool,
+        units: Optional[list[COUUnit]] = None,
+    ) -> ApplicationUpgradePlan:
+        """Generate full upgrade plan for an Application.
+
+        Auxiliary applications cannot upgrade unit by unit.
+
+        :param target: OpenStack codename to upgrade.
+        :type target: OpenStackRelease
+        :param force: Whether the plan generation should be forced
+        :type force: bool
+        :param units: Units to generate upgrade plan, defaults to None
+        :type units: Optional[list[COUUnit]], optional
+        :return: Full upgrade plan if the Application is able to generate it.
+        :rtype: ApplicationUpgradePlan
+        """
+        if units:
+            logger.warning(
+                "%s cannot upgrade by units. The upgrade will use all-in-one method.", self.name
+            )
+        return super().generate_upgrade_plan(target, force, None)
 
 
 @AppFactory.register_application(["rabbitmq-server"])

--- a/tests/unit/apps/test_auxiliary.py
+++ b/tests/unit/apps/test_auxiliary.py
@@ -16,7 +16,13 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from cou.apps.auxiliary import CephMon, MysqlInnodbCluster, OvnPrincipal, RabbitMQServer
+from cou.apps.auxiliary import (
+    AuxiliaryApplication,
+    CephMon,
+    MysqlInnodbCluster,
+    OvnPrincipal,
+    RabbitMQServer,
+)
 from cou.exceptions import ApplicationError, HaltUpgradePlanGeneration
 from cou.steps import (
     ApplicationUpgradePlan,
@@ -1018,5 +1024,99 @@ def test_mysql_innodb_cluster_upgrade(model):
     add_steps(expected_plan, upgrade_steps)
 
     upgrade_plan = app.generate_upgrade_plan(target, False)
+
+    assert_steps(upgrade_plan, expected_plan)
+
+
+def test_auxiliary_upgrade_by_unit(model):
+    """Test generating plan with units doesn't create unit Upgrade steps."""
+    target = OpenStackRelease("victoria")
+    charm = "vault"
+    machines = {
+        "0": MagicMock(spec_set=COUMachine),
+        "1": MagicMock(spec_set=COUMachine),
+        "2": MagicMock(spec_set=COUMachine),
+    }
+    app = AuxiliaryApplication(
+        name=charm,
+        can_upgrade_to="1.7/stable",
+        charm=charm,
+        channel="1.7/stable",
+        config={"source": {"value": "distro"}},
+        machines=machines,
+        model=model,
+        origin="ch",
+        series="focal",
+        subordinate_to=[],
+        units={
+            f"{charm}/0": COUUnit(
+                name=f"{charm}/0",
+                workload_version="1.7",
+                machine=machines["0"],
+            ),
+            f"{charm}/1": COUUnit(
+                name=f"{charm}/1",
+                workload_version="1.7",
+                machine=machines["1"],
+            ),
+            f"{charm}/2": COUUnit(
+                name=f"{charm}/2",
+                workload_version="1.7",
+                machine=machines["2"],
+            ),
+        },
+        workload_version="1.7",
+    )
+
+    upgrade_plan = app.generate_upgrade_plan(target, False, [app.units[f"{charm}/0"]])
+
+    expected_plan = ApplicationUpgradePlan(
+        description=f"Upgrade plan for '{app.name}' to {target}"
+    )
+    upgrade_packages = PreUpgradeStep(
+        description=f"Upgrade software packages of '{app.name}' from the current APT repositories",
+        parallel=True,
+    )
+    # even that a single unit is passed, it upgrade the packages for all units
+    for unit in app.units.values():
+        upgrade_packages.add_step(
+            UnitUpgradeStep(
+                description=f"Upgrade software packages on unit {unit.name}",
+                coro=app_utils.upgrade_packages(unit.name, model, None),
+            )
+        )
+
+    upgrade_steps = [
+        upgrade_packages,
+        PreUpgradeStep(
+            description=f"Refresh '{app.name}' to the latest revision of '1.7/stable'",
+            parallel=False,
+            coro=model.upgrade_charm(app.name, "1.7/stable", switch=None),
+        ),
+        UpgradeStep(
+            description=(
+                f"Change charm config of '{app.name}' "
+                f"'{app.origin_setting}' to 'cloud:focal-{target}'"
+            ),
+            parallel=False,
+            coro=model.set_application_config(
+                app.name, {f"{app.origin_setting}": f"cloud:focal-{target}"}
+            ),
+        ),
+        PostUpgradeStep(
+            description=f"Wait 300s for app {app.name} to reach the idle state.",
+            parallel=False,
+            coro=model.wait_for_active_idle(300, apps=[app.name]),
+        ),
+        PostUpgradeStep(
+            description=(
+                f"Check if the workload of '{app.name}' has been upgraded on units: "
+                f"{', '.join([unit for unit in app.units.keys()])}"
+            ),
+            parallel=False,
+            coro=app._verify_workload_upgrade(target, app.units.values()),
+        ),
+    ]
+    add_steps(expected_plan, upgrade_steps)
 
     assert_steps(upgrade_plan, expected_plan)


### PR DESCRIPTION
- auxiliary apps cannot upgrade unit-by-unit. If units are passed, a warning message will show saying that will upgrade using all- in-one method