### PR TITLE
Preparation for OS app being frozen

### DIFF
--- a/cou/apps/base.py
+++ b/cou/apps/base.py
@@ -73,15 +73,6 @@ class OpenStackApplication:
     :type model: COUModel
     :param charm: Name of the charm.
     :type charm: str
-    :param charm_origin: Origin of the charm (local, ch, cs and etc.), defaults to ""
-    :type charm_origin: str, defaults to ""
-    :param os_origin: OpenStack origin of the application. E.g: cloud:focal-wallaby, defaults to ""
-    :type os_origin: str, defaults to ""
-    :param origin_setting: "source" or "openstack-origin" of the charm configuration.
-        Return None if not present
-    :type origin_setting: Optional[str], defaults to None
-    :param channel: Channel that the charm tracks. E.g: "ussuri/stable", defaults to ""
-    :type channel: str, defaults to ""
     :param units: Units representation of an application.
     :type units: list[ApplicationUnit]
     :raises ApplicationError: When there are no compatible OpenStack release for the
@@ -100,9 +91,6 @@ class OpenStackApplication:
     config: dict
     model: COUModel
     charm: str
-    charm_origin: str = ""
-    os_origin: str = ""
-    origin_setting: Optional[str] = None
     units: list[ApplicationUnit] = field(default_factory=lambda: [])
     packages_to_hold: Optional[list] = field(default=None, init=False)
     wait_timeout: int = field(default=DEFAULT_WAITING_TIMEOUT, init=False)
@@ -110,10 +98,8 @@ class OpenStackApplication:
 
     def __post_init__(self) -> None:
         """Initialize the Application dataclass."""
-        self.charm_origin = self.status.charm.split(":")[0]
-        self.os_origin = self._get_os_origin()
+        self._verify_channel()
         self._populate_units()
-        self.channel = self.status.charm_channel
 
     def __hash__(self) -> int:
         """Hash magic method for Application.
@@ -160,6 +146,23 @@ class OpenStackApplication:
             yaml.dump(summary, stream)
             return stream.getvalue()
 
+    def _verify_channel(self) -> None:
+        """Verify app channel from current data.
+
+        :raises ApplicationError: Exception raised when channel is not a valid OpenStack channel.
+        """
+        if self.is_from_charm_store or self.is_valid_track(self.status.charm_channel):
+            logger.debug("%s app has proper channel %s", self.name, self.status.charm_channel)
+            return
+
+        raise ApplicationError(
+            f"Channel: {self.status.charm_channel} for charm '{self.charm}' on series "
+            f"'{self.series}' is currently not supported in this tool. Please take a look at the "
+            "documentation: "
+            "https://docs.openstack.org/charm-guide/latest/project/charm-delivery.html to see if "
+            "you are using the right track."
+        )
+
     def _populate_units(self) -> None:
         """Populate application units."""
         if not self.is_subordinate:
@@ -190,32 +193,43 @@ class OpenStackApplication:
         :return: Charm channel. E.g: ussuri/stable
         :rtype: str
         """
-        # NOTE(gabrielcocenza) Some applications current_os_release points
-        # to channel_codename without setting the channel before. In that
-        # case we set the attribute before accessing it.
-        if not hasattr(self, "_channel"):
-            self.channel = self.status.charm_channel
-        return self._channel
+        return self.status.charm_channel
 
-    @channel.setter
-    def channel(self, charm_channel: str) -> None:
-        """Set charm channel of the application.
+    @property
+    def charm_origin(self) -> str:
+        """Get the charm origin of application.
 
-        When application comes from charm store, the channel won't be OpenStack related.
-        :param charm_channel: Charm channel. E.g: ussuri/stable
-        :type charm_channel: str
-        :raises ApplicationError:  Exception raised when channel is not a valid OpenStack
-            channel.
+        :return: Charm origin. E.g: cs or ch
+        :rtype: str
         """
-        if self.is_from_charm_store or self.is_valid_track(charm_channel):
-            self._channel = charm_channel
-            return
-        raise ApplicationError(
-            f"Channel: {charm_channel} for charm '{self.charm}' on series '{self.series}' "
-            "is currently not supported in this tool. Please take a look at the documentation:"
-            "https://docs.openstack.org/charm-guide/latest/project/charm-delivery.html to see "
-            "if you are using the right track."
-        )
+        return self.status.charm.split(":")[0]
+
+    @property
+    def os_origin(self) -> str:
+        """Get application configuration for openstack-origin or source.
+
+        :return: Configuration parameter of the charm to set OpenStack origin.
+            e.g: cloud:focal-wallaby
+        :rtype: str
+        """
+        if origin := self.origin_setting:
+            return self.config[origin].get("value", "")
+
+        logger.warning("Failed to get origin for %s, no origin config found", self.name)
+        return ""
+
+    @property
+    def origin_setting(self) -> Optional[str]:
+        """Get charm origin setting name.
+
+        :return: return name of charm origin setting, e.g. "source", "openstack-origin" or None
+        :rtype: Optional[str]
+        """
+        for origin in ("openstack-origin", "source"):
+            if origin in self.config:
+                return origin
+
+        return None
 
     @property
     def is_from_charm_store(self) -> bool:
@@ -250,15 +264,16 @@ class OpenStackApplication:
         :return: The latest compatible OpenStack release.
         :rtype: OpenStackRelease
         """
