### PR TITLE
COUUnit able to evaluate its current OpenStackRelease

### DIFF
--- a/cou/apps/base.py
+++ b/cou/apps/base.py
@@ -116,7 +116,7 @@ class OpenStackApplication(COUApplication):
                         "name": unit.name,
                         "machine": unit.machine.machine_id,
                         "workload_version": unit.workload_version,
-                        "os_version": str(self._get_latest_os_version(unit)),
+                        "os_version": str(unit.os_release),
                     }
                     for unit in self.units.values()
                 },
@@ -191,27 +191,6 @@ class OpenStackApplication(COUApplication):
         except ValueError:
             return self.is_from_charm_store
 
-    def _get_latest_os_version(self, unit: COUUnit) -> OpenStackRelease:
-        """Get the latest compatible OpenStack release based on the unit workload version.
-
-        :param unit: Application Unit
-        :type unit: COUUnit
-        :raises ApplicationError: When there are no compatible OpenStack release for the
-        workload version.
-        :return: The latest compatible OpenStack release.
-        :rtype: OpenStackRelease
-        """
-        compatible_os_versions = OpenStackCodenameLookup.find_compatible_versions(
-            self.charm, unit.workload_version
-        )
-        if not compatible_os_versions:
-            raise ApplicationError(
-                f"'{self.name}' with workload version {unit.workload_version} has no "
-                "compatible OpenStack release."
-            )
-
-        return max(compatible_os_versions)
-
     @staticmethod
     def _get_track_from_channel(charm_channel: str) -> str:
         """Get the track from a given channel.
@@ -251,8 +230,7 @@ class OpenStackApplication(COUApplication):
         """
         os_versions = defaultdict(list)
         for unit in self.units.values():
-            os_version = self._get_latest_os_version(unit)
-            os_versions[os_version].append(unit.name)
+            os_versions[unit.os_release].append(unit.name)
         return dict(os_versions)
 
     @property

--- a/cou/apps/channel_based.py
+++ b/cou/apps/channel_based.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 """Channel based application class."""
 import logging
+from collections import defaultdict
 from typing import Iterable, Optional
 
 from cou.apps.base import OpenStackApplication
@@ -28,17 +29,17 @@ logger = logging.getLogger(__name__)
 class ChannelBasedApplication(OpenStackApplication):
     """Application for charms that are channel based."""
 
-    def _get_latest_os_version(self, unit: COUUnit) -> OpenStackRelease:
-        """Get the latest compatible OpenStack release based on the channel.
+    @property
+    def os_release_units(self) -> dict[OpenStackRelease, list[str]]:
+        """Get the OpenStack release versions from the units.
 
