### PR TITLE
Add dependent option to BaseStep

### DIFF
--- a/cou/steps/__init__.py
+++ b/cou/steps/__init__.py
@@ -82,7 +82,7 @@ class BaseStep:
         :type parallel: bool
         :param coro: Step coroutine
         :type coro: Optional[coroutine]
-        :param dependent: Whether the step is dependent from other step.
+        :param dependent: Whether the step is dependent on another step.
         :type dependent: bool, defaults to False
         """
         if coro is not None:

--- a/cou/steps/__init__.py
+++ b/cou/steps/__init__.py
@@ -26,6 +26,7 @@ from typing import Any, Coroutine, Iterable, List, Optional
 from cou.exceptions import CanceledStep
 
 logger = logging.getLogger(__name__)
+DEPENDENCY_DESCRIPTION_PREFIX = "├── "
 
 
 def compare_step_coroutines(coro1: Optional[Coroutine], coro2: Optional[Coroutine]) -> bool:
@@ -71,6 +72,7 @@ class BaseStep:
         description: str = "",
         parallel: bool = False,
         coro: Optional[Coroutine] = None,
+        dependent: bool = False,
     ):
         """Initialize BaseStep.
 
@@ -80,6 +82,8 @@ class BaseStep:
         :type parallel: bool
         :param coro: Step coroutine
         :type coro: Optional[coroutine]
+        :param dependent: Whether the step is dependent from other step.
+        :type dependent: bool, defaults to False
         """
         if coro is not None:
             # NOTE(rgildein): We need to ignore coroutine not to be awaited if step is not run
@@ -89,7 +93,10 @@ class BaseStep:
 
         self._coro: Optional[Coroutine] = coro
         self.parallel = parallel
-        self.description = description
+        self.dependent = dependent
+        self.description = (
+            DEPENDENCY_DESCRIPTION_PREFIX + description if dependent else description
+        )
         self._sub_steps: List[BaseStep] = []
         self._canceled: bool = False
         self._task: Optional[asyncio.Task] = None

--- a/tests/unit/steps/test_steps.py
+++ b/tests/unit/steps/test_steps.py
@@ -21,6 +21,7 @@ import pytest
 
 from cou.exceptions import CanceledStep
 from cou.steps import (
+    DEPENDENCY_DESCRIPTION_PREFIX,
     BaseStep,
     PostUpgradeStep,
     PreUpgradeStep,
@@ -130,6 +131,23 @@ def test_step_str():
     sub_step.sub_steps = [
         BaseStep(description="a.a.a", coro=mock_coro("a.a.a")),
         BaseStep(description="a.a.b", coro=mock_coro("a.a.b")),
+    ]
+    plan.sub_steps = [sub_step, BaseStep(description="a.b", coro=mock_coro("a.b"))]
+
+    assert str(plan) == expected
+
+
+def test_step_str_dependent():
+    """Test BaseStep string representation."""
+    expected = (
+        f"a\n\ta.a\n\t\t{DEPENDENCY_DESCRIPTION_PREFIX}a.a.a\n"
+        f"\t\t{DEPENDENCY_DESCRIPTION_PREFIX}a.a.b\n\ta.b\n"
+    )
+    plan = BaseStep(description="a")
+    sub_step = BaseStep(description="a.a")
+    sub_step.sub_steps = [
+        BaseStep(description="a.a.a", coro=mock_coro("a.a.a"), dependent=True),
+        BaseStep(description="a.a.b", coro=mock_coro("a.a.b"), dependent=True),
     ]
     plan.sub_steps = [sub_step, BaseStep(description="a.b", coro=mock_coro("a.b"))]
 


### PR DESCRIPTION
This option will be used later for data-plane upgrade, where we do unit by unit.