### PR TITLE
Remove subordinate units from the unit tests

### DIFF
--- a/tests/unit/apps/test_auxiliary_subordinate.py
+++ b/tests/unit/apps/test_auxiliary_subordinate.py
@@ -23,7 +23,7 @@ from cou.apps.auxiliary_subordinate import (
 )
 from cou.exceptions import ApplicationError
 from cou.steps import ApplicationUpgradePlan, PreUpgradeStep, UpgradeStep
-from cou.utils.juju_utils import COUMachine, COUUnit
+from cou.utils.juju_utils import COUMachine
 from cou.utils.openstack import OpenStackRelease
 from tests.unit.apps.utils import add_steps
 from tests.unit.utils import assert_steps
@@ -43,13 +43,7 @@ def test_auxiliary_subordinate(model):
         origin="ch",
         series="focal",
         subordinate_to=["keystone"],
-        units={
-            "keystone-mysql-router/0": COUUnit(
-                name="keystone-mysql-router/0",
-                workload_version="8.0",
-                machine=machines["0"],
-            )
-        },
+        units={},
         workload_version="8.0",
     )
 
@@ -77,13 +71,7 @@ def test_auxiliary_subordinate_upgrade_plan_to_victoria(model):
         origin="ch",
         series="focal",
         subordinate_to=["keystone"],
-        units={
-            "keystone-mysql-router/0": COUUnit(
-                name="keystone-mysql-router/0",
-                workload_version="8.0",
-                machine=machines["0"],
-            )
-        },
+        units={},
         workload_version="8.0",
     )
 
@@ -117,13 +105,7 @@ def test_ovn_subordinate(model):
         origin="ch",
         series="focal",
         subordinate_to=["nova-compute"],
-        units={
-            "ovn-chassis/0": COUUnit(
-                name="ovn-chassis/0",
-                workload_version="22.03",
-                machine=machines["0"],
-            )
-        },
+        units={},
         workload_version="22.3",
     )
 
@@ -156,13 +138,7 @@ def test_ovn_workload_ver_lower_than_22_subordinate(model):
         origin="ch",
         series="focal",
         subordinate_to=["nova-compute"],
-        units={
-            "ovn-chassis/0": COUUnit(
-                name="ovn-chassis/0",
-                workload_version="20.03",
-                machine=machines["0"],
-            )
-        },
+        units={},
         workload_version="20.3",
     )
 
@@ -185,13 +161,7 @@ def test_ovn_subordinate_upgrade_plan(model):
         origin="ch",
         series="focal",
         subordinate_to=["nova-compute"],
-        units={
-            "ovn-chassis/0": COUUnit(
-                name="ovn-chassis/0",
-                workload_version="22.03",
-                machine=machines["0"],
-            )
-        },
+        units={},
         workload_version="22.3",
     )
 
@@ -232,13 +202,7 @@ def test_ovn_subordinate_upgrade_plan_cant_upgrade_charm(model):
         origin="ch",
         series="focal",
         subordinate_to=["nova-compute"],
-        units={
-            "ovn-chassis/0": COUUnit(
-                name="ovn-chassis/0",
-                workload_version="22.03",
-                machine=machines["0"],
-            )
-        },
+        units={},
         workload_version="22.3",
     )
 
@@ -267,13 +231,7 @@ def test_ceph_dashboard_upgrade_plan_ussuri_to_victoria(model):
         origin="ch",
         series="focal",
         subordinate_to=["nova-compute"],
-        units={
-            "ceph-dashboard/0": COUUnit(
-                name="ceph-dashboard/0",
-                workload_version="15.2.0",
-                machine=machines["0"],
-            )
-        },
+        units={},
         workload_version="15.2.0",
     )
 
@@ -310,13 +268,7 @@ def test_ceph_dashboard_upgrade_plan_xena_to_yoga(model):
         origin="ch",
         series="focal",
         subordinate_to=["nova-compute"],
-        units={
-            "ceph-dashboard/0": COUUnit(
-                name="ceph-dashboard/0",
-                workload_version="16.2.0",
-                machine=machines["0"],
-            )
-        },
+        units={},
         workload_version="16.2.0",
     )
 

--- a/tests/unit/apps/test_subordinate.py
+++ b/tests/unit/apps/test_subordinate.py
@@ -20,7 +20,7 @@ import pytest
 from cou.apps.subordinate import SubordinateApplication
 from cou.exceptions import ApplicationError
 from cou.steps import ApplicationUpgradePlan, PreUpgradeStep, UpgradeStep
-from cou.utils.juju_utils import COUMachine, COUUnit
+from cou.utils.juju_utils import COUMachine
 from cou.utils.openstack import OpenStackRelease
 from tests.unit.apps.utils import add_steps
 from tests.unit.utils import assert_steps
@@ -42,13 +42,7 @@ def test_current_os_release(model):
         origin="ch",
         series="focal",
         subordinate_to=["nova-compute"],
-        units={
-            "keystone-ldap/0": COUUnit(
-                name="keystone-ldap/0",
-                workload_version="18.1.0",
-                machine=machines["0"],
-            )
-        },
+        units={},
         workload_version="18.1.0",
     )
 
@@ -119,13 +113,7 @@ def test_channel_valid(model, channel):
         origin="ch",
         series="focal",
         subordinate_to=["nova-compute"],
-        units={
-            "keystone-ldap/0": COUUnit(
-                name="keystone-ldap/0",
-                workload_version="18.1.0",
-                machine=machines["0"],
-            )
-        },
+        units={},
         workload_version="18.1.0",
     )
 
@@ -157,13 +145,7 @@ def test_channel_setter_invalid(model, channel):
             origin="ch",
             series="focal",
             subordinate_to=["nova-compute"],
-            units={
-                "keystone-ldap/0": COUUnit(
-                    name="keystone-ldap/0",
-                    workload_version="18.1.0",
-                    machine=machines["0"],
-                )
-            },
+            units={},
             workload_version="18.1.0",
         )
 


### PR DESCRIPTION
- juju status does not provide units for subordinate units and unit tests should reflect that.