-        :param unit: COUUnit
-        :type unit: COUUnit
-        :raises ApplicationError: When there are no compatible OpenStack release for the
-        workload version.
-        :return: The latest compatible OpenStack release.
-        :rtype: OpenStackRelease
+        :return: OpenStack release versions from the units.
+        :rtype: defaultdict[OpenStackRelease, list[str]]
         """
-        return self.channel_codename
+        os_versions = defaultdict(list)
+        for unit in self.units.values():
+            os_versions[self.channel_codename].append(unit.name)
+        return dict(os_versions)
 
     @property
     def current_os_release(self) -> OpenStackRelease:

--- a/cou/exceptions.py
+++ b/cou/exceptions.py
@@ -43,6 +43,10 @@ class UnitNotFound(COUException):
     """Exception raised when a unit is not found in the model."""
 
 
+class UnitError(COUException):
+    """Exception raised when a unit does something unexpected."""
+
+
 class ApplicationNotFound(COUException):
     """Exception raised when an application is not found in the model."""
 

--- a/tests/unit/apps/test_auxiliary.py
+++ b/tests/unit/apps/test_auxiliary.py
@@ -23,7 +23,7 @@ from cou.apps.auxiliary import (
     OvnPrincipal,
     RabbitMQServer,
 )
-from cou.exceptions import ApplicationError, HaltUpgradePlanGeneration
+from cou.exceptions import ApplicationError, HaltUpgradePlanGeneration, UnitError
 from cou.steps import (
     ApplicationUpgradePlan,
     PostUpgradeStep,
@@ -59,6 +59,7 @@ def test_auxiliary_app(model):
         units={
             "rabbitmq-server/0": COUUnit(
                 name="rabbitmq-server/0",
+                charm="rabbitmq-server",
                 workload_version="3.8",
                 machine=machines["0"],
             )
@@ -91,6 +92,7 @@ def test_auxiliary_app_cs(model):
         units={
             "rabbitmq-server/0": COUUnit(
                 name="rabbitmq-server/0",
+                charm="rabbitmq-server",
                 workload_version="3.8",
                 machine=machines["0"],
             )
@@ -124,6 +126,7 @@ def test_auxiliary_upgrade_plan_ussuri_to_victoria_change_channel(model):
         units={
             "rabbitmq-server/0": COUUnit(
                 name="rabbitmq-server/0",
+                charm="rabbitmq-server",
                 workload_version="3.8",
                 machine=machines["0"],
             )
@@ -208,6 +211,7 @@ def test_auxiliary_upgrade_plan_ussuri_to_victoria(model):
         units={
             "rabbitmq-server/0": COUUnit(
                 name="rabbitmq-server/0",
+                charm="rabbitmq-server",
                 workload_version="3.9",
                 machine=machines["0"],
             )
@@ -287,6 +291,7 @@ def test_auxiliary_upgrade_plan_ussuri_to_victoria_ch_migration(model):
         units={
             "rabbitmq-server/0": COUUnit(
                 name="rabbitmq-server/0",
+                charm="rabbitmq-server",
                 workload_version="3.8",
                 machine=machines["0"],
             )
@@ -378,6 +383,7 @@ def test_auxiliary_upgrade_plan_unknown_track(model):
             units={
                 "rabbitmq-server/0": COUUnit(
                     name="rabbitmq-server/0",
+                    charm="rabbitmq-server",
                     workload_version="3.8",
                     machine=machines["0"],
                 )
@@ -386,7 +392,7 @@ def test_auxiliary_upgrade_plan_unknown_track(model):
         )
 
 
-def test_auxiliary_app_unknown_version_raise_ApplicationError(model):
+def test_auxiliary_app_unknown_version_raise_UnitError(model):
     """Test auxiliary upgrade plan with unknown version."""
     version = "80.5"
     charm = "rabbitmq-server"
@@ -407,14 +413,15 @@ def test_auxiliary_app_unknown_version_raise_ApplicationError(model):
         units={
             f"{charm}/0": COUUnit(
                 name=f"{charm}/0",
+                charm=charm,
                 workload_version=version,
                 machine=machines["0"],
             )
         },
         workload_version=version,
     )
-    with pytest.raises(ApplicationError, match=exp_msg):
-        app._get_latest_os_version(app.units[f"{charm}/0"])
+    with pytest.raises(UnitError, match=exp_msg):
+        app.current_os_release
 
 
 def test_auxiliary_raise_error_unknown_series(model):
@@ -443,6 +450,7 @@ def test_auxiliary_raise_error_unknown_series(model):
             units={
                 "rabbitmq-server/0": COUUnit(
                     name="rabbitmq-server/0",
+                    charm="rabbitmq-server",
                     workload_version="3.8",
                     machine=machines["0"],
                 )
@@ -474,6 +482,7 @@ def test_auxiliary_raise_error_os_not_on_lookup(current_os_release, model):
         units={
             "rabbitmq-server/0": COUUnit(
                 name="rabbitmq-server/0",
+                charm="rabbitmq-server",
                 workload_version="3.8",
                 machine=machines["0"],
             )
@@ -511,6 +520,7 @@ def test_auxiliary_raise_halt_upgrade(model):
         units={
             f"{charm}/0": COUUnit(
                 name=f"{charm}/0",
+                charm="rabbitmq-server",
                 workload_version="3.8",
                 machine=machines["0"],
             )
@@ -549,6 +559,7 @@ def test_auxiliary_no_suitable_channel(model):
         units={
             f"{charm}/0": COUUnit(
                 name=f"{charm}/0",
+                charm="rabbitmq-server",
                 workload_version="3.8",
                 machine=machines["0"],
             )
@@ -578,6 +589,7 @@ def test_ceph_mon_app(model):
         units={
             f"{charm}/0": COUUnit(
                 name=f"{charm}/0",
+                charm="ceph-mon",
                 workload_version="16.2.0",
                 machine=machines["0"],
             )
@@ -587,7 +599,7 @@ def test_ceph_mon_app(model):
 
     assert app.channel == "pacific/stable"
     assert app.os_origin == "cloud:focal-xena"
-    assert app._get_latest_os_version(app.units[f"{charm}/0"]) == OpenStackRelease("xena")
+    assert app.units[f"{charm}/0"].os_release == OpenStackRelease("xena")
     assert app.apt_source_codename == "xena"
     assert app.channel_codename == "xena"
     assert app.is_subordinate is False
@@ -612,6 +624,7 @@ def test_ceph_mon_upgrade_plan_xena_to_yoga(model):
         units={
             f"{charm}/0": COUUnit(
                 name=f"{charm}/0",
+                charm="ceph-mon",
                 workload_version="16.2.0",
                 machine=machines["0"],
             )
@@ -701,6 +714,7 @@ def test_ceph_mon_upgrade_plan_ussuri_to_victoria(model):
         units={
             f"{charm}/0": COUUnit(
                 name=f"{charm}/0",
+                charm="ceph-mon",
                 workload_version="15.2.0",
                 machine=machines["0"],
             )
@@ -784,6 +798,7 @@ def test_ovn_principal(model):
         units={
             f"{charm}/0": COUUnit(
                 name=f"{charm}/0",
+                charm=charm,
                 workload_version="22.03",
                 machine=machines["0"],
             )
@@ -823,6 +838,7 @@ def test_ovn_workload_ver_lower_than_22_principal(model):
         units={
             f"{charm}/0": COUUnit(
                 name=f"{charm}/0",
+                charm=charm,
                 workload_version="20.03.2",
                 machine=machines["0"],
             )
@@ -861,6 +877,7 @@ def test_ovn_no_compatible_os_release(channel, model):
             units={
                 f"{charm}/0": COUUnit(
                     name=f"{charm}/0",
+                    charm=charm,
                     workload_version="22.03",
                     machine=machines["0"],
                 )
@@ -888,6 +905,7 @@ def test_ovn_principal_upgrade_plan(model):
         units={
             f"{charm}/0": COUUnit(
                 name=f"{charm}/0",
+                charm=charm,
                 workload_version="22.03",
                 machine=machines["0"],
             )
@@ -968,6 +986,7 @@ def test_mysql_innodb_cluster_upgrade(model):
         units={
             f"{charm}/0": COUUnit(
                 name=f"{charm}/0",
+                charm=charm,
                 workload_version="8.0",
                 machine=machines["0"],
             )
@@ -1052,16 +1071,19 @@ def test_auxiliary_upgrade_by_unit(mock_super, model):
         units={
             f"{charm}/0": COUUnit(
                 name=f"{charm}/0",
+                charm=charm,
                 workload_version="1.7",
                 machine=machines["0"],
             ),
             f"{charm}/1": COUUnit(
                 name=f"{charm}/1",
+                charm=charm,
                 workload_version="1.7",
                 machine=machines["1"],
             ),
             f"{charm}/2": COUUnit(
                 name=f"{charm}/2",
+                charm=charm,
                 workload_version="1.7",
                 machine=machines["2"],
             ),

--- a/tests/unit/apps/test_auxiliary_subordinate.py
+++ b/tests/unit/apps/test_auxiliary_subordinate.py
@@ -23,7 +23,7 @@ from cou.apps.auxiliary_subordinate import (
 )
 from cou.exceptions import ApplicationError
 from cou.steps import ApplicationUpgradePlan, PreUpgradeStep, UpgradeStep
-from cou.utils.juju_utils import COUMachine, COUUnit
+from cou.utils.juju_utils import COUMachine
 from cou.utils.openstack import OpenStackRelease
 from tests.unit.apps.utils import add_steps
 from tests.unit.utils import assert_steps
@@ -43,13 +43,7 @@ def test_auxiliary_subordinate(model):
         origin="ch",
         series="focal",
         subordinate_to=["keystone"],
-        units={
-            "keystone-mysql-router/0": COUUnit(
-                name="keystone-mysql-router/0",
-                workload_version="8.0",
-                machine=machines["0"],
-            )
-        },
+        units={},
         workload_version="8.0",
     )
 
@@ -77,13 +71,7 @@ def test_auxiliary_subordinate_upgrade_plan_to_victoria(model):
         origin="ch",
         series="focal",
         subordinate_to=["keystone"],
-        units={
-            "keystone-mysql-router/0": COUUnit(
-                name="keystone-mysql-router/0",
-                workload_version="8.0",
-                machine=machines["0"],
-            )
-        },
+        units={},
         workload_version="8.0",
     )
 
@@ -117,13 +105,7 @@ def test_ovn_subordinate(model):
         origin="ch",
         series="focal",
         subordinate_to=["nova-compute"],
-        units={
-            "ovn-chassis/0": COUUnit(
-                name="ovn-chassis/0",
-                workload_version="22.03",
-                machine=machines["0"],
-            )
-        },
+        units={},
         workload_version="22.3",
     )
 
@@ -156,13 +138,7 @@ def test_ovn_workload_ver_lower_than_22_subordinate(model):
         origin="ch",
         series="focal",
         subordinate_to=["nova-compute"],
-        units={
-            "ovn-chassis/0": COUUnit(
-                name="ovn-chassis/0",
-                workload_version="20.03",
-                machine=machines["0"],
-            )
-        },
+        units={},
         workload_version="20.3",
     )
 
@@ -185,13 +161,7 @@ def test_ovn_subordinate_upgrade_plan(model):
         origin="ch",
         series="focal",
         subordinate_to=["nova-compute"],
-        units={
-            "ovn-chassis/0": COUUnit(
-                name="ovn-chassis/0",
-                workload_version="22.03",
-                machine=machines["0"],
-            )
-        },
+        units={},
         workload_version="22.3",
     )
 
@@ -232,13 +202,7 @@ def test_ovn_subordinate_upgrade_plan_cant_upgrade_charm(model):
         origin="ch",
         series="focal",
         subordinate_to=["nova-compute"],
-        units={
-            "ovn-chassis/0": COUUnit(
-                name="ovn-chassis/0",
-                workload_version="22.03",
-                machine=machines["0"],
-            )
-        },
+        units={},
         workload_version="22.3",
     )
 
@@ -267,13 +231,7 @@ def test_ceph_dashboard_upgrade_plan_ussuri_to_victoria(model):
         origin="ch",
         series="focal",
         subordinate_to=["nova-compute"],
-        units={
-            "ceph-dashboard/0": COUUnit(
-                name="ceph-dashboard/0",
-                workload_version="15.2.0",
-                machine=machines["0"],
-            )
-        },
+        units={},
         workload_version="15.2.0",
     )
 
@@ -310,13 +268,7 @@ def test_ceph_dashboard_upgrade_plan_xena_to_yoga(model):
         origin="ch",
         series="focal",
         subordinate_to=["nova-compute"],
-        units={
-            "ceph-dashboard/0": COUUnit(
-                name="ceph-dashboard/0",
-                workload_version="16.2.0",
-                machine=machines["0"],
-            )
-        },
+        units={},
         workload_version="16.2.0",
     )
 

--- a/tests/unit/apps/test_channel_based.py
+++ b/tests/unit/apps/test_channel_based.py
@@ -33,6 +33,7 @@ def test_application_versionless(model):
     units = {
         "glance-simplestreams-sync/0": COUUnit(
             name="glance-simplestreams-sync/0",
+            charm="glance-simplestreams-sync",
             workload_version="",
             machine=machines["0"],
         )
@@ -57,7 +58,7 @@ def test_application_versionless(model):
 
     assert app.current_os_release == "ussuri"
     assert app.is_versionless is True
-    assert app._get_latest_os_version(units["glance-simplestreams-sync/0"]) == app.channel_codename
+    assert app.os_release_units == {OpenStackRelease("ussuri"): ["glance-simplestreams-sync/0"]}
 
 
 def test_application_gnocchi_ussuri(model):
@@ -80,6 +81,7 @@ def test_application_gnocchi_ussuri(model):
         units={
             "gnocchi/0": COUUnit(
                 name="gnocchi/0",
+                charm="gnocchi",
                 workload_version="4.3.4",
                 machine=machines["0"],
             )
@@ -112,6 +114,7 @@ def test_application_gnocchi_xena(model):
         units={
             "gnocchi/0": COUUnit(
                 name="gnocchi/0",
+                charm="gnocchi",
                 workload_version="4.4.1",
                 machine=machines["0"],
             )
@@ -147,6 +150,7 @@ def test_application_designate_bind_ussuri(model):
         units={
             "designate-bind/0": COUUnit(
                 name="designate-bind/0",
+                charm="designate-bind",
                 workload_version="9.16.1",
                 machine=machines["0"],
             )
@@ -176,6 +180,7 @@ def test_application_versionless_upgrade_plan_ussuri_to_victoria(model):
         units={
             "glance-simplestreams-sync/0": COUUnit(
                 name="glance-simplestreams-sync/0",
+                charm="glance-simplestreams-sync",
                 workload_version="",
                 machine=machines["0"],
             )
@@ -255,6 +260,7 @@ def test_application_gnocchi_upgrade_plan_ussuri_to_victoria(model):
         units={
             "gnocchi/0": COUUnit(
                 name="gnocchi/0",
+                charm="gnocchi",
                 workload_version="4.3.4",
                 machine=machines["0"],
             )
@@ -344,6 +350,7 @@ def test_application_designate_bind_upgrade_plan_ussuri_to_victoria(model):
         units={
             "designate-bind/0": COUUnit(
                 name="designate-bind/0",
+                charm="designate-bind",
                 workload_version="9.16.1",
                 machine=machines["0"],
             )

--- a/tests/unit/apps/test_core.py
+++ b/tests/unit/apps/test_core.py
@@ -44,16 +44,19 @@ def test_application_different_wl(model):
     units = {
         "keystone/0": COUUnit(
             name="keystone/0",
+            charm="keystone",
             workload_version="17.0.1",
             machine=machines["0"],
         ),
         "keystone/1": COUUnit(
             name="keystone/1",
+            charm="keystone",
             workload_version="17.0.1",
             machine=machines["1"],
         ),
         "keystone/2": COUUnit(
             name="keystone/2",
+            charm="keystone",
             workload_version="18.1.0",
             machine=machines["2"],
         ),
@@ -93,6 +96,7 @@ def test_application_no_origin_config(model):
         units={
             "keystone/0": COUUnit(
                 name="keystone/0",
+                charm="keystone",
                 workload_version="18.0.1",
                 machine=machines["0"],
             )
@@ -121,6 +125,7 @@ def test_application_empty_origin_config(model):
         units={
             "keystone/0": COUUnit(
                 name="keystone/0",
+                charm="keystone",
                 workload_version="18.0.1",
                 machine=machines["0"],
             )
@@ -153,6 +158,7 @@ def test_application_unexpected_channel(model):
         units={
             "keystone/0": COUUnit(
                 name="keystone/0",
+                charm="keystone",
                 workload_version="19.0.1",
                 machine=machines["0"],
             )
@@ -186,6 +192,7 @@ def test_application_unknown_source(source_value, model):
         units={
             "keystone/0": COUUnit(
                 name="keystone/0",
+                charm="keystone",
                 workload_version="19.0.1",
                 machine=machines["0"],
             )
@@ -219,6 +226,7 @@ async def test_application_verify_workload_upgrade(model):
         units={
             "keystone/0": COUUnit(
                 name="keystone/0",
+                charm="keystone",
                 workload_version="17.0.1",
                 machine=machines["0"],
             )
@@ -261,6 +269,7 @@ async def test_application_verify_workload_upgrade_fail(model):
         units={
             "keystone/0": COUUnit(
                 name="keystone/0",
+                charm="keystone",
                 workload_version="17.0.1",
                 machine=machines["0"],
             )
@@ -302,6 +311,7 @@ def test_upgrade_plan_ussuri_to_victoria(model):
         units={
             f"keystone/{unit}": COUUnit(
                 name=f"keystone/{unit}",
+                charm="keystone",
                 workload_version="17.0.1",
                 machine=machines["0"],
             )
@@ -392,6 +402,7 @@ def test_upgrade_plan_ussuri_to_victoria_ch_migration(model):
         units={
             f"keystone/{unit}": COUUnit(
                 name=f"keystone/{unit}",
+                charm="keystone",
                 workload_version="17.0.1",
                 machine=machines["0"],
             )
@@ -485,6 +496,7 @@ def test_upgrade_plan_channel_on_next_os_release(model):
         units={
             f"keystone/{unit}": COUUnit(
                 name=f"keystone/{unit}",
+                charm="keystone",
                 workload_version="17.0.1",
                 machine=machines["0"],
             )
@@ -569,6 +581,7 @@ def test_upgrade_plan_origin_already_on_next_openstack_release(model):
         units={
             f"keystone/{unit}": COUUnit(
                 name=f"keystone/{unit}",
+                charm="keystone",
                 workload_version="17.0.1",
                 machine=machines["0"],
             )
@@ -653,6 +666,7 @@ def test_upgrade_plan_application_already_upgraded(model):
         units={
             f"keystone/{unit}": COUUnit(
                 name=f"keystone/{unit}",
+                charm="keystone",
                 workload_version="19.0.1",
                 machine=machines["0"],
             )
@@ -687,6 +701,7 @@ def test_upgrade_plan_application_already_disable_action_managed(model):
         units={
             f"keystone/{unit}": COUUnit(
                 name=f"keystone/{unit}",
+                charm="keystone",
                 workload_version="17.0.1",
                 machine=machines["0"],
             )
@@ -828,7 +843,9 @@ def _generate_nova_compute_app(model):
     channel = "ussuri/stable"
 
     units = {
-        f"nova-compute/{unit_num}": COUUnit(f"nova-compute/{unit_num}", MagicMock(), MagicMock())
+        f"nova-compute/{unit_num}": COUUnit(
+            f"nova-compute/{unit_num}", "nova-compute", MagicMock(), MagicMock()
+        )
         for unit_num in range(3)
     }
     app = NovaCompute(
@@ -882,6 +899,7 @@ def test_nova_compute_upgrade_plan(model):
     units = {
         f"nova-compute/{unit}": COUUnit(
             name=f"nova-compute/{unit}",
+            charm="nova-compute",
             workload_version="21.0.0",
             machine=machines[f"{unit}"],
         )
@@ -935,6 +953,7 @@ def test_nova_compute_upgrade_plan_single_unit(model):
     units = {
         f"nova-compute/{unit}": COUUnit(
             name=f"nova-compute/{unit}",
+            charm="nova-compute",
             workload_version="21.0.0",
             machine=machines[f"{unit}"],
         )
@@ -981,6 +1000,7 @@ def test_cinder_upgrade_plan(model):
     units = {
         f"cinder/{i}": COUUnit(
             name=f"cinder/{i}",
+            charm="cinder",
             workload_version="16.4.2",
             machine=machines[f"{i}"],
         )
@@ -1034,6 +1054,7 @@ def test_cinder_upgrade_plan_single_unit(model):
     units = {
         f"cinder/{i}": COUUnit(
             name=f"cinder/{i}",
+            charm="cinder",
             workload_version="16.4.2",
             machine=machines[f"{i}"],
         )

--- a/tests/unit/apps/test_subordinate.py
+++ b/tests/unit/apps/test_subordinate.py
@@ -20,7 +20,7 @@ import pytest
 from cou.apps.subordinate import SubordinateApplication
 from cou.exceptions import ApplicationError
 from cou.steps import ApplicationUpgradePlan, PreUpgradeStep, UpgradeStep
-from cou.utils.juju_utils import COUMachine, COUUnit
+from cou.utils.juju_utils import COUMachine
 from cou.utils.openstack import OpenStackRelease
 from tests.unit.apps.utils import add_steps
 from tests.unit.utils import assert_steps
@@ -42,13 +42,7 @@ def test_current_os_release(model):
         origin="ch",
         series="focal",
         subordinate_to=["nova-compute"],
-        units={
-            "keystone-ldap/0": COUUnit(
-                name="keystone-ldap/0",
-                workload_version="18.1.0",
-                machine=machines["0"],
-            )
-        },
+        units={},
         workload_version="18.1.0",
     )
 
@@ -119,13 +113,7 @@ def test_channel_valid(model, channel):
         origin="ch",
         series="focal",
         subordinate_to=["nova-compute"],
-        units={
-            "keystone-ldap/0": COUUnit(
-                name="keystone-ldap/0",
-                workload_version="18.1.0",
-                machine=machines["0"],
-            )
-        },
+        units={},
         workload_version="18.1.0",
     )
 
@@ -157,13 +145,7 @@ def test_channel_setter_invalid(model, channel):
             origin="ch",
             series="focal",
             subordinate_to=["nova-compute"],
-            units={
-                "keystone-ldap/0": COUUnit(
-                    name="keystone-ldap/0",
-                    workload_version="18.1.0",
-                    machine=machines["0"],
-                )
-            },
+            units={},
             workload_version="18.1.0",
         )
 

--- a/tests/unit/steps/test_hypervisor.py
+++ b/tests/unit/steps/test_hypervisor.py
@@ -81,7 +81,7 @@ def test_hypervisor_group():
 def test_azs():
     """Test AZs as custom defaultdict object."""
     azs = AZs()
-    test_unit = COUUnit("my-unit", MagicMock(spec_set=COUMachine)(), "")
+    test_unit = COUUnit("my-unit", "my-unit", MagicMock(spec_set=COUMachine)(), "")
 
     # test accessing parts of AZs
     assert azs["my-az"].name == "my-az"
@@ -127,16 +127,16 @@ def test_hypervisor_azs_grouping():
     machines = {f"{i}": COUMachine(f"{i}", (), f"az{i//2}") for i in range(6)}
     units = {
         # app1
-        "app1/0": COUUnit("app1/0", machines["0"], ""),
-        "app1/1": COUUnit("app1/1", machines["1"], ""),
-        "app1/2": COUUnit("app1/2", machines["2"], ""),
-        "app1/3": COUUnit("app1/3", machines["3"], ""),
-        "app1/4": COUUnit("app1/4", machines["4"], ""),
-        "app1/5": COUUnit("app1/5", machines["5"], ""),
+        "app1/0": COUUnit("app1/0", "app1", machines["0"], ""),
+        "app1/1": COUUnit("app1/1", "app1", machines["1"], ""),
+        "app1/2": COUUnit("app1/2", "app1", machines["2"], ""),
+        "app1/3": COUUnit("app1/3", "app1", machines["3"], ""),
+        "app1/4": COUUnit("app1/4", "app1", machines["4"], ""),
+        "app1/5": COUUnit("app1/5", "app1", machines["5"], ""),
         # app2
-        "app2/0": COUUnit("app2/0", machines["0"], ""),
-        "app2/1": COUUnit("app2/1", machines["2"], ""),
-        "app2/2": COUUnit("app2/2", machines["4"], ""),
+        "app2/0": COUUnit("app2/0", "app2", machines["0"], ""),
+        "app2/1": COUUnit("app2/1", "app2", machines["2"], ""),
+        "app2/2": COUUnit("app2/2", "app2", machines["4"], ""),
     }
 
     app1 = MagicMock(spec_set=COUApplication)()
@@ -265,6 +265,7 @@ def test_hypervisor_upgrade_plan(model):
         units={
             "cinder/0": COUUnit(
                 name="cinder/0",
+                charm="cinder",
                 workload_version="16.4.2",
                 machine=machines["0"],
             )
@@ -285,6 +286,7 @@ def test_hypervisor_upgrade_plan(model):
         units={
             f"nova-compute/{unit}": COUUnit(
                 name=f"nova-compute/{unit}",
+                charm="nova-compute",
                 workload_version="21.0.0",
                 machine=machines[f"{unit}"],
             )
@@ -358,6 +360,7 @@ def test_hypervisor_upgrade_plan_single_machine(model):
         units={
             "cinder/0": COUUnit(
                 name="cinder/0",
+                charm="cinder",
                 workload_version="16.4.2",
                 machine=machines["0"],
             )
@@ -378,6 +381,7 @@ def test_hypervisor_upgrade_plan_single_machine(model):
         units={
             f"nova-compute/{unit}": COUUnit(
                 name=f"nova-compute/{unit}",
+                charm="nova-compute",
                 workload_version="21.0.0",
                 machine=machines[f"{unit}"],
             )

--- a/tests/unit/steps/test_steps_analyze.py
+++ b/tests/unit/steps/test_steps_analyze.py
@@ -159,7 +159,10 @@ def test_analysis_dump(model):
         subordinate_to=[],
         units={
             f"keystone/{unit}": COUUnit(
-                name=f"keystone/{unit}", workload_version="17.0.1", machine=machines[f"{unit}"]
+                name=f"keystone/{unit}",
+                charm="keystone",
+                workload_version="17.0.1",
+                machine=machines[f"{unit}"],
             )
             for unit in range(3)
         },
@@ -179,6 +182,7 @@ def test_analysis_dump(model):
         units={
             "rabbitmq-server/0": COUUnit(
                 name="rabbitmq-server/0",
+                charm="rabbitmq-server",
                 workload_version="3.8",
                 machine=machines["0"],
             )
@@ -199,6 +203,7 @@ def test_analysis_dump(model):
         units={
             f"cinder/{unit}": COUUnit(
                 name=f"cinder/{unit}",
+                charm="cinder",
                 workload_version="16.4.2",
                 machine=machines[f"{unit}"],
             )
@@ -266,6 +271,7 @@ async def test_analysis_create(mock_split_apps, mock_populate, model):
         units={
             "keystone/0": COUUnit(
                 name="keystone/0",
+                charm="keystone",
                 workload_version="17.1.0",
                 machine=machines["0"],
             )
@@ -286,6 +292,7 @@ async def test_analysis_create(mock_split_apps, mock_populate, model):
         units={
             "rabbitmq-server/0": COUUnit(
                 name="rabbitmq-server/0",
+                charm="rabbitmq-server",
                 workload_version="3.8",
                 machine=machines["0"],
             )
@@ -306,6 +313,7 @@ async def test_analysis_create(mock_split_apps, mock_populate, model):
         units={
             "cinder/0": COUUnit(
                 name="cinder/0",
+                charm="cinder",
                 workload_version="16.4.2",
                 machine=machines["0"],
             )
@@ -344,6 +352,7 @@ async def test_analysis_detect_current_cloud_os_release_different_releases(model
         units={
             "keystone/0": COUUnit(
                 name="keystone/0",
+                charm="keystone",
                 workload_version="19.1.0",
                 machine=machines["0"],
             )
@@ -364,6 +373,7 @@ async def test_analysis_detect_current_cloud_os_release_different_releases(model
         units={
             "rabbitmq-server/0": COUUnit(
                 name="rabbitmq-server/0",
+                charm="rabbitmq-server",
                 workload_version="3.8",
                 machine=machines["0"],
             )
@@ -384,6 +394,7 @@ async def test_analysis_detect_current_cloud_os_release_different_releases(model
         units={
             "cinder/0": COUUnit(
                 name="cinder/0",
+                charm="cinder",
                 workload_version="16.4.2",
                 machine=machines["0"],
             )
@@ -418,6 +429,7 @@ async def test_analysis_detect_current_cloud_series_different_series(model):
         units={
             "keystone/0": COUUnit(
                 name="keystone/0",
+                charm="keystone",
                 workload_version="17.1.0",
                 machine=machines["0"],
             )
@@ -438,6 +450,7 @@ async def test_analysis_detect_current_cloud_series_different_series(model):
         units={
             "rabbitmq-server/0": COUUnit(
                 name="rabbitmq-server/0",
+                charm="rabbitmq-server",
                 workload_version="3.8",
                 machine=machines["0"],
             )
@@ -458,6 +471,7 @@ async def test_analysis_detect_current_cloud_series_different_series(model):
         units={
             "cinder/0": COUUnit(
                 name="cinder/0",
+                charm="cinder",
                 workload_version="16.4.2",
                 machine=machines["0"],
             )
@@ -543,6 +557,7 @@ async def test_analysis_machines(model):
         units={
             "keystone/0": COUUnit(
                 name="keystone/0",
+                charm="keystone",
                 workload_version="17.1.0",
                 machine=machines["3"],
             )
@@ -563,6 +578,7 @@ async def test_analysis_machines(model):
         units={
             "rabbitmq-server/0": COUUnit(
                 name="rabbitmq-server/0",
+                charm="rabbitmq-server",
                 workload_version="3.8",
                 machine=machines["4"],
             )
@@ -583,6 +599,7 @@ async def test_analysis_machines(model):
         units={
             "cinder/0": COUUnit(
                 name="cinder/0",
+                charm="cinder",
                 workload_version="16.4.2",
                 machine=machines["5"],
             )
@@ -603,6 +620,7 @@ async def test_analysis_machines(model):
         units={
             f"nova-compute/{unit}": COUUnit(
                 name=f"nova-compute/{unit}",
+                charm="nova-compute",
                 workload_version="21.0.0",
                 machine=machines[f"{unit}"],
             )

--- a/tests/unit/steps/test_steps_plan.py
+++ b/tests/unit/steps/test_steps_plan.py
@@ -171,6 +171,7 @@ async def test_generate_plan(mock_generate_data_plane, model, cli_args):
         units={
             "keystone/0": COUUnit(
                 name="keystone/0",
+                charm="keystone",
                 workload_version="17.0.1",
                 machine=machines["0"],
             )
@@ -208,6 +209,7 @@ async def test_generate_plan(mock_generate_data_plane, model, cli_args):
         units={
             "cinder/0": COUUnit(
                 name="cinder/0",
+                charm="cinder",
                 workload_version="16.4.2",
                 machine=machines["0"],
             )
@@ -691,6 +693,7 @@ async def test_get_upgradable_hypervisors_machines(
     nova_compute.units = {
         f"nova-compute/{i}": COUUnit(
             name=f"nova-compute/{i}",
+            charm="nova-compute",
             workload_version="21.0.0",
             machine=machines[f"{i}"],
         )


### PR DESCRIPTION
- move the responsability to evaluate OpenStackRelease from units to the COUUnit instead of the Application
- adapt unit tests