-        try:
-            return max(
-                OpenStackCodenameLookup.find_compatible_versions(self.charm, unit.workload_version)
-            )
-        except ValueError as exc:
+        compatible_os_versions = OpenStackCodenameLookup.find_compatible_versions(
+            self.charm, unit.workload_version
+        )
+        if not compatible_os_versions:
             raise ApplicationError(
                 f"'{self.name}' with workload version {unit.workload_version} has no "
                 "compatible OpenStack release."
-            ) from exc
+            )
+
+        return max(compatible_os_versions)
 
     @staticmethod
     def _get_track_from_channel(charm_channel: str) -> str:
@@ -400,21 +415,6 @@ class OpenStackApplication:
         :rtype: str
         """
         return f"cloud:{self.series}-{target.codename}"
-
-    def _get_os_origin(self) -> str:
-        """Get application configuration for openstack-origin or source.
-
-        :return: Configuration parameter of the charm to set OpenStack origin.
-            E.g: cloud:focal-wallaby
-        :rtype: str
-        """
-        for origin in ("openstack-origin", "source"):
-            if self.config.get(origin):
-                self.origin_setting = origin
-                return self.config[origin].get("value", "")
-
-        logger.warning("Failed to get origin for %s, no origin config found", self.name)
-        return ""
 
     async def _check_upgrade(self, target: OpenStackRelease) -> None:
         """Check if an application has upgraded its workload version.

--- a/tests/unit/apps/test_base.py
+++ b/tests/unit/apps/test_base.py
@@ -1,0 +1,43 @@
+#  Copyright 2023 Canonical Limited
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+from unittest.mock import MagicMock, patch
+
+import pytest
+from juju.client._definitions import UnitStatus
+
+from cou.apps.base import OpenStackApplication
+from cou.exceptions import ApplicationError
+
+
+@patch("cou.apps.base.OpenStackApplication._verify_channel", return_value=None)
+@patch("cou.utils.openstack.OpenStackCodenameLookup.find_compatible_versions")
+def test_application_get_latest_os_version_failed(
+    mock_find_compatible_versions, config, status, model
+):
+    charm = "app"
+    app_name = "my_app"
+    unit = MagicMock(spec_set=UnitStatus())
+    unit.workload_version = "15.0.1"
+    exp_error = (
+        f"'{app_name}' with workload version {unit.workload_version} has no compatible OpenStack "
+        "release."
+    )
+    mock_find_compatible_versions.return_value = []
+
+    app = OpenStackApplication(app_name, MagicMock(), MagicMock(), MagicMock(), charm, {})
+
+    with pytest.raises(ApplicationError, match=exp_error):
+        app._get_latest_os_version(unit)
+
+    mock_find_compatible_versions.assert_called_once_with(charm, unit.workload_version)

--- a/tests/unit/apps/test_core.py
+++ b/tests/unit/apps/test_core.py
@@ -246,7 +246,7 @@ def test_application_no_origin_config(status, model):
         model,
         "keystone",
     )
-    assert app._get_os_origin() == ""
+    assert app.os_origin == ""
     assert app.apt_source_codename is None
 
 

--- a/tests/unit/apps/test_subordinate.py
+++ b/tests/unit/apps/test_subordinate.py
@@ -83,13 +83,13 @@ def test_generate_upgrade_plan(status, model):
         "wallaby/edge",
     ],
 )
-def test_channel_setter_valid(status, model, channel):
+def test_channel_valid(status, model, channel):
     app_status = status["keystone-ldap"]
+    app_status.charm_channel = channel
     app = OpenStackSubordinateApplication(
         "my_keystone_ldap", app_status, {}, model, "keystone-ldap"
     )
 
-    app.channel = channel
     assert app.channel == channel
 
 
@@ -120,11 +120,12 @@ def test_channel_setter_invalid(status, model, channel):
 def test_generate_plan_ch_migration(status, model, channel):
     target = OpenStackRelease("wallaby")
     app_status = status["keystone-ldap-cs"]
+    app_status.charm = "cs:amd64/focal/keystone-ldap-437"
+    app_status.charm_channel = f"ussuri/{channel}"
     app = OpenStackSubordinateApplication(
         "my_keystone_ldap", app_status, {}, model, "keystone-ldap"
     )
 
-    app.channel = channel
     upgrade_plan = app.generate_upgrade_plan(target)
 
     expected_plan = ApplicationUpgradePlan(
@@ -158,11 +159,11 @@ def test_generate_plan_ch_migration(status, model, channel):
 )
 def test_generate_plan_from_to(status, model, from_os, to_os):
     app_status = status["keystone-ldap"]
+    app_status.charm_channel = f"{from_os}/stable"
     app = OpenStackSubordinateApplication(
         "my_keystone_ldap", app_status, {}, model, "keystone-ldap"
     )
 
-    app.channel = f"{from_os}/stable"
     upgrade_plan = app.generate_upgrade_plan(OpenStackRelease(to_os))
 
     expected_plan = ApplicationUpgradePlan(description=f"Upgrade plan for '{app.name}' to {to_os}")
@@ -195,11 +196,11 @@ def test_generate_plan_from_to(status, model, from_os, to_os):
 )
 def test_generate_plan_in_same_version(status, model, from_to):
     app_status = status["keystone-ldap"]
+    app_status.charm_channel = f"{from_to}/stable"
     app = OpenStackSubordinateApplication(
         "my_keystone_ldap", app_status, {}, model, "keystone-ldap"
     )
 
-    app.channel = f"{from_to}/stable"
     upgrade_plan = app.generate_upgrade_plan(OpenStackRelease(from_to))
     expected_plan = ApplicationUpgradePlan(
         description=f"Upgrade plan for '{app.name}' to {from_to}"


### PR DESCRIPTION
- remove post channel settings
- drop post init charm_origin settings
- drop os_origin and origin_setting from post_init Configure these two values as properties, instead of getting them in post_init.