### PR TITLE
Enhance clarity and consistency of step descriptions

### DIFF
--- a/cou/apps/auxiliary.py
+++ b/cou/apps/auxiliary.py
@@ -252,7 +252,7 @@ class CephOsd(AuxiliaryApplication):
         """
         steps = [
             PreUpgradeStep(
-                description="Verify that all nova-compute units had been upgraded",
+                description="Verify that all 'nova-compute' units had been upgraded",
                 coro=self._verify_nova_compute(target),
             )
         ]

--- a/cou/apps/auxiliary.py
+++ b/cou/apps/auxiliary.py
@@ -196,7 +196,9 @@ class CephMon(AuxiliaryApplication):
         """
         ceph_mon_unit, *_ = self.units.values()
         return PreUpgradeStep(
-            description="Ensure the 'require-osd-release' option matches the 'ceph-osd' version",
+            description=(
+                "Ensure that the 'require-osd-release' option matches the 'ceph-osd' version"
+            ),
             coro=set_require_osd_release_option(ceph_mon_unit.name, self.model),
         )
 
@@ -250,7 +252,7 @@ class CephOsd(AuxiliaryApplication):
         """
         steps = [
             PreUpgradeStep(
-                description="Check if all nova-compute units had been upgraded",
+                description="Verify that all nova-compute units had been upgraded",
                 coro=self._verify_nova_compute(target),
             )
         ]

--- a/cou/apps/base.py
+++ b/cou/apps/base.py
@@ -432,7 +432,7 @@ class OpenStackApplication(COUApplication):
         self.upgrade_plan_sanity_checks(target, units)
 
         upgrade_plan = ApplicationUpgradePlan(
-            description=f"Upgrade plan for '{self.name}' to {target}",
+            description=f"Upgrade plan for '{self.name}' to '{target}'",
         )
 
         upgrade_plan.sub_steps = [
@@ -454,7 +454,7 @@ class OpenStackApplication(COUApplication):
         :rtype: UnitUpgradeStep
         """
         # pylint: disable=unused-argument
-        unit_plan = UnitUpgradeStep(description=f"Upgrade plan for unit: {unit.name}")
+        unit_plan = UnitUpgradeStep(description=f"Upgrade plan for unit '{unit.name}'")
         unit_plan.add_step(self._get_pause_unit_step(unit))
         unit_plan.add_step(self._get_openstack_upgrade_step(unit))
         unit_plan.add_step(self._get_resume_unit_step(unit))
@@ -500,7 +500,7 @@ class OpenStackApplication(COUApplication):
         )
         step.sub_steps = [
             UnitUpgradeStep(
-                description=f"Upgrade software packages on unit {unit.name}",
+                description=f"Upgrade software packages on unit '{unit.name}'",
                 coro=upgrade_packages(unit.name, self.model, self.packages_to_hold),
             )
             for unit in units
@@ -739,13 +739,13 @@ class OpenStackApplication(COUApplication):
         """
         if self.wait_for_model:
             description = (
-                f"Wait for up to {self.wait_timeout}s for model {self.model.name} "
+                f"Wait for up to {self.wait_timeout}s for model '{self.model.name}' "
                 "to reach the idle state"
             )
             apps = None
         else:
             description = (
-                f"Wait for up to {self.wait_timeout}s for app {self.name} "
+                f"Wait for up to {self.wait_timeout}s for app '{self.name}' "
                 "to reach the idle state"
             )
             apps = [self.name]

--- a/cou/apps/base.py
+++ b/cou/apps/base.py
@@ -536,7 +536,7 @@ class OpenStackApplication(COUApplication):
             )
 
         if self.origin == "cs":
-            description = f"Migration of '{self.name}' from charmstore to charmhub"
+            description = f"Migrate '{self.name}' from charmstore to charmhub"
             switch = f"ch:{self.charm}"
         elif self.channel in self.possible_current_channels:
             channel = self.channel
@@ -611,7 +611,7 @@ class OpenStackApplication(COUApplication):
         :rtype: UnitUpgradeStep
         """
         return UnitUpgradeStep(
-            description=f"Pause the unit: '{unit.name}'.",
+            description=f"Pause the unit: '{unit.name}'",
             coro=self.model.run_action(
                 unit_name=unit.name, action_name="pause", raise_on_failure=True
             ),
@@ -629,7 +629,7 @@ class OpenStackApplication(COUApplication):
         :rtype: UnitUpgradeStep
         """
         return UnitUpgradeStep(
-            description=f"Resume the unit: '{unit.name}'.",
+            description=f"Resume the unit: '{unit.name}'",
             coro=self.model.run_action(
                 unit_name=unit.name, action_name="resume", raise_on_failure=True
             ),
@@ -649,7 +649,7 @@ class OpenStackApplication(COUApplication):
         :rtype: UnitUpgradeStep
         """
         return UnitUpgradeStep(
-            description=f"Upgrade the unit: '{unit.name}'.",
+            description=f"Upgrade the unit: '{unit.name}'",
             coro=self.model.run_action(
                 unit_name=unit.name, action_name="openstack-upgrade", raise_on_failure=True
             ),
@@ -698,7 +698,7 @@ class OpenStackApplication(COUApplication):
             units = list(self.units.values())
         return PostUpgradeStep(
             description=(
-                f"Check if the workload of '{self.name}' has been upgraded on units: "
+                f"Verify that the workload of '{self.name}' has been upgraded on units: "
                 f"{', '.join([unit.name for unit in units])}"
             ),
             coro=self._verify_workload_upgrade(target, units),
@@ -739,11 +739,15 @@ class OpenStackApplication(COUApplication):
         """
         if self.wait_for_model:
             description = (
-                f"Wait {self.wait_timeout}s for model {self.model.name} to reach the idle state."
+                f"Wait for up to {self.wait_timeout}s for model {self.model.name} "
+                "to reach the idle state"
             )
             apps = None
         else:
-            description = f"Wait {self.wait_timeout}s for app {self.name} to reach the idle state."
+            description = (
+                f"Wait for up to {self.wait_timeout}s for app {self.name} "
+                "to reach the idle state"
+            )
             apps = [self.name]
 
         return PostUpgradeStep(

--- a/cou/apps/core.py
+++ b/cou/apps/core.py
@@ -88,7 +88,7 @@ class NovaCompute(OpenStackApplication):
         :return: Unit upgrade step
         :rtype: UnitUpgradeStep
         """
-        unit_plan = UnitUpgradeStep(description=f"Upgrade plan for unit: {unit.name}")
+        unit_plan = UnitUpgradeStep(description=f"Upgrade plan for unit '{unit.name}'")
         unit_plan.add_step(self._get_disable_scheduler_step(unit))
 
         if not force:
@@ -113,7 +113,7 @@ class NovaCompute(OpenStackApplication):
         :rtype: UnitUpgradeStep
         """
         return UnitUpgradeStep(
-            description=f"Verify that unit {unit.name} has no VMs running",
+            description=f"Verify that unit '{unit.name}' has no VMs running",
             coro=verify_empty_hypervisor_before_upgrade(unit, self.model),
         )
 

--- a/cou/apps/core.py
+++ b/cou/apps/core.py
@@ -113,7 +113,7 @@ class NovaCompute(OpenStackApplication):
         :rtype: UnitUpgradeStep
         """
         return UnitUpgradeStep(
-            description=f"Check if unit {unit.name} has no VMs running before upgrading.",
+            description=f"Verify that unit {unit.name} has no VMs running",
             coro=verify_empty_hypervisor_before_upgrade(unit, self.model),
         )
 
@@ -126,7 +126,7 @@ class NovaCompute(OpenStackApplication):
         :rtype: UnitUpgradeStep
         """
         return UnitUpgradeStep(
-            description=f"Enable nova-compute scheduler from unit: '{unit.name}'.",
+            description=f"Enable nova-compute scheduler from unit: '{unit.name}'",
             coro=self.model.run_action(
                 unit_name=unit.name, action_name="enable", raise_on_failure=True
             ),
@@ -141,7 +141,7 @@ class NovaCompute(OpenStackApplication):
         :rtype: UnitUpgradeStep
         """
         return UnitUpgradeStep(
-            description=f"Disable nova-compute scheduler from unit: '{unit.name}'.",
+            description=f"Disable nova-compute scheduler from unit: '{unit.name}'",
             coro=self.model.run_action(
                 unit_name=unit.name, action_name="disable", raise_on_failure=True
             ),

--- a/cou/steps/hypervisor.py
+++ b/cou/steps/hypervisor.py
@@ -273,7 +273,9 @@ class HypervisorUpgradePlanner:
         """
         plan = UpgradePlan("Upgrading all applications deployed on machines with hypervisor.")
         for az, group in self.azs.items():
-            hypervisor_plan = HypervisorUpgradePlan(f"Upgrade plan for '{group.name}' to {target}")
+            hypervisor_plan = HypervisorUpgradePlan(
+                f"Upgrade plan for '{group.name}' to '{target}'"
+            )
 
             # pre upgrade steps
             logger.debug("generating pre-upgrade steps for %s AZ", az)

--- a/cou/steps/plan.py
+++ b/cou/steps/plan.py
@@ -352,7 +352,7 @@ def _get_pre_upgrade_steps(analysis_result: Analysis, args: CLIargs) -> list[Pre
     if args.backup:
         steps.append(
             PreUpgradeStep(
-                description="Backup mysql databases",
+                description="Back up MySQL databases",
                 coro=backup(analysis_result.model),
             )
         )
@@ -392,8 +392,8 @@ def _get_ceph_mon_post_upgrade_steps(apps: list[OpenStackApplication]) -> list[P
         unit = list(app.units.values())[0]  # getting the first unit, since we don't care which one
         steps.append(
             PostUpgradeStep(
-                f"Ensure the 'require-osd-release' option in '{app.name}' matches the 'ceph-osd' "
-                "version",
+                f"Ensure that the 'require-osd-release' option in '{app.name}' matches the "
+                "'ceph-osd' version",
                 coro=set_require_osd_release_option(unit.name, app.model),
             )
         )
@@ -531,7 +531,7 @@ def create_upgrade_group(
     :type apps: list[OpenStackApplication]
     :param target: Target OpenStack release.
     :type target: OpenStackRelease
-    :param description: Description of the upgrade step.
+    :param description: Description of the upgrade plan.
     :type description: str
     :param force: Whether the plan generation should be forced
     :type force: bool

--- a/docs/how-to/interruption.rst
+++ b/docs/how-to/interruption.rst
@@ -26,14 +26,14 @@ Usage example:
     Running cloud upgrade...
     Verify that all OpenStack applications are in idle state ✔
     Back up MySQL databases ✔
-    Upgrade plan for 'keystone' to victoria
+    Upgrade plan for 'keystone' to 'victoria'
         Upgrade software packages of 'keystone' from the current APT repositories
-            Upgrade software packages on unit keystone/0
-            Upgrade software packages on unit keystone/1
-            Upgrade software packages on unit keystone/2
+            Upgrade software packages on unit 'keystone/0'
+            Upgrade software packages on unit 'keystone/1'
+            Upgrade software packages on unit 'keystone/2'
         Upgrade 'keystone' to the new channel: 'victoria/stable'
         Change charm config of 'keystone' 'openstack-origin' to 'cloud:focal-victoria'
-        Wait for up to 1800s for model test-model to reach the idle state
+        Wait for up to 1800s for model 'test-model' to reach the idle state
         Verify that the workload of 'keystone' has been upgraded
 
     Would you like to start the upgrade? Continue (y/N): n

--- a/docs/how-to/interruption.rst
+++ b/docs/how-to/interruption.rst
@@ -25,7 +25,7 @@ Usage example:
     ...
     Running cloud upgrade...
     Verify that all OpenStack applications are in idle state ✔
-    Backup mysql databases ✔
+    Back up MySQL databases ✔
     Upgrade plan for 'keystone' to victoria
         Upgrade software packages of 'keystone' from the current APT repositories
             Upgrade software packages on unit keystone/0
@@ -33,8 +33,8 @@ Usage example:
             Upgrade software packages on unit keystone/2
         Upgrade 'keystone' to the new channel: 'victoria/stable'
         Change charm config of 'keystone' 'openstack-origin' to 'cloud:focal-victoria'
-        Wait 1800s for model test-model to reach the idle state.
-        Check if the workload of 'keystone' has been upgraded
+        Wait for up to 1800s for model test-model to reach the idle state
+        Verify that the workload of 'keystone' has been upgraded
 
     Would you like to start the upgrade? Continue (y/N): n
 

--- a/docs/how-to/no-backup.rst
+++ b/docs/how-to/no-backup.rst
@@ -21,11 +21,11 @@ Plan:
         Verify that all OpenStack applications are in idle state
         # note that there's no backup step planned
         Control Plane principal(s) upgrade plan
-        Upgrade plan for 'rabbitmq-server' to victoria
+        Upgrade plan for 'rabbitmq-server' to 'victoria'
             Upgrade software packages of 'rabbitmq-server' from the current APT repositories
-                Upgrade software packages on unit rabbitmq-server/0
-                Upgrade software packages on unit rabbitmq-server/1
-                Upgrade software packages on unit rabbitmq-server/2
+                Upgrade software packages on unit 'rabbitmq-server/0'
+                Upgrade software packages on unit 'rabbitmq-server/1'
+                Upgrade software packages on unit 'rabbitmq-server/2'
         ...
 
 Upgrade:
@@ -42,18 +42,18 @@ Upgrade:
     Verify that all OpenStack applications are in idle state ✔
     # note that there's no backup step being executed
 
-    Upgrade plan for 'rabbitmq-server' to victoria
+    Upgrade plan for 'rabbitmq-server' to 'victoria'
         Upgrade software packages of 'rabbitmq-server' from the current APT repositories
-            Upgrade software packages on unit rabbitmq-server/0
-            Upgrade software packages on unit rabbitmq-server/1
-            Upgrade software packages on unit rabbitmq-server/2
+            Upgrade software packages on unit 'rabbitmq-server/0'
+            Upgrade software packages on unit 'rabbitmq-server/1'
+            Upgrade software packages on unit 'rabbitmq-server/2'
         Upgrade 'rabbitmq-server' to the new channel: '3.9/stable'
         Change charm config of 'rabbitmq-server' 'source' to 'cloud:focal-victoria'
-        Wait for up to 1800s for model test-model to reach the idle state
+        Wait for up to 1800s for model 'test-model' to reach the idle state
         Verify that the workload of 'rabbitmq-server' has been upgraded
 
     Continue (y/n): y
-    Upgrade plan for 'rabbitmq-server' to victoria ✔
+    Upgrade plan for 'rabbitmq-server' to 'victoria' ✔
 
     ... # apply steps
     Upgrade completed.

--- a/docs/how-to/no-backup.rst
+++ b/docs/how-to/no-backup.rst
@@ -49,8 +49,8 @@ Upgrade:
             Upgrade software packages on unit rabbitmq-server/2
         Upgrade 'rabbitmq-server' to the new channel: '3.9/stable'
         Change charm config of 'rabbitmq-server' 'source' to 'cloud:focal-victoria'
-        Wait 1800s for model test-model to reach the idle state.
-        Check if the workload of 'rabbitmq-server' has been upgraded
+        Wait for up to 1800s for model test-model to reach the idle state
+        Verify that the workload of 'rabbitmq-server' has been upgraded
 
     Continue (y/n): y
     Upgrade plan for 'rabbitmq-server' to victoria ✔

--- a/docs/how-to/plan-upgrade.rst
+++ b/docs/how-to/plan-upgrade.rst
@@ -23,72 +23,72 @@ Usage example
         Verify that all OpenStack applications are in idle state
         Back up MySQL databases
         Control Plane principal(s) upgrade plan
-        Upgrade plan for 'rabbitmq-server' to victoria
+        Upgrade plan for 'rabbitmq-server' to 'victoria'
             Upgrade software packages of 'rabbitmq-server' from the current APT repositories
-                Upgrade software packages on unit rabbitmq-server/0
-                Upgrade software packages on unit rabbitmq-server/1
-                Upgrade software packages on unit rabbitmq-server/2
+                Upgrade software packages on unit 'rabbitmq-server/0'
+                Upgrade software packages on unit 'rabbitmq-server/1'
+                Upgrade software packages on unit 'rabbitmq-server/2'
             Upgrade 'rabbitmq-server' to the new channel: '3.9/stable'
             Change charm config of 'rabbitmq-server' 'source' to 'cloud:focal-victoria'
-            Wait for up to 1800s for model test-model to reach the idle state
+            Wait for up to 1800s for model 'test-model' to reach the idle state
             Verify that the workload of 'rabbitmq-server' has been upgraded
-        Upgrade plan for 'keystone' to victoria
+        Upgrade plan for 'keystone' to 'victoria'
             Upgrade software packages of 'keystone' from the current APT repositories
-                Upgrade software packages on unit keystone/0
-                Upgrade software packages on unit keystone/1
-                Upgrade software packages on unit keystone/2
+                Upgrade software packages on unit 'keystone/0'
+                Upgrade software packages on unit 'keystone/1'
+                Upgrade software packages on unit 'keystone/2'
             Upgrade 'keystone' to the new channel: 'victoria/stable'
             Change charm config of 'keystone' 'openstack-origin' to 'cloud:focal-victoria'
-            Wait for up to 1800s for model test-model to reach the idle state
+            Wait for up to 1800s for model 'test-model' to reach the idle state
             Verify that the workload of 'keystone' has been upgraded
-        Upgrade plan for 'cinder' to victoria
+        Upgrade plan for 'cinder' to 'victoria'
             Upgrade software packages of 'cinder' from the current APT repositories
-                Upgrade software packages on unit cinder/0
+                Upgrade software packages on unit 'cinder/0'
             Upgrade 'cinder' to the new channel: 'victoria/stable'
             Change charm config of 'cinder' 'openstack-origin' to 'cloud:focal-victoria'
-            Wait for up to 300s for app cinder to reach the idle state
+            Wait for up to 300s for app 'cinder' to reach the idle state
             Verify that the workload of 'cinder' has been upgraded
-        Upgrade plan for 'glance' to victoria
+        Upgrade plan for 'glance' to 'victoria'
             Upgrade software packages of 'glance' from the current APT repositories
-                Upgrade software packages on unit glance/0
+                Upgrade software packages on unit 'glance/0'
             Upgrade 'glance' to the new channel: 'victoria/stable'
             Change charm config of 'glance' 'openstack-origin' to 'cloud:focal-victoria'
-            Wait for up to 300s for app glance to reach the idle state
+            Wait for up to 300s for app 'glance' to reach the idle state
             Verify that the workload of 'glance' has been upgraded
-        Upgrade plan for 'neutron-api' to victoria
+        Upgrade plan for 'neutron-api' to 'victoria'
             Upgrade software packages of 'neutron-api' from the current APT repositories
-                Upgrade software packages on unit neutron-api/0
+                Upgrade software packages on unit 'neutron-api/0'
             Upgrade 'neutron-api' to the new channel: 'victoria/stable'
             Change charm config of 'neutron-api' 'openstack-origin' to 'cloud:focal-victoria'
-            Wait for up to 300s for app neutron-api to reach the idle state
+            Wait for up to 300s for app 'neutron-api' to reach the idle state
             Verify that the workload of 'neutron-api' has been upgraded
-        Upgrade plan for 'neutron-gateway' to victoria
+        Upgrade plan for 'neutron-gateway' to 'victoria'
             Upgrade software packages of 'neutron-gateway' from the current APT repositories
-                Upgrade software packages on unit neutron-gateway/0
+                Upgrade software packages on unit 'neutron-gateway/0'
             Upgrade 'neutron-gateway' to the new channel: 'victoria/stable'
             Change charm config of 'neutron-gateway' 'openstack-origin' to 'cloud:focal-victoria'
-            Wait for up to 300s for app neutron-gateway to reach the idle state
+            Wait for up to 300s for app 'neutron-gateway' to reach the idle state
             Verify that the workload of 'neutron-gateway' has been upgraded
-        Upgrade plan for 'placement' to victoria
+        Upgrade plan for 'placement' to 'victoria'
             Upgrade software packages of 'placement' from the current APT repositories
-                Upgrade software packages on unit placement/0
+                Upgrade software packages on unit 'placement/0'
             Upgrade 'placement' to the new channel: 'victoria/stable'
             Change charm config of 'placement' 'openstack-origin' to 'cloud:focal-victoria'
-            Wait for up to 300s for app placement to reach the idle state
+            Wait for up to 300s for app 'placement' to reach the idle state
             Verify that the workload of 'placement' has been upgraded
-        Upgrade plan for 'nova-cloud-controller' to victoria
+        Upgrade plan for 'nova-cloud-controller' to 'victoria'
             Upgrade software packages of 'nova-cloud-controller' from the current APT repositories
-                Upgrade software packages on unit nova-cloud-controller/0
+                Upgrade software packages on unit 'nova-cloud-controller/0'
             Upgrade 'nova-cloud-controller' to the new channel: 'victoria/stable'
             Change charm config of 'nova-cloud-controller' 'openstack-origin' to 'cloud:focal-victoria'
-            Wait for up to 300s for app nova-cloud-controller to reach the idle state
+            Wait for up to 300s for app 'nova-cloud-controller' to reach the idle state
             Verify that the workload of 'nova-cloud-controller' has been upgraded
-        Upgrade plan for 'mysql' to victoria
+        Upgrade plan for 'mysql' to 'victoria'
             Upgrade software packages of 'mysql' from the current APT repositories
-                Upgrade software packages on unit mysql/0
+                Upgrade software packages on unit 'mysql/0'
             Change charm config of 'mysql' 'source' to 'cloud:focal-victoria'
-            Wait for up to 1800s for app mysql to reach the idle state
+            Wait for up to 1800s for app 'mysql' to reach the idle state
             Verify that the workload of 'mysql' has been upgraded
         Control Plane subordinate(s) upgrade plan
-        Upgrade plan for 'neutron-openvswitch' to victoria
+        Upgrade plan for 'neutron-openvswitch' to 'victoria'
             Upgrade 'neutron-openvswitch' to the new channel: 'victoria/stable'

--- a/docs/how-to/plan-upgrade.rst
+++ b/docs/how-to/plan-upgrade.rst
@@ -21,7 +21,7 @@ Usage example
     Generating upgrade plan... ✔
     Upgrade cloud from 'ussuri' to 'victoria'
         Verify that all OpenStack applications are in idle state
-        Backup mysql databases
+        Back up MySQL databases
         Control Plane principal(s) upgrade plan
         Upgrade plan for 'rabbitmq-server' to victoria
             Upgrade software packages of 'rabbitmq-server' from the current APT repositories
@@ -30,8 +30,8 @@ Usage example
                 Upgrade software packages on unit rabbitmq-server/2
             Upgrade 'rabbitmq-server' to the new channel: '3.9/stable'
             Change charm config of 'rabbitmq-server' 'source' to 'cloud:focal-victoria'
-            Wait 1800s for model test-model to reach the idle state.
-            Check if the workload of 'rabbitmq-server' has been upgraded
+            Wait for up to 1800s for model test-model to reach the idle state
+            Verify that the workload of 'rabbitmq-server' has been upgraded
         Upgrade plan for 'keystone' to victoria
             Upgrade software packages of 'keystone' from the current APT repositories
                 Upgrade software packages on unit keystone/0
@@ -39,56 +39,56 @@ Usage example
                 Upgrade software packages on unit keystone/2
             Upgrade 'keystone' to the new channel: 'victoria/stable'
             Change charm config of 'keystone' 'openstack-origin' to 'cloud:focal-victoria'
-            Wait 1800s for model test-model to reach the idle state.
-            Check if the workload of 'keystone' has been upgraded
+            Wait for up to 1800s for model test-model to reach the idle state
+            Verify that the workload of 'keystone' has been upgraded
         Upgrade plan for 'cinder' to victoria
             Upgrade software packages of 'cinder' from the current APT repositories
                 Upgrade software packages on unit cinder/0
             Upgrade 'cinder' to the new channel: 'victoria/stable'
             Change charm config of 'cinder' 'openstack-origin' to 'cloud:focal-victoria'
-            Wait 300s for app cinder to reach the idle state.
-            Check if the workload of 'cinder' has been upgraded
+            Wait for up to 300s for app cinder to reach the idle state
+            Verify that the workload of 'cinder' has been upgraded
         Upgrade plan for 'glance' to victoria
             Upgrade software packages of 'glance' from the current APT repositories
                 Upgrade software packages on unit glance/0
             Upgrade 'glance' to the new channel: 'victoria/stable'
             Change charm config of 'glance' 'openstack-origin' to 'cloud:focal-victoria'
-            Wait 300s for app glance to reach the idle state.
-            Check if the workload of 'glance' has been upgraded
+            Wait for up to 300s for app glance to reach the idle state
+            Verify that the workload of 'glance' has been upgraded
         Upgrade plan for 'neutron-api' to victoria
             Upgrade software packages of 'neutron-api' from the current APT repositories
                 Upgrade software packages on unit neutron-api/0
             Upgrade 'neutron-api' to the new channel: 'victoria/stable'
             Change charm config of 'neutron-api' 'openstack-origin' to 'cloud:focal-victoria'
-            Wait 300s for app neutron-api to reach the idle state.
-            Check if the workload of 'neutron-api' has been upgraded
+            Wait for up to 300s for app neutron-api to reach the idle state
+            Verify that the workload of 'neutron-api' has been upgraded
         Upgrade plan for 'neutron-gateway' to victoria
             Upgrade software packages of 'neutron-gateway' from the current APT repositories
                 Upgrade software packages on unit neutron-gateway/0
             Upgrade 'neutron-gateway' to the new channel: 'victoria/stable'
             Change charm config of 'neutron-gateway' 'openstack-origin' to 'cloud:focal-victoria'
-            Wait 300s for app neutron-gateway to reach the idle state.
-            Check if the workload of 'neutron-gateway' has been upgraded
+            Wait for up to 300s for app neutron-gateway to reach the idle state
+            Verify that the workload of 'neutron-gateway' has been upgraded
         Upgrade plan for 'placement' to victoria
             Upgrade software packages of 'placement' from the current APT repositories
                 Upgrade software packages on unit placement/0
             Upgrade 'placement' to the new channel: 'victoria/stable'
             Change charm config of 'placement' 'openstack-origin' to 'cloud:focal-victoria'
-            Wait 300s for app placement to reach the idle state.
-            Check if the workload of 'placement' has been upgraded
+            Wait for up to 300s for app placement to reach the idle state
+            Verify that the workload of 'placement' has been upgraded
         Upgrade plan for 'nova-cloud-controller' to victoria
             Upgrade software packages of 'nova-cloud-controller' from the current APT repositories
                 Upgrade software packages on unit nova-cloud-controller/0
             Upgrade 'nova-cloud-controller' to the new channel: 'victoria/stable'
             Change charm config of 'nova-cloud-controller' 'openstack-origin' to 'cloud:focal-victoria'
-            Wait 300s for app nova-cloud-controller to reach the idle state.
-            Check if the workload of 'nova-cloud-controller' has been upgraded
+            Wait for up to 300s for app nova-cloud-controller to reach the idle state
+            Verify that the workload of 'nova-cloud-controller' has been upgraded
         Upgrade plan for 'mysql' to victoria
             Upgrade software packages of 'mysql' from the current APT repositories
                 Upgrade software packages on unit mysql/0
             Change charm config of 'mysql' 'source' to 'cloud:focal-victoria'
-            Wait 1800s for app mysql to reach the idle state.
-            Check if the workload of 'mysql' has been upgraded
+            Wait for up to 1800s for app mysql to reach the idle state
+            Verify that the workload of 'mysql' has been upgraded
         Control Plane subordinate(s) upgrade plan
         Upgrade plan for 'neutron-openvswitch' to victoria
             Upgrade 'neutron-openvswitch' to the new channel: 'victoria/stable'

--- a/docs/how-to/upgrade-cloud.rst
+++ b/docs/how-to/upgrade-cloud.rst
@@ -25,7 +25,7 @@ Usage example
     Generating upgrade plan... ✔
     Upgrade cloud from 'ussuri' to 'victoria'
         Verify that all OpenStack applications are in idle state
-        Backup mysql databases
+        Back up MySQL databases
         Control Plane principal(s) upgrade plan
         Upgrade plan for 'rabbitmq-server' to victoria
             Upgrade software packages of 'rabbitmq-server' from the current APT repositories
@@ -34,8 +34,8 @@ Usage example
                 Upgrade software packages on unit rabbitmq-server/2
             Upgrade 'rabbitmq-server' to the new channel: '3.9/stable'
             Change charm config of 'rabbitmq-server' 'source' to 'cloud:focal-victoria'
-            Wait 1800s for model test-model to reach the idle state.
-            Check if the workload of 'rabbitmq-server' has been upgraded
+            Wait for up to 1800s for model test-model to reach the idle state
+            Verify that the workload of 'rabbitmq-server' has been upgraded
         Upgrade plan for 'keystone' to victoria
             Upgrade software packages of 'keystone' from the current APT repositories
                 Upgrade software packages on unit keystone/0
@@ -43,65 +43,65 @@ Usage example
                 Upgrade software packages on unit keystone/2
             Upgrade 'keystone' to the new channel: 'victoria/stable'
             Change charm config of 'keystone' 'openstack-origin' to 'cloud:focal-victoria'
-            Wait 1800s for model test-model to reach the idle state.
-            Check if the workload of 'keystone' has been upgraded
+            Wait for up to 1800s for model test-model to reach the idle state
+            Verify that the workload of 'keystone' has been upgraded
         Upgrade plan for 'cinder' to victoria
             Upgrade software packages of 'cinder' from the current APT repositories
                 Upgrade software packages on unit cinder/0
             Refresh 'cinder' to the latest revision of 'ussuri/stable'
             Upgrade 'cinder' to the new channel: 'victoria/stable'
             Change charm config of 'cinder' 'openstack-origin' to 'cloud:focal-victoria'
-            Wait 300s for app cinder to reach the idle state.
-            Check if the workload of 'cinder' has been upgraded
+            Wait for up to 300s for app cinder to reach the idle state
+            Verify that the workload of 'cinder' has been upgraded
         Upgrade plan for 'glance' to victoria
             Upgrade software packages of 'glance' from the current APT repositories
                 Upgrade software packages on unit glance/0
             Upgrade 'glance' to the new channel: 'victoria/stable'
             Change charm config of 'glance' 'openstack-origin' to 'cloud:focal-victoria'
-            Wait 300s for app glance to reach the idle state.
-            Check if the workload of 'glance' has been upgraded
+            Wait for up to 300s for app glance to reach the idle state
+            Verify that the workload of 'glance' has been upgraded
         Upgrade plan for 'neutron-api' to victoria
             Upgrade software packages of 'neutron-api' from the current APT repositories
                 Upgrade software packages on unit neutron-api/0
             Upgrade 'neutron-api' to the new channel: 'victoria/stable'
             Change charm config of 'neutron-api' 'openstack-origin' to 'cloud:focal-victoria'
-            Wait 300s for app neutron-api to reach the idle state.
-            Check if the workload of 'neutron-api' has been upgraded
+            Wait for up to 300s for app neutron-api to reach the idle state
+            Verify that the workload of 'neutron-api' has been upgraded
         Upgrade plan for 'neutron-gateway' to victoria
             Upgrade software packages of 'neutron-gateway' from the current APT repositories
                 Upgrade software packages on unit neutron-gateway/0
             Upgrade 'neutron-gateway' to the new channel: 'victoria/stable'
             Change charm config of 'neutron-gateway' 'openstack-origin' to 'cloud:focal-victoria'
-            Wait 300s for app neutron-gateway to reach the idle state.
-            Check if the workload of 'neutron-gateway' has been upgraded
+            Wait for up to 300s for app neutron-gateway to reach the idle state
+            Verify that the workload of 'neutron-gateway' has been upgraded
         Upgrade plan for 'placement' to victoria
             Upgrade software packages of 'placement' from the current APT repositories
                 Upgrade software packages on unit placement/0
             Upgrade 'placement' to the new channel: 'victoria/stable'
             Change charm config of 'placement' 'openstack-origin' to 'cloud:focal-victoria'
-            Wait 300s for app placement to reach the idle state.
-            Check if the workload of 'placement' has been upgraded
+            Wait for up to 300s for app placement to reach the idle state
+            Verify that the workload of 'placement' has been upgraded
         Upgrade plan for 'nova-cloud-controller' to victoria
             Upgrade software packages of 'nova-cloud-controller' from the current APT repositories
                 Upgrade software packages on unit nova-cloud-controller/0
             Refresh 'nova-cloud-controller' to the latest revision of 'ussuri/stable'
             Upgrade 'nova-cloud-controller' to the new channel: 'victoria/stable'
             Change charm config of 'nova-cloud-controller' 'openstack-origin' to 'cloud:focal-victoria'
-            Wait 300s for app nova-cloud-controller to reach the idle state.
-            Check if the workload of 'nova-cloud-controller' has been upgraded
+            Wait for up to 300s for app nova-cloud-controller to reach the idle state
+            Verify that the workload of 'nova-cloud-controller' has been upgraded
         Upgrade plan for 'mysql' to victoria
             Upgrade software packages of 'mysql' from the current APT repositories
                 Upgrade software packages on unit mysql/0
             Change charm config of 'mysql' 'source' to 'cloud:focal-victoria'
-            Wait 1800s for app mysql to reach the idle state.
-            Check if the workload of 'mysql' has been upgraded
+            Wait for up to 1800s for app mysql to reach the idle state
+            Verify that the workload of 'mysql' has been upgraded
         Control Plane subordinate(s) upgrade plan
         Upgrade plan for 'neutron-openvswitch' to victoria
             Upgrade 'neutron-openvswitch' to the new channel: 'victoria/stable'
     Would you like to start the upgrade? Continue (y/N): y
     Running cloud upgrade...
     Verify that all OpenStack applications are in idle state ✔
-    Backup mysql databases ✔
+    Back up MySQL databases ✔
 
     Upgrade plan for 'rabbitmq-server' to victoria
         Upgrade software packages of 'rabbitmq-server' from the current APT repositories
@@ -110,8 +110,8 @@ Usage example
             Upgrade software packages on unit rabbitmq-server/2
         Upgrade 'rabbitmq-server' to the new channel: '3.9/stable'
         Change charm config of 'rabbitmq-server' 'source' to 'cloud:focal-victoria'
-        Wait 1800s for model test-model to reach the idle state.
-        Check if the workload of 'rabbitmq-server' has been upgraded
+        Wait for up to 1800s for model test-model to reach the idle state
+        Verify that the workload of 'rabbitmq-server' has been upgraded
 
     Continue (y/n): y
     Upgrade plan for 'rabbitmq-server' to victoria ✔
@@ -123,8 +123,8 @@ Usage example
                 Upgrade software packages on unit keystone/2
             Upgrade 'keystone' to the new channel: 'victoria/stable'
             Change charm config of 'keystone' 'openstack-origin' to 'cloud:focal-victoria'
-            Wait 1800s for model test-model to reach the idle state.
-            Check if the workload of 'keystone' has been upgraded
+            Wait for up to 1800s for model test-model to reach the idle state
+            Verify that the workload of 'keystone' has been upgraded
 
     Continue (y/n): y
     Upgrade software packages of 'keystone' from the current APT repositories \
@@ -156,7 +156,7 @@ Non-interactive mode:
     ...
     Running cloud upgrade...
     Verify that all OpenStack applications are in idle state ✔
-    Backup mysql databases ✔
+    Back up MySQL databases ✔
     Upgrade software packages of 'keystone' from the current APT repositories ✔
     Upgrade 'keystone' to the new channel: 'victoria/stable' ✔
     ...

--- a/docs/how-to/upgrade-cloud.rst
+++ b/docs/how-to/upgrade-cloud.rst
@@ -27,103 +27,103 @@ Usage example
         Verify that all OpenStack applications are in idle state
         Back up MySQL databases
         Control Plane principal(s) upgrade plan
-        Upgrade plan for 'rabbitmq-server' to victoria
+        Upgrade plan for 'rabbitmq-server' to 'victoria'
             Upgrade software packages of 'rabbitmq-server' from the current APT repositories
-                Upgrade software packages on unit rabbitmq-server/0
-                Upgrade software packages on unit rabbitmq-server/1
-                Upgrade software packages on unit rabbitmq-server/2
+                Upgrade software packages on unit 'rabbitmq-server/0'
+                Upgrade software packages on unit 'rabbitmq-server/1'
+                Upgrade software packages on unit 'rabbitmq-server/2'
             Upgrade 'rabbitmq-server' to the new channel: '3.9/stable'
             Change charm config of 'rabbitmq-server' 'source' to 'cloud:focal-victoria'
-            Wait for up to 1800s for model test-model to reach the idle state
+            Wait for up to 1800s for model 'test-model' to reach the idle state
             Verify that the workload of 'rabbitmq-server' has been upgraded
-        Upgrade plan for 'keystone' to victoria
+        Upgrade plan for 'keystone' to 'victoria'
             Upgrade software packages of 'keystone' from the current APT repositories
-                Upgrade software packages on unit keystone/0
-                Upgrade software packages on unit keystone/1
-                Upgrade software packages on unit keystone/2
+                Upgrade software packages on unit 'keystone/0'
+                Upgrade software packages on unit 'keystone/1'
+                Upgrade software packages on unit 'keystone/2'
             Upgrade 'keystone' to the new channel: 'victoria/stable'
             Change charm config of 'keystone' 'openstack-origin' to 'cloud:focal-victoria'
-            Wait for up to 1800s for model test-model to reach the idle state
+            Wait for up to 1800s for model 'test-model' to reach the idle state
             Verify that the workload of 'keystone' has been upgraded
-        Upgrade plan for 'cinder' to victoria
+        Upgrade plan for 'cinder' to 'victoria'
             Upgrade software packages of 'cinder' from the current APT repositories
-                Upgrade software packages on unit cinder/0
+                Upgrade software packages on unit 'cinder/0'
             Refresh 'cinder' to the latest revision of 'ussuri/stable'
             Upgrade 'cinder' to the new channel: 'victoria/stable'
             Change charm config of 'cinder' 'openstack-origin' to 'cloud:focal-victoria'
-            Wait for up to 300s for app cinder to reach the idle state
+            Wait for up to 300s for app 'cinder' to reach the idle state
             Verify that the workload of 'cinder' has been upgraded
-        Upgrade plan for 'glance' to victoria
+        Upgrade plan for 'glance' to 'victoria'
             Upgrade software packages of 'glance' from the current APT repositories
-                Upgrade software packages on unit glance/0
+                Upgrade software packages on unit 'glance/0'
             Upgrade 'glance' to the new channel: 'victoria/stable'
             Change charm config of 'glance' 'openstack-origin' to 'cloud:focal-victoria'
-            Wait for up to 300s for app glance to reach the idle state
+            Wait for up to 300s for app 'glance' to reach the idle state
             Verify that the workload of 'glance' has been upgraded
-        Upgrade plan for 'neutron-api' to victoria
+        Upgrade plan for 'neutron-api' to 'victoria'
             Upgrade software packages of 'neutron-api' from the current APT repositories
-                Upgrade software packages on unit neutron-api/0
+                Upgrade software packages on unit 'neutron-api/0'
             Upgrade 'neutron-api' to the new channel: 'victoria/stable'
             Change charm config of 'neutron-api' 'openstack-origin' to 'cloud:focal-victoria'
-            Wait for up to 300s for app neutron-api to reach the idle state
+            Wait for up to 300s for app 'neutron-api' to reach the idle state
             Verify that the workload of 'neutron-api' has been upgraded
-        Upgrade plan for 'neutron-gateway' to victoria
+        Upgrade plan for 'neutron-gateway' to 'victoria'
             Upgrade software packages of 'neutron-gateway' from the current APT repositories
-                Upgrade software packages on unit neutron-gateway/0
+                Upgrade software packages on unit 'neutron-gateway/0'
             Upgrade 'neutron-gateway' to the new channel: 'victoria/stable'
             Change charm config of 'neutron-gateway' 'openstack-origin' to 'cloud:focal-victoria'
-            Wait for up to 300s for app neutron-gateway to reach the idle state
+            Wait for up to 300s for app 'neutron-gateway' to reach the idle state
             Verify that the workload of 'neutron-gateway' has been upgraded
-        Upgrade plan for 'placement' to victoria
+        Upgrade plan for 'placement' to 'victoria'
             Upgrade software packages of 'placement' from the current APT repositories
-                Upgrade software packages on unit placement/0
+                Upgrade software packages on unit 'placement/0'
             Upgrade 'placement' to the new channel: 'victoria/stable'
             Change charm config of 'placement' 'openstack-origin' to 'cloud:focal-victoria'
-            Wait for up to 300s for app placement to reach the idle state
+            Wait for up to 300s for app 'placement' to reach the idle state
             Verify that the workload of 'placement' has been upgraded
-        Upgrade plan for 'nova-cloud-controller' to victoria
+        Upgrade plan for 'nova-cloud-controller' to 'victoria'
             Upgrade software packages of 'nova-cloud-controller' from the current APT repositories
-                Upgrade software packages on unit nova-cloud-controller/0
+                Upgrade software packages on unit 'nova-cloud-controller/0'
             Refresh 'nova-cloud-controller' to the latest revision of 'ussuri/stable'
             Upgrade 'nova-cloud-controller' to the new channel: 'victoria/stable'
             Change charm config of 'nova-cloud-controller' 'openstack-origin' to 'cloud:focal-victoria'
-            Wait for up to 300s for app nova-cloud-controller to reach the idle state
+            Wait for up to 300s for app 'nova-cloud-controller' to reach the idle state
             Verify that the workload of 'nova-cloud-controller' has been upgraded
-        Upgrade plan for 'mysql' to victoria
+        Upgrade plan for 'mysql' to 'victoria'
             Upgrade software packages of 'mysql' from the current APT repositories
-                Upgrade software packages on unit mysql/0
+                Upgrade software packages on unit 'mysql/0'
             Change charm config of 'mysql' 'source' to 'cloud:focal-victoria'
-            Wait for up to 1800s for app mysql to reach the idle state
+            Wait for up to 1800s for app 'mysql' to reach the idle state
             Verify that the workload of 'mysql' has been upgraded
         Control Plane subordinate(s) upgrade plan
-        Upgrade plan for 'neutron-openvswitch' to victoria
+        Upgrade plan for 'neutron-openvswitch' to 'victoria'
             Upgrade 'neutron-openvswitch' to the new channel: 'victoria/stable'
     Would you like to start the upgrade? Continue (y/N): y
     Running cloud upgrade...
     Verify that all OpenStack applications are in idle state ✔
     Back up MySQL databases ✔
 
-    Upgrade plan for 'rabbitmq-server' to victoria
+    Upgrade plan for 'rabbitmq-server' to 'victoria'
         Upgrade software packages of 'rabbitmq-server' from the current APT repositories
-            Upgrade software packages on unit rabbitmq-server/0
-            Upgrade software packages on unit rabbitmq-server/1
-            Upgrade software packages on unit rabbitmq-server/2
+            Upgrade software packages on unit 'rabbitmq-server/0'
+            Upgrade software packages on unit 'rabbitmq-server/1'
+            Upgrade software packages on unit 'rabbitmq-server/2'
         Upgrade 'rabbitmq-server' to the new channel: '3.9/stable'
         Change charm config of 'rabbitmq-server' 'source' to 'cloud:focal-victoria'
-        Wait for up to 1800s for model test-model to reach the idle state
+        Wait for up to 1800s for model 'test-model' to reach the idle state
         Verify that the workload of 'rabbitmq-server' has been upgraded
 
     Continue (y/n): y
-    Upgrade plan for 'rabbitmq-server' to victoria ✔
+    Upgrade plan for 'rabbitmq-server' to 'victoria' ✔
 
-    Upgrade plan for 'keystone' to victoria
+    Upgrade plan for 'keystone' to 'victoria'
             Upgrade software packages of 'keystone' from the current APT repositories
-                Upgrade software packages on unit keystone/0
-                Upgrade software packages on unit keystone/1
-                Upgrade software packages on unit keystone/2
+                Upgrade software packages on unit 'keystone/0'
+                Upgrade software packages on unit 'keystone/1'
+                Upgrade software packages on unit 'keystone/2'
             Upgrade 'keystone' to the new channel: 'victoria/stable'
             Change charm config of 'keystone' 'openstack-origin' to 'cloud:focal-victoria'
-            Wait for up to 1800s for model test-model to reach the idle state
+            Wait for up to 1800s for model 'test-model' to reach the idle state
             Verify that the workload of 'keystone' has been upgraded
 
     Continue (y/n): y

--- a/tests/functional/tests/smoke.py
+++ b/tests/functional/tests/smoke.py
@@ -131,7 +131,7 @@ class SmokeTest(unittest.TestCase):
         :return: The upgrade plan.
         :rtype: str
         """
-        backup_plan = "\tBackup mysql databases\n" if backup else ""
+        backup_plan = "\tBack up MySQL databases\n" if backup else ""
         return (
             "Upgrade cloud from 'ussuri' to 'victoria'\n"
             "\tVerify that all OpenStack applications are in idle state\n"
@@ -142,8 +142,8 @@ class SmokeTest(unittest.TestCase):
             "from the current APT repositories\n"
             "\t\t\t\tUpgrade software packages on unit designate-bind/0\n"
             "\t\t\tUpgrade 'designate-bind' to the new channel: 'victoria/stable'\n"
-            "\t\t\tWait 300s for app designate-bind to reach the idle state.\n"
-            "\t\t\tCheck if the workload of 'designate-bind' has been upgraded on units:"
+            "\t\t\tWait for up to 300s for app designate-bind to reach the idle state\n"
+            "\t\t\tVerify that the workload of 'designate-bind' has been upgraded on units:"
             " designate-bind/0\n"
             "\t\tUpgrade plan for 'mysql-innodb-cluster' to victoria\n"
             "\t\t\tUpgrade software packages of 'mysql-innodb-cluster' "
@@ -153,8 +153,8 @@ class SmokeTest(unittest.TestCase):
             "\t\t\t\tUpgrade software packages on unit mysql-innodb-cluster/2\n"
             "\t\t\tChange charm config of 'mysql-innodb-cluster' 'source' to "
             "'cloud:focal-victoria'\n"
-            "\t\t\tWait 1800s for app mysql-innodb-cluster to reach the idle state.\n"
-            "\t\t\tCheck if the workload of 'mysql-innodb-cluster' has been upgraded on units: "
+            "\t\t\tWait for up to 1800s for app mysql-innodb-cluster to reach the idle state\n"
+            "\t\t\tVerify that the workload of 'mysql-innodb-cluster' has been upgraded on units: "
             "mysql-innodb-cluster/0, mysql-innodb-cluster/1, mysql-innodb-cluster/2\n"
         )
 

--- a/tests/functional/tests/smoke.py
+++ b/tests/functional/tests/smoke.py
@@ -137,23 +137,23 @@ class SmokeTest(unittest.TestCase):
             "\tVerify that all OpenStack applications are in idle state\n"
             f"{backup_plan}"
             "\tControl Plane principal(s) upgrade plan\n"
-            "\t\tUpgrade plan for 'designate-bind' to victoria\n"
+            "\t\tUpgrade plan for 'designate-bind' to 'victoria'\n"
             "\t\t\tUpgrade software packages of 'designate-bind' "
             "from the current APT repositories\n"
-            "\t\t\t\tUpgrade software packages on unit designate-bind/0\n"
+            "\t\t\t\tUpgrade software packages on unit 'designate-bind/0'\n"
             "\t\t\tUpgrade 'designate-bind' to the new channel: 'victoria/stable'\n"
-            "\t\t\tWait for up to 300s for app designate-bind to reach the idle state\n"
+            "\t\t\tWait for up to 300s for app 'designate-bind' to reach the idle state\n"
             "\t\t\tVerify that the workload of 'designate-bind' has been upgraded on units:"
             " designate-bind/0\n"
-            "\t\tUpgrade plan for 'mysql-innodb-cluster' to victoria\n"
+            "\t\tUpgrade plan for 'mysql-innodb-cluster' to 'victoria'\n"
             "\t\t\tUpgrade software packages of 'mysql-innodb-cluster' "
             "from the current APT repositories\n"
-            "\t\t\t\tUpgrade software packages on unit mysql-innodb-cluster/0\n"
-            "\t\t\t\tUpgrade software packages on unit mysql-innodb-cluster/1\n"
-            "\t\t\t\tUpgrade software packages on unit mysql-innodb-cluster/2\n"
+            "\t\t\t\tUpgrade software packages on unit 'mysql-innodb-cluster/0'\n"
+            "\t\t\t\tUpgrade software packages on unit 'mysql-innodb-cluster/1'\n"
+            "\t\t\t\tUpgrade software packages on unit 'mysql-innodb-cluster/2'\n"
             "\t\t\tChange charm config of 'mysql-innodb-cluster' 'source' to "
             "'cloud:focal-victoria'\n"
-            "\t\t\tWait for up to 1800s for app mysql-innodb-cluster to reach the idle state\n"
+            "\t\t\tWait for up to 1800s for app 'mysql-innodb-cluster' to reach the idle state\n"
             "\t\t\tVerify that the workload of 'mysql-innodb-cluster' has been upgraded on units: "
             "mysql-innodb-cluster/0, mysql-innodb-cluster/1, mysql-innodb-cluster/2\n"
         )
@@ -189,8 +189,8 @@ class SmokeTest(unittest.TestCase):
         """Test cou upgrade."""
         # designate-bind upgrades from ussuri to victoria
         expected_msgs_before_upgrade = [
-            "Upgrade plan for 'designate-bind' to victoria",
-            "Upgrade plan for 'mysql-innodb-cluster' to victoria",
+            "Upgrade plan for 'designate-bind' to 'victoria'",
+            "Upgrade plan for 'mysql-innodb-cluster' to 'victoria'",
         ]
         result_before_upgrade = self.cou(
             ["upgrade", "--model", self.model_name, "--no-backup", "--auto-approve"]
@@ -201,8 +201,8 @@ class SmokeTest(unittest.TestCase):
 
         # designate-bind was upgraded to victoria and next step is to wallaby
         expected_msg_after_upgrade = [
-            "Upgrade plan for 'designate-bind' to wallaby",
-            "Upgrade plan for 'mysql-innodb-cluster' to wallaby",
+            "Upgrade plan for 'designate-bind' to 'wallaby'",
+            "Upgrade plan for 'mysql-innodb-cluster' to 'wallaby'",
         ]
         result_after_upgrade = self.cou(["plan", "--model", self.model_name, "--no-backup"]).stdout
         for expected_msg in expected_msg_after_upgrade:

--- a/tests/unit/apps/test_auxiliary.py
+++ b/tests/unit/apps/test_auxiliary.py
@@ -173,13 +173,13 @@ def test_auxiliary_upgrade_plan_ussuri_to_victoria_change_channel(model):
             ),
         ),
         PostUpgradeStep(
-            description=f"Wait 1800s for model {model.name} to reach the idle state.",
+            description=f"Wait for up to 1800s for model {model.name} to reach the idle state",
             parallel=False,
             coro=model.wait_for_active_idle(1800, apps=None),
         ),
         PostUpgradeStep(
             description=(
-                f"Check if the workload of '{app.name}' has been upgraded on units: "
+                f"Verify that the workload of '{app.name}' has been upgraded on units: "
                 f"{', '.join([unit for unit in app.units.keys()])}"
             ),
             parallel=False,
@@ -251,13 +251,13 @@ def test_auxiliary_upgrade_plan_ussuri_to_victoria(model):
             ),
         ),
         PostUpgradeStep(
-            description=f"Wait 1800s for model {model.name} to reach the idle state.",
+            description=f"Wait for up to 1800s for model {model.name} to reach the idle state",
             parallel=False,
             coro=model.wait_for_active_idle(1800, apps=None),
         ),
         PostUpgradeStep(
             description=(
-                f"Check if the workload of '{app.name}' has been upgraded on units: "
+                f"Verify that the workload of '{app.name}' has been upgraded on units: "
                 f"{', '.join([unit for unit in app.units.keys()])}"
             ),
             parallel=False,
@@ -314,7 +314,7 @@ def test_auxiliary_upgrade_plan_ussuri_to_victoria_ch_migration(model):
     upgrade_steps = [
         upgrade_packages,
         PreUpgradeStep(
-            description=f"Migration of '{app.name}' from charmstore to charmhub",
+            description=f"Migrate '{app.name}' from charmstore to charmhub",
             parallel=False,
             coro=model.upgrade_charm(app.name, "3.9/stable", switch="ch:rabbitmq-server"),
         ),
@@ -335,13 +335,13 @@ def test_auxiliary_upgrade_plan_ussuri_to_victoria_ch_migration(model):
             ),
         ),
         PostUpgradeStep(
-            description=f"Wait 1800s for model {model.name} to reach the idle state.",
+            description=f"Wait for up to 1800s for model {model.name} to reach the idle state",
             parallel=False,
             coro=model.wait_for_active_idle(1800, apps=None),
         ),
         PostUpgradeStep(
             description=(
-                f"Check if the workload of '{app.name}' has been upgraded on units: "
+                f"Verify that the workload of '{app.name}' has been upgraded on units: "
                 f"{', '.join([unit for unit in app.units.keys()])}"
             ),
             parallel=False,
@@ -644,7 +644,9 @@ def test_ceph_mon_upgrade_plan_xena_to_yoga(model):
             coro=model.upgrade_charm(app.name, "pacific/stable", switch=None),
         ),
         PreUpgradeStep(
-            description="Ensure the 'require-osd-release' option matches the 'ceph-osd' version",
+            description=(
+                "Ensure that the 'require-osd-release' option matches the 'ceph-osd' version"
+            ),
             parallel=False,
             coro=app_utils.set_require_osd_release_option("ceph-mon/0", model),
         ),
@@ -664,13 +666,13 @@ def test_ceph_mon_upgrade_plan_xena_to_yoga(model):
             ),
         ),
         PostUpgradeStep(
-            description=f"Wait 1800s for model {model.name} to reach the idle state.",
+            description=f"Wait for up to 1800s for model {model.name} to reach the idle state",
             parallel=False,
             coro=model.wait_for_active_idle(1800, apps=None),
         ),
         PostUpgradeStep(
             description=(
-                f"Check if the workload of '{app.name}' has been upgraded on units: "
+                f"Verify that the workload of '{app.name}' has been upgraded on units: "
                 f"{', '.join([unit for unit in app.units.keys()])}"
             ),
             parallel=False,
@@ -733,7 +735,9 @@ def test_ceph_mon_upgrade_plan_ussuri_to_victoria(model):
             coro=model.upgrade_charm(app.name, "octopus/stable", switch=None),
         ),
         PreUpgradeStep(
-            description="Ensure the 'require-osd-release' option matches the 'ceph-osd' version",
+            description=(
+                "Ensure that the 'require-osd-release' option matches the 'ceph-osd' version"
+            ),
             parallel=False,
             coro=app_utils.set_require_osd_release_option("ceph-mon/0", model),
         ),
@@ -748,13 +752,13 @@ def test_ceph_mon_upgrade_plan_ussuri_to_victoria(model):
             ),
         ),
         PostUpgradeStep(
-            description=f"Wait 1800s for model {model.name} to reach the idle state.",
+            description=f"Wait for up to 1800s for model {model.name} to reach the idle state",
             parallel=False,
             coro=model.wait_for_active_idle(1800, apps=None),
         ),
         PostUpgradeStep(
             description=(
-                f"Check if the workload of '{app.name}' has been upgraded on units: "
+                f"Verify that the workload of '{app.name}' has been upgraded on units: "
                 f"{', '.join([unit for unit in app.units.keys()])}"
             ),
             parallel=False,
@@ -931,13 +935,13 @@ def test_ovn_principal_upgrade_plan(model):
             ),
         ),
         PostUpgradeStep(
-            description=f"Wait 300s for app {app.name} to reach the idle state.",
+            description=f"Wait for up to 300s for app {app.name} to reach the idle state",
             parallel=False,
             coro=model.wait_for_active_idle(300, apps=[app.name]),
         ),
         PostUpgradeStep(
             description=(
-                f"Check if the workload of '{app.name}' has been upgraded on units: "
+                f"Verify that the workload of '{app.name}' has been upgraded on units: "
                 f"{', '.join([unit for unit in app.units.keys()])}"
             ),
             parallel=False,
@@ -1010,13 +1014,13 @@ def test_mysql_innodb_cluster_upgrade(model):
             ),
         ),
         PostUpgradeStep(
-            description=f"Wait 1800s for app {app.name} to reach the idle state.",
+            description=f"Wait for up to 1800s for app {app.name} to reach the idle state",
             parallel=False,
             coro=model.wait_for_active_idle(1800, apps=[app.name]),
         ),
         PostUpgradeStep(
             description=(
-                f"Check if the workload of '{app.name}' has been upgraded on units: "
+                f"Verify that the workload of '{app.name}' has been upgraded on units: "
                 f"{', '.join([unit for unit in app.units.keys()])}"
             ),
             parallel=False,
@@ -1053,7 +1057,7 @@ def test_ceph_osd_pre_upgrade_steps(mock_pre_upgrade_steps, target, model):
 
     assert steps == [
         PreUpgradeStep(
-            description="Check if all nova-compute units had been upgraded",
+            description="Verify that all nova-compute units had been upgraded",
             coro=app._verify_nova_compute(target),
         ),
         *mock_pre_upgrade_steps.return_value,
@@ -1201,14 +1205,14 @@ def test_ceph_osd_upgrade_plan(model):
     exp_plan = dedent_plan(
         """\
     Upgrade plan for 'ceph-osd' to victoria
-        Check if all nova-compute units had been upgraded
+        Verify that all nova-compute units had been upgraded
         Upgrade software packages of 'ceph-osd' from the current APT repositories
             Upgrade software packages on unit ceph-osd/0
             Upgrade software packages on unit ceph-osd/1
             Upgrade software packages on unit ceph-osd/2
         Change charm config of 'ceph-osd' 'source' to 'cloud:focal-victoria'
-        Wait 300s for app ceph-osd to reach the idle state.
-        Check if the workload of 'ceph-osd' has been upgraded on units: ceph-osd/0, ceph-osd/1, ceph-osd/2
+        Wait for up to 300s for app ceph-osd to reach the idle state
+        Verify that the workload of 'ceph-osd' has been upgraded on units: ceph-osd/0, ceph-osd/1, ceph-osd/2
     """  # noqa: E501 line too long
     )
     target = OpenStackRelease("victoria")

--- a/tests/unit/apps/test_auxiliary.py
+++ b/tests/unit/apps/test_auxiliary.py
@@ -134,7 +134,7 @@ def test_auxiliary_upgrade_plan_ussuri_to_victoria_change_channel(model):
     )
 
     expected_plan = ApplicationUpgradePlan(
-        description=f"Upgrade plan for '{app.name}' to {target}"
+        description=f"Upgrade plan for '{app.name}' to '{target}'"
     )
     expected_upgrade_package_step = PreUpgradeStep(
         description=f"Upgrade software packages of '{app.name}' from the current APT repositories",
@@ -143,7 +143,7 @@ def test_auxiliary_upgrade_plan_ussuri_to_victoria_change_channel(model):
     for unit in app.units.keys():
         expected_upgrade_package_step.add_step(
             UnitUpgradeStep(
-                description=f"Upgrade software packages on unit {unit}",
+                description=f"Upgrade software packages on unit '{unit}'",
                 parallel=False,
                 coro=app_utils.upgrade_packages(unit, model, None),
             )
@@ -173,7 +173,7 @@ def test_auxiliary_upgrade_plan_ussuri_to_victoria_change_channel(model):
             ),
         ),
         PostUpgradeStep(
-            description=f"Wait for up to 1800s for model {model.name} to reach the idle state",
+            description=f"Wait for up to 1800s for model '{model.name}' to reach the idle state",
             parallel=False,
             coro=model.wait_for_active_idle(1800, apps=None),
         ),
@@ -218,7 +218,7 @@ def test_auxiliary_upgrade_plan_ussuri_to_victoria(model):
     )
 
     expected_plan = ApplicationUpgradePlan(
-        description=f"Upgrade plan for '{app.name}' to {target}"
+        description=f"Upgrade plan for '{app.name}' to '{target}'"
     )
     upgrade_packages = PreUpgradeStep(
         description=f"Upgrade software packages of '{app.name}' from the current APT repositories",
@@ -227,7 +227,7 @@ def test_auxiliary_upgrade_plan_ussuri_to_victoria(model):
     for unit in app.units.values():
         upgrade_packages.add_step(
             UnitUpgradeStep(
-                description=f"Upgrade software packages on unit {unit.name}",
+                description=f"Upgrade software packages on unit '{unit.name}'",
                 coro=app_utils.upgrade_packages(unit.name, model, None),
             )
         )
@@ -251,7 +251,7 @@ def test_auxiliary_upgrade_plan_ussuri_to_victoria(model):
             ),
         ),
         PostUpgradeStep(
-            description=f"Wait for up to 1800s for model {model.name} to reach the idle state",
+            description=f"Wait for up to 1800s for model '{model.name}' to reach the idle state",
             parallel=False,
             coro=model.wait_for_active_idle(1800, apps=None),
         ),
@@ -297,7 +297,7 @@ def test_auxiliary_upgrade_plan_ussuri_to_victoria_ch_migration(model):
     )
 
     expected_plan = ApplicationUpgradePlan(
-        description=f"Upgrade plan for '{app.name}' to {target}",
+        description=f"Upgrade plan for '{app.name}' to '{target}'",
     )
     upgrade_packages = PreUpgradeStep(
         description=f"Upgrade software packages of '{app.name}' from the current APT repositories",
@@ -306,7 +306,7 @@ def test_auxiliary_upgrade_plan_ussuri_to_victoria_ch_migration(model):
     for unit in app.units.values():
         upgrade_packages.add_step(
             UnitUpgradeStep(
-                description=f"Upgrade software packages on unit {unit.name}",
+                description=f"Upgrade software packages on unit '{unit.name}'",
                 coro=app_utils.upgrade_packages(unit.name, model, None),
             )
         )
@@ -335,7 +335,7 @@ def test_auxiliary_upgrade_plan_ussuri_to_victoria_ch_migration(model):
             ),
         ),
         PostUpgradeStep(
-            description=f"Wait for up to 1800s for model {model.name} to reach the idle state",
+            description=f"Wait for up to 1800s for model '{model.name}' to reach the idle state",
             parallel=False,
             coro=model.wait_for_active_idle(1800, apps=None),
         ),
@@ -622,7 +622,7 @@ def test_ceph_mon_upgrade_plan_xena_to_yoga(model):
     )
 
     expected_plan = ApplicationUpgradePlan(
-        description=f"Upgrade plan for '{app.name}' to {target}"
+        description=f"Upgrade plan for '{app.name}' to '{target}'"
     )
     upgrade_packages = PreUpgradeStep(
         description=f"Upgrade software packages of '{app.name}' from the current APT repositories",
@@ -631,7 +631,7 @@ def test_ceph_mon_upgrade_plan_xena_to_yoga(model):
     for unit in app.units.values():
         upgrade_packages.add_step(
             UnitUpgradeStep(
-                description=f"Upgrade software packages on unit {unit.name}",
+                description=f"Upgrade software packages on unit '{unit.name}'",
                 coro=app_utils.upgrade_packages(unit.name, model, None),
             )
         )
@@ -666,7 +666,7 @@ def test_ceph_mon_upgrade_plan_xena_to_yoga(model):
             ),
         ),
         PostUpgradeStep(
-            description=f"Wait for up to 1800s for model {model.name} to reach the idle state",
+            description=f"Wait for up to 1800s for model '{model.name}' to reach the idle state",
             parallel=False,
             coro=model.wait_for_active_idle(1800, apps=None),
         ),
@@ -713,7 +713,7 @@ def test_ceph_mon_upgrade_plan_ussuri_to_victoria(model):
     )
 
     expected_plan = ApplicationUpgradePlan(
-        description=f"Upgrade plan for '{app.name}' to {target}"
+        description=f"Upgrade plan for '{app.name}' to '{target}'"
     )
     upgrade_packages = PreUpgradeStep(
         description=f"Upgrade software packages of '{app.name}' from the current APT repositories",
@@ -722,7 +722,7 @@ def test_ceph_mon_upgrade_plan_ussuri_to_victoria(model):
     for unit in app.units.values():
         upgrade_packages.add_step(
             UnitUpgradeStep(
-                description=f"Upgrade software packages on unit {unit.name}",
+                description=f"Upgrade software packages on unit '{unit.name}'",
                 coro=app_utils.upgrade_packages(unit.name, model, None),
             )
         )
@@ -752,7 +752,7 @@ def test_ceph_mon_upgrade_plan_ussuri_to_victoria(model):
             ),
         ),
         PostUpgradeStep(
-            description=f"Wait for up to 1800s for model {model.name} to reach the idle state",
+            description=f"Wait for up to 1800s for model '{model.name}' to reach the idle state",
             parallel=False,
             coro=model.wait_for_active_idle(1800, apps=None),
         ),
@@ -902,7 +902,7 @@ def test_ovn_principal_upgrade_plan(model):
     )
 
     expected_plan = ApplicationUpgradePlan(
-        description=f"Upgrade plan for '{app.name}' to {target}"
+        description=f"Upgrade plan for '{app.name}' to '{target}'"
     )
 
     upgrade_packages = PreUpgradeStep(
@@ -912,7 +912,7 @@ def test_ovn_principal_upgrade_plan(model):
     for unit in app.units.values():
         upgrade_packages.add_step(
             UnitUpgradeStep(
-                description=f"Upgrade software packages on unit {unit.name}",
+                description=f"Upgrade software packages on unit '{unit.name}'",
                 coro=app_utils.upgrade_packages(unit.name, model, None),
             )
         )
@@ -935,7 +935,7 @@ def test_ovn_principal_upgrade_plan(model):
             ),
         ),
         PostUpgradeStep(
-            description=f"Wait for up to 300s for app {app.name} to reach the idle state",
+            description=f"Wait for up to 300s for app '{app.name}' to reach the idle state",
             parallel=False,
             coro=model.wait_for_active_idle(300, apps=[app.name]),
         ),
@@ -982,7 +982,7 @@ def test_mysql_innodb_cluster_upgrade(model):
     )
 
     expected_plan = ApplicationUpgradePlan(
-        description=f"Upgrade plan for '{app.name}' to {target}"
+        description=f"Upgrade plan for '{app.name}' to '{target}'"
     )
     upgrade_packages = PreUpgradeStep(
         description=f"Upgrade software packages of '{app.name}' from the current APT repositories",
@@ -991,7 +991,7 @@ def test_mysql_innodb_cluster_upgrade(model):
     for unit in app.units.values():
         upgrade_packages.add_step(
             UnitUpgradeStep(
-                description=f"Upgrade software packages on unit {unit.name}",
+                description=f"Upgrade software packages on unit '{unit.name}'",
                 coro=app_utils.upgrade_packages(unit.name, model, ["mysql-server-core-8.0"]),
             )
         )
@@ -1014,7 +1014,7 @@ def test_mysql_innodb_cluster_upgrade(model):
             ),
         ),
         PostUpgradeStep(
-            description=f"Wait for up to 1800s for app {app.name} to reach the idle state",
+            description=f"Wait for up to 1800s for app '{app.name}' to reach the idle state",
             parallel=False,
             coro=model.wait_for_active_idle(1800, apps=[app.name]),
         ),
@@ -1057,7 +1057,7 @@ def test_ceph_osd_pre_upgrade_steps(mock_pre_upgrade_steps, target, model):
 
     assert steps == [
         PreUpgradeStep(
-            description="Verify that all nova-compute units had been upgraded",
+            description="Verify that all 'nova-compute' units had been upgraded",
             coro=app._verify_nova_compute(target),
         ),
         *mock_pre_upgrade_steps.return_value,
@@ -1204,14 +1204,14 @@ def test_ceph_osd_upgrade_plan(model):
     """Testing generating ceph-osd upgrade plan."""
     exp_plan = dedent_plan(
         """\
-    Upgrade plan for 'ceph-osd' to victoria
-        Verify that all nova-compute units had been upgraded
+    Upgrade plan for 'ceph-osd' to 'victoria'
+        Verify that all 'nova-compute' units had been upgraded
         Upgrade software packages of 'ceph-osd' from the current APT repositories
-            Upgrade software packages on unit ceph-osd/0
-            Upgrade software packages on unit ceph-osd/1
-            Upgrade software packages on unit ceph-osd/2
+            Upgrade software packages on unit 'ceph-osd/0'
+            Upgrade software packages on unit 'ceph-osd/1'
+            Upgrade software packages on unit 'ceph-osd/2'
         Change charm config of 'ceph-osd' 'source' to 'cloud:focal-victoria'
-        Wait for up to 300s for app ceph-osd to reach the idle state
+        Wait for up to 300s for app 'ceph-osd' to reach the idle state
         Verify that the workload of 'ceph-osd' has been upgraded on units: ceph-osd/0, ceph-osd/1, ceph-osd/2
     """  # noqa: E501 line too long
     )

--- a/tests/unit/apps/test_auxiliary_subordinate.py
+++ b/tests/unit/apps/test_auxiliary_subordinate.py
@@ -76,7 +76,7 @@ def test_auxiliary_subordinate_upgrade_plan_to_victoria(model):
     )
 
     expected_plan = ApplicationUpgradePlan(
-        description=f"Upgrade plan for '{app.name}' to {target}",
+        description=f"Upgrade plan for '{app.name}' to '{target}'",
     )
     expected_plan.add_step(
         PreUpgradeStep(
@@ -166,7 +166,7 @@ def test_ovn_subordinate_upgrade_plan(model):
     )
 
     expected_plan = ApplicationUpgradePlan(
-        description=f"Upgrade plan for '{app.name}' to {target}"
+        description=f"Upgrade plan for '{app.name}' to '{target}'"
     )
 
     upgrade_steps = [
@@ -207,7 +207,7 @@ def test_ovn_subordinate_upgrade_plan_cant_upgrade_charm(model):
     )
 
     expected_plan = ApplicationUpgradePlan(
-        description=f"Upgrade plan for '{app.name}' to {target}"
+        description=f"Upgrade plan for '{app.name}' to '{target}'"
     )
 
     upgrade_plan = app.generate_upgrade_plan(target, False)
@@ -236,7 +236,7 @@ def test_ceph_dashboard_upgrade_plan_ussuri_to_victoria(model):
     )
 
     expected_plan = ApplicationUpgradePlan(
-        description=f"Upgrade plan for '{app.name}' to {target}"
+        description=f"Upgrade plan for '{app.name}' to '{target}'"
     )
 
     upgrade_steps = [
@@ -273,7 +273,7 @@ def test_ceph_dashboard_upgrade_plan_xena_to_yoga(model):
     )
 
     expected_plan = ApplicationUpgradePlan(
-        description=f"Upgrade plan for '{app.name}' to {target}"
+        description=f"Upgrade plan for '{app.name}' to '{target}'"
     )
 
     upgrade_steps = [

--- a/tests/unit/apps/test_base.py
+++ b/tests/unit/apps/test_base.py
@@ -150,7 +150,7 @@ def test_get_pause_unit_step(model):
         machine=machines["0"],
     )
     expected_upgrade_step = UnitUpgradeStep(
-        description=f"Pause the unit: '{unit.name}'.",
+        description=f"Pause the unit: '{unit.name}'",
         coro=model.run_action(
             unit_name=f"{unit.name}", action_name="pause", raise_on_failure=True
         ),
@@ -185,7 +185,7 @@ def test_get_resume_unit_step(model):
         machine=machines["0"],
     )
     expected_upgrade_step = UnitUpgradeStep(
-        description=f"Resume the unit: '{unit.name}'.",
+        description=f"Resume the unit: '{unit.name}'",
         coro=model.run_action(unit_name=unit.name, action_name="resume", raise_on_failure=True),
     )
     app = OpenStackApplication(
@@ -218,7 +218,7 @@ def test_get_openstack_upgrade_step(model):
         machine=machines["0"],
     )
     expected_upgrade_step = UnitUpgradeStep(
-        description=f"Upgrade the unit: '{unit.name}'.",
+        description=f"Upgrade the unit: '{unit.name}'",
         coro=model.run_action(
             unit_name=unit.name, action_name="openstack-upgrade", raise_on_failure=True
         ),

--- a/tests/unit/apps/test_channel_based.py
+++ b/tests/unit/apps/test_channel_based.py
@@ -184,7 +184,7 @@ def test_application_versionless_upgrade_plan_ussuri_to_victoria(model):
     )
 
     expected_plan = ApplicationUpgradePlan(
-        description=f"Upgrade plan for '{app.name}' to {target}"
+        description=f"Upgrade plan for '{app.name}' to '{target}'"
     )
 
     upgrade_packages = PreUpgradeStep(
@@ -194,7 +194,7 @@ def test_application_versionless_upgrade_plan_ussuri_to_victoria(model):
     for unit in app.units.values():
         upgrade_packages.add_step(
             UnitUpgradeStep(
-                description=f"Upgrade software packages on unit {unit.name}",
+                description=f"Upgrade software packages on unit '{unit.name}'",
                 coro=app_utils.upgrade_packages(unit.name, model, None),
             )
         )
@@ -263,7 +263,7 @@ def test_application_gnocchi_upgrade_plan_ussuri_to_victoria(model):
     )
 
     expected_plan = ApplicationUpgradePlan(
-        description=f"Upgrade plan for '{app.name}' to {target}"
+        description=f"Upgrade plan for '{app.name}' to '{target}'"
     )
 
     upgrade_packages = PreUpgradeStep(
@@ -273,7 +273,7 @@ def test_application_gnocchi_upgrade_plan_ussuri_to_victoria(model):
     for unit in app.units.values():
         upgrade_packages.add_step(
             UnitUpgradeStep(
-                description=f"Upgrade software packages on unit {unit.name}",
+                description=f"Upgrade software packages on unit '{unit.name}'",
                 coro=app_utils.upgrade_packages(unit.name, model, None),
             )
         )
@@ -302,7 +302,7 @@ def test_application_gnocchi_upgrade_plan_ussuri_to_victoria(model):
             ),
         ),
         PostUpgradeStep(
-            description=f"Wait for up to 300s for app {app.name} to reach the idle state",
+            description=f"Wait for up to 300s for app '{app.name}' to reach the idle state",
             parallel=False,
             coro=model.wait_for_active_idle(300, apps=[app.name]),
         ),
@@ -352,7 +352,7 @@ def test_application_designate_bind_upgrade_plan_ussuri_to_victoria(model):
     )
 
     expected_plan = ApplicationUpgradePlan(
-        description=f"Upgrade plan for '{app.name}' to {target}"
+        description=f"Upgrade plan for '{app.name}' to '{target}'"
     )
 
     upgrade_packages = PreUpgradeStep(
@@ -362,7 +362,7 @@ def test_application_designate_bind_upgrade_plan_ussuri_to_victoria(model):
     for unit in app.units.values():
         upgrade_packages.add_step(
             UnitUpgradeStep(
-                description=f"Upgrade software packages on unit {unit.name}",
+                description=f"Upgrade software packages on unit '{unit.name}'",
                 coro=app_utils.upgrade_packages(unit.name, model, None),
             )
         )
@@ -391,7 +391,7 @@ def test_application_designate_bind_upgrade_plan_ussuri_to_victoria(model):
             ),
         ),
         PostUpgradeStep(
-            description=f"Wait for up to 300s for app {app.name} to reach the idle state",
+            description=f"Wait for up to 300s for app '{app.name}' to reach the idle state",
             parallel=False,
             coro=model.wait_for_active_idle(300, apps=[app.name]),
         ),

--- a/tests/unit/apps/test_channel_based.py
+++ b/tests/unit/apps/test_channel_based.py
@@ -302,13 +302,13 @@ def test_application_gnocchi_upgrade_plan_ussuri_to_victoria(model):
             ),
         ),
         PostUpgradeStep(
-            description=f"Wait 300s for app {app.name} to reach the idle state.",
+            description=f"Wait for up to 300s for app {app.name} to reach the idle state",
             parallel=False,
             coro=model.wait_for_active_idle(300, apps=[app.name]),
         ),
         PostUpgradeStep(
             description=(
-                f"Check if the workload of '{app.name}' has been upgraded on units: "
+                f"Verify that the workload of '{app.name}' has been upgraded on units: "
                 f"{', '.join([unit for unit in app.units.keys()])}"
             ),
             parallel=False,
@@ -391,13 +391,13 @@ def test_application_designate_bind_upgrade_plan_ussuri_to_victoria(model):
             ),
         ),
         PostUpgradeStep(
-            description=f"Wait 300s for app {app.name} to reach the idle state.",
+            description=f"Wait for up to 300s for app {app.name} to reach the idle state",
             parallel=False,
             coro=model.wait_for_active_idle(300, apps=[app.name]),
         ),
         PostUpgradeStep(
             description=(
-                f"Check if the workload of '{app.name}' has been upgraded on units: "
+                f"Verify that the workload of '{app.name}' has been upgraded on units: "
                 f"{', '.join([unit for unit in app.units.keys()])}"
             ),
             parallel=False,

--- a/tests/unit/apps/test_core.py
+++ b/tests/unit/apps/test_core.py
@@ -310,7 +310,7 @@ def test_upgrade_plan_ussuri_to_victoria(model):
         workload_version="17.1.0",
     )
     expected_plan = ApplicationUpgradePlan(
-        description=f"Upgrade plan for '{app.name}' to {target}"
+        description=f"Upgrade plan for '{app.name}' to '{target}'"
     )
     upgrade_packages = PreUpgradeStep(
         description=f"Upgrade software packages of '{app.name}' from the current APT repositories",
@@ -319,7 +319,7 @@ def test_upgrade_plan_ussuri_to_victoria(model):
     for unit in app.units.values():
         upgrade_packages.add_step(
             UnitUpgradeStep(
-                description=f"Upgrade software packages on unit {unit.name}",
+                description=f"Upgrade software packages on unit '{unit.name}'",
                 coro=app_utils.upgrade_packages(unit.name, model, None),
             )
         )
@@ -352,7 +352,7 @@ def test_upgrade_plan_ussuri_to_victoria(model):
             ),
         ),
         PostUpgradeStep(
-            description=f"Wait for up to 1800s for model {model.name} to reach the idle state",
+            description=f"Wait for up to 1800s for model '{model.name}' to reach the idle state",
             parallel=False,
             coro=model.wait_for_active_idle(1800, apps=None),
         ),
@@ -400,7 +400,7 @@ def test_upgrade_plan_ussuri_to_victoria_ch_migration(model):
         workload_version="17.1.0",
     )
     expected_plan = ApplicationUpgradePlan(
-        description=f"Upgrade plan for '{app.name}' to {target}"
+        description=f"Upgrade plan for '{app.name}' to '{target}'"
     )
     upgrade_packages = PreUpgradeStep(
         description=f"Upgrade software packages of '{app.name}' from the current APT repositories",
@@ -409,7 +409,7 @@ def test_upgrade_plan_ussuri_to_victoria_ch_migration(model):
     for unit in app.units.values():
         upgrade_packages.add_step(
             UnitUpgradeStep(
-                description=f"Upgrade software packages on unit {unit.name}",
+                description=f"Upgrade software packages on unit '{unit.name}'",
                 coro=app_utils.upgrade_packages(unit.name, model, None),
             )
         )
@@ -442,7 +442,7 @@ def test_upgrade_plan_ussuri_to_victoria_ch_migration(model):
             ),
         ),
         PostUpgradeStep(
-            description=f"Wait for up to 1800s for model {model.name} to reach the idle state",
+            description=f"Wait for up to 1800s for model '{model.name}' to reach the idle state",
             parallel=False,
             coro=model.wait_for_active_idle(1800, apps=None),
         ),
@@ -493,7 +493,7 @@ def test_upgrade_plan_channel_on_next_os_release(model):
         workload_version="17.1.0",
     )
     expected_plan = ApplicationUpgradePlan(
-        description=f"Upgrade plan for '{app.name}' to {target}"
+        description=f"Upgrade plan for '{app.name}' to '{target}'"
     )
     # no sub-step for refresh current channel or next channel
     upgrade_packages = PreUpgradeStep(
@@ -503,7 +503,7 @@ def test_upgrade_plan_channel_on_next_os_release(model):
     for unit in app.units.values():
         upgrade_packages.add_step(
             UnitUpgradeStep(
-                description=f"Upgrade software packages on unit {unit.name}",
+                description=f"Upgrade software packages on unit '{unit.name}'",
                 coro=app_utils.upgrade_packages(unit.name, model, None),
             )
         )
@@ -526,7 +526,7 @@ def test_upgrade_plan_channel_on_next_os_release(model):
             ),
         ),
         PostUpgradeStep(
-            description=f"Wait for up to 1800s for model {model.name} to reach the idle state",
+            description=f"Wait for up to 1800s for model '{model.name}' to reach the idle state",
             parallel=False,
             coro=model.wait_for_active_idle(1800, apps=None),
         ),
@@ -577,7 +577,7 @@ def test_upgrade_plan_origin_already_on_next_openstack_release(model):
         workload_version="17.1.0",
     )
     expected_plan = ApplicationUpgradePlan(
-        description=f"Upgrade plan for '{app.name}' to {target}"
+        description=f"Upgrade plan for '{app.name}' to '{target}'"
     )
     upgrade_packages = PreUpgradeStep(
         description=f"Upgrade software packages of '{app.name}' from the current APT repositories",
@@ -586,7 +586,7 @@ def test_upgrade_plan_origin_already_on_next_openstack_release(model):
     for unit in app.units.values():
         upgrade_packages.add_step(
             UnitUpgradeStep(
-                description=f"Upgrade software packages on unit {unit.name}",
+                description=f"Upgrade software packages on unit '{unit.name}'",
                 coro=app_utils.upgrade_packages(unit.name, model, None),
             )
         )
@@ -609,7 +609,7 @@ def test_upgrade_plan_origin_already_on_next_openstack_release(model):
             coro=model.upgrade_charm(app.name, "victoria/stable"),
         ),
         PostUpgradeStep(
-            description=f"Wait for up to 1800s for model {model.name} to reach the idle state",
+            description=f"Wait for up to 1800s for model '{model.name}' to reach the idle state",
             parallel=False,
             coro=model.wait_for_active_idle(1800, apps=None),
         ),
@@ -695,7 +695,7 @@ def test_upgrade_plan_application_already_disable_action_managed(model):
         workload_version="17.1.0",
     )
     expected_plan = ApplicationUpgradePlan(
-        description=f"Upgrade plan for '{app.name}' to {target}"
+        description=f"Upgrade plan for '{app.name}' to '{target}'"
     )
     upgrade_packages = PreUpgradeStep(
         description=f"Upgrade software packages of '{app.name}' from the current APT repositories",
@@ -704,7 +704,7 @@ def test_upgrade_plan_application_already_disable_action_managed(model):
     for unit in app.units.values():
         upgrade_packages.add_step(
             UnitUpgradeStep(
-                description=f"Upgrade software packages on unit {unit.name}",
+                description=f"Upgrade software packages on unit '{unit.name}'",
                 coro=app_utils.upgrade_packages(unit.name, model, None),
             )
         )
@@ -732,7 +732,7 @@ def test_upgrade_plan_application_already_disable_action_managed(model):
             ),
         ),
         PostUpgradeStep(
-            description=f"Wait for up to 1800s for model {model.name} to reach the idle state",
+            description=f"Wait for up to 1800s for model '{model.name}' to reach the idle state",
             parallel=False,
             coro=model.wait_for_active_idle(1800, apps=None),
         ),
@@ -792,7 +792,7 @@ def test_nova_compute_get_empty_hypervisor_step(model):
     unit = units[0]
 
     expected_step = UpgradeStep(
-        description=f"Verify that unit {unit.name} has no VMs running",
+        description=f"Verify that unit '{unit.name}' has no VMs running",
         coro=nova_compute_utils.verify_empty_hypervisor_before_upgrade(unit, model),
     )
     assert app._get_empty_hypervisor_step(unit) == expected_step
@@ -843,38 +843,38 @@ def test_nova_compute_upgrade_plan(model):
     target = OpenStackRelease("victoria")
     exp_plan = dedent_plan(
         """
-    Upgrade plan for 'nova-compute' to victoria
+    Upgrade plan for 'nova-compute' to 'victoria'
         Upgrade software packages of 'nova-compute' from the current APT repositories
-            Upgrade software packages on unit nova-compute/0
-            Upgrade software packages on unit nova-compute/1
-            Upgrade software packages on unit nova-compute/2
+            Upgrade software packages on unit 'nova-compute/0'
+            Upgrade software packages on unit 'nova-compute/1'
+            Upgrade software packages on unit 'nova-compute/2'
         Refresh 'nova-compute' to the latest revision of 'ussuri/stable'
         Change charm config of 'nova-compute' 'action-managed-upgrade' to True
         Upgrade 'nova-compute' to the new channel: 'victoria/stable'
         Change charm config of 'nova-compute' 'source' to 'cloud:focal-victoria'
         Upgrade plan for units: nova-compute/0, nova-compute/1, nova-compute/2
-            Upgrade plan for unit: nova-compute/0
+            Upgrade plan for unit 'nova-compute/0'
                 Disable nova-compute scheduler from unit: 'nova-compute/0'
-                Verify that unit nova-compute/0 has no VMs running
+                Verify that unit 'nova-compute/0' has no VMs running
                 ├── Pause the unit: 'nova-compute/0'
                 ├── Upgrade the unit: 'nova-compute/0'
                 ├── Resume the unit: 'nova-compute/0'
                 Enable nova-compute scheduler from unit: 'nova-compute/0'
-            Upgrade plan for unit: nova-compute/1
+            Upgrade plan for unit 'nova-compute/1'
                 Disable nova-compute scheduler from unit: 'nova-compute/1'
-                Verify that unit nova-compute/1 has no VMs running
+                Verify that unit 'nova-compute/1' has no VMs running
                 ├── Pause the unit: 'nova-compute/1'
                 ├── Upgrade the unit: 'nova-compute/1'
                 ├── Resume the unit: 'nova-compute/1'
                 Enable nova-compute scheduler from unit: 'nova-compute/1'
-            Upgrade plan for unit: nova-compute/2
+            Upgrade plan for unit 'nova-compute/2'
                 Disable nova-compute scheduler from unit: 'nova-compute/2'
-                Verify that unit nova-compute/2 has no VMs running
+                Verify that unit 'nova-compute/2' has no VMs running
                 ├── Pause the unit: 'nova-compute/2'
                 ├── Upgrade the unit: 'nova-compute/2'
                 ├── Resume the unit: 'nova-compute/2'
                 Enable nova-compute scheduler from unit: 'nova-compute/2'
-        Wait for up to 1800s for model test_model to reach the idle state
+        Wait for up to 1800s for model 'test_model' to reach the idle state
         Verify that the workload of 'nova-compute' has been upgraded on units: nova-compute/0, nova-compute/1, nova-compute/2
     """  # noqa: E501 line too long
     )
@@ -912,22 +912,22 @@ def test_nova_compute_upgrade_plan_single_unit(model):
     target = OpenStackRelease("victoria")
     exp_plan = dedent_plan(
         """
-    Upgrade plan for 'nova-compute' to victoria
+    Upgrade plan for 'nova-compute' to 'victoria'
         Upgrade software packages of 'nova-compute' from the current APT repositories
-            Upgrade software packages on unit nova-compute/0
+            Upgrade software packages on unit 'nova-compute/0'
         Refresh 'nova-compute' to the latest revision of 'ussuri/stable'
         Change charm config of 'nova-compute' 'action-managed-upgrade' to True
         Upgrade 'nova-compute' to the new channel: 'victoria/stable'
         Change charm config of 'nova-compute' 'source' to 'cloud:focal-victoria'
         Upgrade plan for units: nova-compute/0
-            Upgrade plan for unit: nova-compute/0
+            Upgrade plan for unit 'nova-compute/0'
                 Disable nova-compute scheduler from unit: 'nova-compute/0'
-                Verify that unit nova-compute/0 has no VMs running
+                Verify that unit 'nova-compute/0' has no VMs running
                 ├── Pause the unit: 'nova-compute/0'
                 ├── Upgrade the unit: 'nova-compute/0'
                 ├── Resume the unit: 'nova-compute/0'
                 Enable nova-compute scheduler from unit: 'nova-compute/0'
-        Wait for up to 1800s for model test_model to reach the idle state
+        Wait for up to 1800s for model 'test_model' to reach the idle state
         Verify that the workload of 'nova-compute' has been upgraded on units: nova-compute/0
     """
     )
@@ -965,15 +965,15 @@ def test_cinder_upgrade_plan(model):
     target = OpenStackRelease("victoria")
     exp_plan = dedent_plan(
         """
-    Upgrade plan for 'cinder' to victoria
+    Upgrade plan for 'cinder' to 'victoria'
         Upgrade software packages of 'cinder' from the current APT repositories
-            Upgrade software packages on unit cinder/0
-            Upgrade software packages on unit cinder/1
-            Upgrade software packages on unit cinder/2
+            Upgrade software packages on unit 'cinder/0'
+            Upgrade software packages on unit 'cinder/1'
+            Upgrade software packages on unit 'cinder/2'
         Refresh 'cinder' to the latest revision of 'ussuri/stable'
         Upgrade 'cinder' to the new channel: 'victoria/stable'
         Change charm config of 'cinder' 'openstack-origin' to 'cloud:focal-victoria'
-        Wait for up to 300s for app cinder to reach the idle state
+        Wait for up to 300s for app 'cinder' to reach the idle state
         Verify that the workload of 'cinder' has been upgraded on units: \
 cinder/0, cinder/1, cinder/2
     """
@@ -1015,19 +1015,19 @@ def test_cinder_upgrade_plan_single_unit(model):
     target = OpenStackRelease("victoria")
     exp_plan = dedent_plan(
         """
-    Upgrade plan for 'cinder' to victoria
+    Upgrade plan for 'cinder' to 'victoria'
         Upgrade software packages of 'cinder' from the current APT repositories
-            Upgrade software packages on unit cinder/0
+            Upgrade software packages on unit 'cinder/0'
         Refresh 'cinder' to the latest revision of 'ussuri/stable'
         Change charm config of 'cinder' 'action-managed-upgrade' to True
         Upgrade 'cinder' to the new channel: 'victoria/stable'
         Change charm config of 'cinder' 'openstack-origin' to 'cloud:focal-victoria'
         Upgrade plan for units: cinder/0
-            Upgrade plan for unit: cinder/0
+            Upgrade plan for unit 'cinder/0'
                 Pause the unit: 'cinder/0'
                 Upgrade the unit: 'cinder/0'
                 Resume the unit: 'cinder/0'
-        Wait for up to 300s for app cinder to reach the idle state
+        Wait for up to 300s for app 'cinder' to reach the idle state
         Verify that the workload of 'cinder' has been upgraded on units: cinder/0
     """
     )

--- a/tests/unit/apps/test_core.py
+++ b/tests/unit/apps/test_core.py
@@ -352,13 +352,13 @@ def test_upgrade_plan_ussuri_to_victoria(model):
             ),
         ),
         PostUpgradeStep(
-            description=f"Wait 1800s for model {model.name} to reach the idle state.",
+            description=f"Wait for up to 1800s for model {model.name} to reach the idle state",
             parallel=False,
             coro=model.wait_for_active_idle(1800, apps=None),
         ),
         PostUpgradeStep(
             description=(
-                f"Check if the workload of '{app.name}' has been upgraded on units: "
+                f"Verify that the workload of '{app.name}' has been upgraded on units: "
                 f"{', '.join([unit for unit in app.units.keys()])}"
             ),
             parallel=False,
@@ -417,7 +417,7 @@ def test_upgrade_plan_ussuri_to_victoria_ch_migration(model):
     upgrade_steps = [
         upgrade_packages,
         PreUpgradeStep(
-            description=f"Migration of '{app.name}' from charmstore to charmhub",
+            description=f"Migrate '{app.name}' from charmstore to charmhub",
             parallel=False,
             coro=model.upgrade_charm(app.name, "ussuri/stable", switch="ch:keystone"),
         ),
@@ -442,13 +442,13 @@ def test_upgrade_plan_ussuri_to_victoria_ch_migration(model):
             ),
         ),
         PostUpgradeStep(
-            description=f"Wait 1800s for model {model.name} to reach the idle state.",
+            description=f"Wait for up to 1800s for model {model.name} to reach the idle state",
             parallel=False,
             coro=model.wait_for_active_idle(1800, apps=None),
         ),
         PostUpgradeStep(
             description=(
-                f"Check if the workload of '{app.name}' has been upgraded on units: "
+                f"Verify that the workload of '{app.name}' has been upgraded on units: "
                 f"{', '.join([unit for unit in app.units.keys()])}"
             ),
             parallel=False,
@@ -526,13 +526,13 @@ def test_upgrade_plan_channel_on_next_os_release(model):
             ),
         ),
         PostUpgradeStep(
-            description=f"Wait 1800s for model {model.name} to reach the idle state.",
+            description=f"Wait for up to 1800s for model {model.name} to reach the idle state",
             parallel=False,
             coro=model.wait_for_active_idle(1800, apps=None),
         ),
         PostUpgradeStep(
             description=(
-                f"Check if the workload of '{app.name}' has been upgraded on units: "
+                f"Verify that the workload of '{app.name}' has been upgraded on units: "
                 f"{', '.join([unit for unit in app.units.keys()])}"
             ),
             parallel=False,
@@ -609,13 +609,13 @@ def test_upgrade_plan_origin_already_on_next_openstack_release(model):
             coro=model.upgrade_charm(app.name, "victoria/stable"),
         ),
         PostUpgradeStep(
-            description=f"Wait 1800s for model {model.name} to reach the idle state.",
+            description=f"Wait for up to 1800s for model {model.name} to reach the idle state",
             parallel=False,
             coro=model.wait_for_active_idle(1800, apps=None),
         ),
         PostUpgradeStep(
             description=(
-                f"Check if the workload of '{app.name}' has been upgraded on units: "
+                f"Verify that the workload of '{app.name}' has been upgraded on units: "
                 f"{', '.join([unit for unit in app.units.keys()])}"
             ),
             parallel=False,
@@ -732,13 +732,13 @@ def test_upgrade_plan_application_already_disable_action_managed(model):
             ),
         ),
         PostUpgradeStep(
-            description=f"Wait 1800s for model {model.name} to reach the idle state.",
+            description=f"Wait for up to 1800s for model {model.name} to reach the idle state",
             parallel=False,
             coro=model.wait_for_active_idle(1800, apps=None),
         ),
         PostUpgradeStep(
             description=(
-                f"Check if the workload of '{app.name}' has been upgraded on units: "
+                f"Verify that the workload of '{app.name}' has been upgraded on units: "
                 f"{', '.join([unit for unit in app.units.keys()])}"
             ),
             parallel=False,
@@ -792,7 +792,7 @@ def test_nova_compute_get_empty_hypervisor_step(model):
     unit = units[0]
 
     expected_step = UpgradeStep(
-        description=f"Check if unit {unit.name} has no VMs running before upgrading.",
+        description=f"Verify that unit {unit.name} has no VMs running",
         coro=nova_compute_utils.verify_empty_hypervisor_before_upgrade(unit, model),
     )
     assert app._get_empty_hypervisor_step(unit) == expected_step
@@ -804,7 +804,7 @@ def test_nova_compute_get_enable_scheduler_step(model):
     unit = units[0]
 
     expected_step = UpgradeStep(
-        description=f"Enable nova-compute scheduler from unit: '{unit.name}'.",
+        description=f"Enable nova-compute scheduler from unit: '{unit.name}'",
         coro=model.run_action(unit_name=unit.name, action_name="enable", raise_on_failure=True),
     )
     assert app._get_enable_scheduler_step(unit) == expected_step
@@ -816,7 +816,7 @@ def test_nova_compute_get_disable_scheduler_step(model):
     unit = units[0]
 
     expected_step = UpgradeStep(
-        description=f"Disable nova-compute scheduler from unit: '{unit.name}'.",
+        description=f"Disable nova-compute scheduler from unit: '{unit.name}'",
         coro=model.run_action(unit_name=unit.name, action_name="disable", raise_on_failure=True),
     )
     assert app._get_disable_scheduler_step(unit) == expected_step
@@ -854,28 +854,28 @@ def test_nova_compute_upgrade_plan(model):
         Change charm config of 'nova-compute' 'source' to 'cloud:focal-victoria'
         Upgrade plan for units: nova-compute/0, nova-compute/1, nova-compute/2
             Upgrade plan for unit: nova-compute/0
-                Disable nova-compute scheduler from unit: 'nova-compute/0'.
-                Check if unit nova-compute/0 has no VMs running before upgrading.
-                ├── Pause the unit: 'nova-compute/0'.
-                ├── Upgrade the unit: 'nova-compute/0'.
-                ├── Resume the unit: 'nova-compute/0'.
-                Enable nova-compute scheduler from unit: 'nova-compute/0'.
+                Disable nova-compute scheduler from unit: 'nova-compute/0'
+                Verify that unit nova-compute/0 has no VMs running
+                ├── Pause the unit: 'nova-compute/0'
+                ├── Upgrade the unit: 'nova-compute/0'
+                ├── Resume the unit: 'nova-compute/0'
+                Enable nova-compute scheduler from unit: 'nova-compute/0'
             Upgrade plan for unit: nova-compute/1
-                Disable nova-compute scheduler from unit: 'nova-compute/1'.
-                Check if unit nova-compute/1 has no VMs running before upgrading.
-                ├── Pause the unit: 'nova-compute/1'.
-                ├── Upgrade the unit: 'nova-compute/1'.
-                ├── Resume the unit: 'nova-compute/1'.
-                Enable nova-compute scheduler from unit: 'nova-compute/1'.
+                Disable nova-compute scheduler from unit: 'nova-compute/1'
+                Verify that unit nova-compute/1 has no VMs running
+                ├── Pause the unit: 'nova-compute/1'
+                ├── Upgrade the unit: 'nova-compute/1'
+                ├── Resume the unit: 'nova-compute/1'
+                Enable nova-compute scheduler from unit: 'nova-compute/1'
             Upgrade plan for unit: nova-compute/2
-                Disable nova-compute scheduler from unit: 'nova-compute/2'.
-                Check if unit nova-compute/2 has no VMs running before upgrading.
-                ├── Pause the unit: 'nova-compute/2'.
-                ├── Upgrade the unit: 'nova-compute/2'.
-                ├── Resume the unit: 'nova-compute/2'.
-                Enable nova-compute scheduler from unit: 'nova-compute/2'.
-        Wait 1800s for model test_model to reach the idle state.
-        Check if the workload of 'nova-compute' has been upgraded on units: nova-compute/0, nova-compute/1, nova-compute/2
+                Disable nova-compute scheduler from unit: 'nova-compute/2'
+                Verify that unit nova-compute/2 has no VMs running
+                ├── Pause the unit: 'nova-compute/2'
+                ├── Upgrade the unit: 'nova-compute/2'
+                ├── Resume the unit: 'nova-compute/2'
+                Enable nova-compute scheduler from unit: 'nova-compute/2'
+        Wait for up to 1800s for model test_model to reach the idle state
+        Verify that the workload of 'nova-compute' has been upgraded on units: nova-compute/0, nova-compute/1, nova-compute/2
     """  # noqa: E501 line too long
     )
     machines = {f"{i}": generate_cou_machine(f"{i}", f"az-{i}") for i in range(3)}
@@ -921,14 +921,14 @@ def test_nova_compute_upgrade_plan_single_unit(model):
         Change charm config of 'nova-compute' 'source' to 'cloud:focal-victoria'
         Upgrade plan for units: nova-compute/0
             Upgrade plan for unit: nova-compute/0
-                Disable nova-compute scheduler from unit: 'nova-compute/0'.
-                Check if unit nova-compute/0 has no VMs running before upgrading.
-                ├── Pause the unit: 'nova-compute/0'.
-                ├── Upgrade the unit: 'nova-compute/0'.
-                ├── Resume the unit: 'nova-compute/0'.
-                Enable nova-compute scheduler from unit: 'nova-compute/0'.
-        Wait 1800s for model test_model to reach the idle state.
-        Check if the workload of 'nova-compute' has been upgraded on units: nova-compute/0
+                Disable nova-compute scheduler from unit: 'nova-compute/0'
+                Verify that unit nova-compute/0 has no VMs running
+                ├── Pause the unit: 'nova-compute/0'
+                ├── Upgrade the unit: 'nova-compute/0'
+                ├── Resume the unit: 'nova-compute/0'
+                Enable nova-compute scheduler from unit: 'nova-compute/0'
+        Wait for up to 1800s for model test_model to reach the idle state
+        Verify that the workload of 'nova-compute' has been upgraded on units: nova-compute/0
     """
     )
     machines = {f"{i}": generate_cou_machine(f"{i}", f"az-{i}") for i in range(3)}
@@ -973,8 +973,9 @@ def test_cinder_upgrade_plan(model):
         Refresh 'cinder' to the latest revision of 'ussuri/stable'
         Upgrade 'cinder' to the new channel: 'victoria/stable'
         Change charm config of 'cinder' 'openstack-origin' to 'cloud:focal-victoria'
-        Wait 300s for app cinder to reach the idle state.
-        Check if the workload of 'cinder' has been upgraded on units: cinder/0, cinder/1, cinder/2
+        Wait for up to 300s for app cinder to reach the idle state
+        Verify that the workload of 'cinder' has been upgraded on units: \
+cinder/0, cinder/1, cinder/2
     """
     )
     machines = {f"{i}": generate_cou_machine(f"{i}", f"az-{i}") for i in range(3)}
@@ -1023,11 +1024,11 @@ def test_cinder_upgrade_plan_single_unit(model):
         Change charm config of 'cinder' 'openstack-origin' to 'cloud:focal-victoria'
         Upgrade plan for units: cinder/0
             Upgrade plan for unit: cinder/0
-                Pause the unit: 'cinder/0'.
-                Upgrade the unit: 'cinder/0'.
-                Resume the unit: 'cinder/0'.
-        Wait 300s for app cinder to reach the idle state.
-        Check if the workload of 'cinder' has been upgraded on units: cinder/0
+                Pause the unit: 'cinder/0'
+                Upgrade the unit: 'cinder/0'
+                Resume the unit: 'cinder/0'
+        Wait for up to 300s for app cinder to reach the idle state
+        Verify that the workload of 'cinder' has been upgraded on units: cinder/0
     """
     )
     machines = {f"{i}": generate_cou_machine(f"{i}", f"az-{i}") for i in range(3)}

--- a/tests/unit/apps/test_subordinate.py
+++ b/tests/unit/apps/test_subordinate.py
@@ -181,7 +181,7 @@ def test_generate_plan_ch_migration(model, channel):
     )
     upgrade_steps = [
         PreUpgradeStep(
-            description=f"Migration of '{app.name}' from charmstore to charmhub",
+            description=f"Migrate '{app.name}' from charmstore to charmhub",
             parallel=False,
             coro=model.upgrade_charm(app.name, "ussuri/stable", switch="ch:keystone-ldap"),
         ),

--- a/tests/unit/apps/test_subordinate.py
+++ b/tests/unit/apps/test_subordinate.py
@@ -68,7 +68,7 @@ def test_generate_upgrade_plan(model):
         workload_version="18.1.0",
     )
     expected_plan = ApplicationUpgradePlan(
-        description=f"Upgrade plan for '{app.name}' to {target}"
+        description=f"Upgrade plan for '{app.name}' to '{target}'"
     )
     upgrade_steps = [
         PreUpgradeStep(
@@ -177,7 +177,7 @@ def test_generate_plan_ch_migration(model, channel):
         workload_version="18.1.0",
     )
     expected_plan = ApplicationUpgradePlan(
-        description=f"Upgrade plan for '{app.name}' to {target}"
+        description=f"Upgrade plan for '{app.name}' to '{target}'"
     )
     upgrade_steps = [
         PreUpgradeStep(
@@ -224,7 +224,9 @@ def test_generate_plan_from_to(model, from_os, to_os):
         units={},
         workload_version="18.1.0",
     )
-    expected_plan = ApplicationUpgradePlan(description=f"Upgrade plan for '{app.name}' to {to_os}")
+    expected_plan = ApplicationUpgradePlan(
+        description=f"Upgrade plan for '{app.name}' to '{to_os}'"
+    )
     upgrade_steps = [
         PreUpgradeStep(
             description=f"Refresh '{app.name}' to the latest revision of '{from_os}/stable'",
@@ -272,7 +274,7 @@ def test_generate_plan_in_same_version(model, from_to):
         workload_version="18.1.0",
     )
     expected_plan = ApplicationUpgradePlan(
-        description=f"Upgrade plan for '{app.name}' to {from_to}"
+        description=f"Upgrade plan for '{app.name}' to '{from_to}'"
     )
     upgrade_steps = [
         PreUpgradeStep(

--- a/tests/unit/steps/test_hypervisor.py
+++ b/tests/unit/steps/test_hypervisor.py
@@ -193,24 +193,24 @@ def test_hypervisor_upgrade_plan(model):
             Change charm config of 'cinder' 'openstack-origin' to 'cloud:focal-victoria'
             Upgrade plan for units: cinder/0
                 Upgrade plan for unit: cinder/0
-                    Pause the unit: 'cinder/0'.
-                    Upgrade the unit: 'cinder/0'.
-                    Resume the unit: 'cinder/0'.
+                    Pause the unit: 'cinder/0'
+                    Upgrade the unit: 'cinder/0'
+                    Resume the unit: 'cinder/0'
             Change charm config of 'nova-compute' 'action-managed-upgrade' to True
             Upgrade 'nova-compute' to the new channel: 'victoria/stable'
             Change charm config of 'nova-compute' 'source' to 'cloud:focal-victoria'
             Upgrade plan for units: nova-compute/0
                 Upgrade plan for unit: nova-compute/0
-                    Disable nova-compute scheduler from unit: 'nova-compute/0'.
-                    Check if unit nova-compute/0 has no VMs running before upgrading.
-                    ├── Pause the unit: 'nova-compute/0'.
-                    ├── Upgrade the unit: 'nova-compute/0'.
-                    ├── Resume the unit: 'nova-compute/0'.
-                    Enable nova-compute scheduler from unit: 'nova-compute/0'.
-            Wait 1800s for model test_model to reach the idle state.
-            Check if the workload of 'nova-compute' has been upgraded on units: nova-compute/0
-            Wait 300s for app cinder to reach the idle state.
-            Check if the workload of 'cinder' has been upgraded on units: cinder/0
+                    Disable nova-compute scheduler from unit: 'nova-compute/0'
+                    Verify that unit nova-compute/0 has no VMs running
+                    ├── Pause the unit: 'nova-compute/0'
+                    ├── Upgrade the unit: 'nova-compute/0'
+                    ├── Resume the unit: 'nova-compute/0'
+                    Enable nova-compute scheduler from unit: 'nova-compute/0'
+            Wait for up to 1800s for model test_model to reach the idle state
+            Verify that the workload of 'nova-compute' has been upgraded on units: nova-compute/0
+            Wait for up to 300s for app cinder to reach the idle state
+            Verify that the workload of 'cinder' has been upgraded on units: cinder/0
         Upgrade plan for 'az-1' to victoria
             Upgrade software packages of 'nova-compute' from the current APT repositories
                 Upgrade software packages on unit nova-compute/1
@@ -220,14 +220,14 @@ def test_hypervisor_upgrade_plan(model):
             Change charm config of 'nova-compute' 'source' to 'cloud:focal-victoria'
             Upgrade plan for units: nova-compute/1
                 Upgrade plan for unit: nova-compute/1
-                    Disable nova-compute scheduler from unit: 'nova-compute/1'.
-                    Check if unit nova-compute/1 has no VMs running before upgrading.
-                    ├── Pause the unit: 'nova-compute/1'.
-                    ├── Upgrade the unit: 'nova-compute/1'.
-                    ├── Resume the unit: 'nova-compute/1'.
-                    Enable nova-compute scheduler from unit: 'nova-compute/1'.
-            Wait 1800s for model test_model to reach the idle state.
-            Check if the workload of 'nova-compute' has been upgraded on units: nova-compute/1
+                    Disable nova-compute scheduler from unit: 'nova-compute/1'
+                    Verify that unit nova-compute/1 has no VMs running
+                    ├── Pause the unit: 'nova-compute/1'
+                    ├── Upgrade the unit: 'nova-compute/1'
+                    ├── Resume the unit: 'nova-compute/1'
+                    Enable nova-compute scheduler from unit: 'nova-compute/1'
+            Wait for up to 1800s for model test_model to reach the idle state
+            Verify that the workload of 'nova-compute' has been upgraded on units: nova-compute/1
         Upgrade plan for 'az-2' to victoria
             Upgrade software packages of 'nova-compute' from the current APT repositories
                 Upgrade software packages on unit nova-compute/2
@@ -237,14 +237,14 @@ def test_hypervisor_upgrade_plan(model):
             Change charm config of 'nova-compute' 'source' to 'cloud:focal-victoria'
             Upgrade plan for units: nova-compute/2
                 Upgrade plan for unit: nova-compute/2
-                    Disable nova-compute scheduler from unit: 'nova-compute/2'.
-                    Check if unit nova-compute/2 has no VMs running before upgrading.
-                    ├── Pause the unit: 'nova-compute/2'.
-                    ├── Upgrade the unit: 'nova-compute/2'.
-                    ├── Resume the unit: 'nova-compute/2'.
-                    Enable nova-compute scheduler from unit: 'nova-compute/2'.
-            Wait 1800s for model test_model to reach the idle state.
-            Check if the workload of 'nova-compute' has been upgraded on units: nova-compute/2
+                    Disable nova-compute scheduler from unit: 'nova-compute/2'
+                    Verify that unit nova-compute/2 has no VMs running
+                    ├── Pause the unit: 'nova-compute/2'
+                    ├── Upgrade the unit: 'nova-compute/2'
+                    ├── Resume the unit: 'nova-compute/2'
+                    Enable nova-compute scheduler from unit: 'nova-compute/2'
+            Wait for up to 1800s for model test_model to reach the idle state
+            Verify that the workload of 'nova-compute' has been upgraded on units: nova-compute/2
     """
     )
     machines = {f"{i}": generate_cou_machine(f"{i}", f"az-{i}") for i in range(3)}
@@ -320,24 +320,24 @@ def test_hypervisor_upgrade_plan_single_machine(model):
             Change charm config of 'cinder' 'openstack-origin' to 'cloud:focal-victoria'
             Upgrade plan for units: cinder/0
                 Upgrade plan for unit: cinder/0
-                    Pause the unit: 'cinder/0'.
-                    Upgrade the unit: 'cinder/0'.
-                    Resume the unit: 'cinder/0'.
+                    Pause the unit: 'cinder/0'
+                    Upgrade the unit: 'cinder/0'
+                    Resume the unit: 'cinder/0'
             Change charm config of 'nova-compute' 'action-managed-upgrade' to True
             Upgrade 'nova-compute' to the new channel: 'victoria/stable'
             Change charm config of 'nova-compute' 'source' to 'cloud:focal-victoria'
             Upgrade plan for units: nova-compute/0
                 Upgrade plan for unit: nova-compute/0
-                    Disable nova-compute scheduler from unit: 'nova-compute/0'.
-                    Check if unit nova-compute/0 has no VMs running before upgrading.
-                    ├── Pause the unit: 'nova-compute/0'.
-                    ├── Upgrade the unit: 'nova-compute/0'.
-                    ├── Resume the unit: 'nova-compute/0'.
-                    Enable nova-compute scheduler from unit: 'nova-compute/0'.
-            Wait 1800s for model test_model to reach the idle state.
-            Check if the workload of 'nova-compute' has been upgraded on units: nova-compute/0
-            Wait 300s for app cinder to reach the idle state.
-            Check if the workload of 'cinder' has been upgraded on units: cinder/0
+                    Disable nova-compute scheduler from unit: 'nova-compute/0'
+                    Verify that unit nova-compute/0 has no VMs running
+                    ├── Pause the unit: 'nova-compute/0'
+                    ├── Upgrade the unit: 'nova-compute/0'
+                    ├── Resume the unit: 'nova-compute/0'
+                    Enable nova-compute scheduler from unit: 'nova-compute/0'
+            Wait for up to 1800s for model test_model to reach the idle state
+            Verify that the workload of 'nova-compute' has been upgraded on units: nova-compute/0
+            Wait for up to 300s for app cinder to reach the idle state
+            Verify that the workload of 'cinder' has been upgraded on units: cinder/0
     """
     )
     machines = {f"{i}": generate_cou_machine(f"{i}", f"az-{i}") for i in range(3)}

--- a/tests/unit/steps/test_hypervisor.py
+++ b/tests/unit/steps/test_hypervisor.py
@@ -181,18 +181,18 @@ def test_hypervisor_upgrade_plan(model):
     exp_plan = dedent_plan(
         """
     Upgrading all applications deployed on machines with hypervisor.
-        Upgrade plan for 'az-0' to victoria
+        Upgrade plan for 'az-0' to 'victoria'
             Upgrade software packages of 'cinder' from the current APT repositories
-                Upgrade software packages on unit cinder/0
+                Upgrade software packages on unit 'cinder/0'
             Refresh 'cinder' to the latest revision of 'ussuri/stable'
             Upgrade software packages of 'nova-compute' from the current APT repositories
-                Upgrade software packages on unit nova-compute/0
+                Upgrade software packages on unit 'nova-compute/0'
             Refresh 'nova-compute' to the latest revision of 'ussuri/stable'
             Change charm config of 'cinder' 'action-managed-upgrade' to True
             Upgrade 'cinder' to the new channel: 'victoria/stable'
             Change charm config of 'cinder' 'openstack-origin' to 'cloud:focal-victoria'
             Upgrade plan for units: cinder/0
-                Upgrade plan for unit: cinder/0
+                Upgrade plan for unit 'cinder/0'
                     Pause the unit: 'cinder/0'
                     Upgrade the unit: 'cinder/0'
                     Resume the unit: 'cinder/0'
@@ -200,50 +200,50 @@ def test_hypervisor_upgrade_plan(model):
             Upgrade 'nova-compute' to the new channel: 'victoria/stable'
             Change charm config of 'nova-compute' 'source' to 'cloud:focal-victoria'
             Upgrade plan for units: nova-compute/0
-                Upgrade plan for unit: nova-compute/0
+                Upgrade plan for unit 'nova-compute/0'
                     Disable nova-compute scheduler from unit: 'nova-compute/0'
-                    Verify that unit nova-compute/0 has no VMs running
+                    Verify that unit 'nova-compute/0' has no VMs running
                     ├── Pause the unit: 'nova-compute/0'
                     ├── Upgrade the unit: 'nova-compute/0'
                     ├── Resume the unit: 'nova-compute/0'
                     Enable nova-compute scheduler from unit: 'nova-compute/0'
-            Wait for up to 1800s for model test_model to reach the idle state
+            Wait for up to 1800s for model 'test_model' to reach the idle state
             Verify that the workload of 'nova-compute' has been upgraded on units: nova-compute/0
-            Wait for up to 300s for app cinder to reach the idle state
+            Wait for up to 300s for app 'cinder' to reach the idle state
             Verify that the workload of 'cinder' has been upgraded on units: cinder/0
-        Upgrade plan for 'az-1' to victoria
+        Upgrade plan for 'az-1' to 'victoria'
             Upgrade software packages of 'nova-compute' from the current APT repositories
-                Upgrade software packages on unit nova-compute/1
+                Upgrade software packages on unit 'nova-compute/1'
             Refresh 'nova-compute' to the latest revision of 'ussuri/stable'
             Change charm config of 'nova-compute' 'action-managed-upgrade' to True
             Upgrade 'nova-compute' to the new channel: 'victoria/stable'
             Change charm config of 'nova-compute' 'source' to 'cloud:focal-victoria'
             Upgrade plan for units: nova-compute/1
-                Upgrade plan for unit: nova-compute/1
+                Upgrade plan for unit 'nova-compute/1'
                     Disable nova-compute scheduler from unit: 'nova-compute/1'
-                    Verify that unit nova-compute/1 has no VMs running
+                    Verify that unit 'nova-compute/1' has no VMs running
                     ├── Pause the unit: 'nova-compute/1'
                     ├── Upgrade the unit: 'nova-compute/1'
                     ├── Resume the unit: 'nova-compute/1'
                     Enable nova-compute scheduler from unit: 'nova-compute/1'
-            Wait for up to 1800s for model test_model to reach the idle state
+            Wait for up to 1800s for model 'test_model' to reach the idle state
             Verify that the workload of 'nova-compute' has been upgraded on units: nova-compute/1
-        Upgrade plan for 'az-2' to victoria
+        Upgrade plan for 'az-2' to 'victoria'
             Upgrade software packages of 'nova-compute' from the current APT repositories
-                Upgrade software packages on unit nova-compute/2
+                Upgrade software packages on unit 'nova-compute/2'
             Refresh 'nova-compute' to the latest revision of 'ussuri/stable'
             Change charm config of 'nova-compute' 'action-managed-upgrade' to True
             Upgrade 'nova-compute' to the new channel: 'victoria/stable'
             Change charm config of 'nova-compute' 'source' to 'cloud:focal-victoria'
             Upgrade plan for units: nova-compute/2
-                Upgrade plan for unit: nova-compute/2
+                Upgrade plan for unit 'nova-compute/2'
                     Disable nova-compute scheduler from unit: 'nova-compute/2'
-                    Verify that unit nova-compute/2 has no VMs running
+                    Verify that unit 'nova-compute/2' has no VMs running
                     ├── Pause the unit: 'nova-compute/2'
                     ├── Upgrade the unit: 'nova-compute/2'
                     ├── Resume the unit: 'nova-compute/2'
                     Enable nova-compute scheduler from unit: 'nova-compute/2'
-            Wait for up to 1800s for model test_model to reach the idle state
+            Wait for up to 1800s for model 'test_model' to reach the idle state
             Verify that the workload of 'nova-compute' has been upgraded on units: nova-compute/2
     """
     )
@@ -308,18 +308,18 @@ def test_hypervisor_upgrade_plan_single_machine(model):
     exp_plan = dedent_plan(
         """
     Upgrading all applications deployed on machines with hypervisor.
-        Upgrade plan for 'az-0' to victoria
+        Upgrade plan for 'az-0' to 'victoria'
             Upgrade software packages of 'cinder' from the current APT repositories
-                Upgrade software packages on unit cinder/0
+                Upgrade software packages on unit 'cinder/0'
             Refresh 'cinder' to the latest revision of 'ussuri/stable'
             Upgrade software packages of 'nova-compute' from the current APT repositories
-                Upgrade software packages on unit nova-compute/0
+                Upgrade software packages on unit 'nova-compute/0'
             Refresh 'nova-compute' to the latest revision of 'ussuri/stable'
             Change charm config of 'cinder' 'action-managed-upgrade' to True
             Upgrade 'cinder' to the new channel: 'victoria/stable'
             Change charm config of 'cinder' 'openstack-origin' to 'cloud:focal-victoria'
             Upgrade plan for units: cinder/0
-                Upgrade plan for unit: cinder/0
+                Upgrade plan for unit 'cinder/0'
                     Pause the unit: 'cinder/0'
                     Upgrade the unit: 'cinder/0'
                     Resume the unit: 'cinder/0'
@@ -327,16 +327,16 @@ def test_hypervisor_upgrade_plan_single_machine(model):
             Upgrade 'nova-compute' to the new channel: 'victoria/stable'
             Change charm config of 'nova-compute' 'source' to 'cloud:focal-victoria'
             Upgrade plan for units: nova-compute/0
-                Upgrade plan for unit: nova-compute/0
+                Upgrade plan for unit 'nova-compute/0'
                     Disable nova-compute scheduler from unit: 'nova-compute/0'
-                    Verify that unit nova-compute/0 has no VMs running
+                    Verify that unit 'nova-compute/0' has no VMs running
                     ├── Pause the unit: 'nova-compute/0'
                     ├── Upgrade the unit: 'nova-compute/0'
                     ├── Resume the unit: 'nova-compute/0'
                     Enable nova-compute scheduler from unit: 'nova-compute/0'
-            Wait for up to 1800s for model test_model to reach the idle state
+            Wait for up to 1800s for model 'test_model' to reach the idle state
             Verify that the workload of 'nova-compute' has been upgraded on units: nova-compute/0
-            Wait for up to 300s for app cinder to reach the idle state
+            Wait for up to 300s for app 'cinder' to reach the idle state
             Verify that the workload of 'cinder' has been upgraded on units: cinder/0
     """
     )

--- a/tests/unit/steps/test_steps_plan.py
+++ b/tests/unit/steps/test_steps_plan.py
@@ -54,13 +54,13 @@ def generate_expected_upgrade_plan_principal(app, target, model):
     if app.charm in ["rabbitmq-server", "ceph-mon", "keystone"]:
         # apps waiting for whole model
         wait_step = PostUpgradeStep(
-            description=f"Wait 1800s for model {model.name} to reach the idle state.",
+            description=f"Wait for up to 1800s for model {model.name} to reach the idle state",
             parallel=False,
             coro=model.wait_for_active_idle(1800, apps=None),
         )
     else:
         wait_step = PostUpgradeStep(
-            description=f"Wait 300s for app {app.name} to reach the idle state.",
+            description=f"Wait for up to 300s for app {app.name} to reach the idle state",
             parallel=False,
             coro=model.wait_for_active_idle(300, apps=[app.name]),
         )
@@ -110,7 +110,7 @@ def generate_expected_upgrade_plan_principal(app, target, model):
         wait_step,
         PostUpgradeStep(
             description=(
-                f"Check if the workload of '{app.name}' has been upgraded on units: "
+                f"Verify that the workload of '{app.name}' has been upgraded on units: "
                 f"{', '.join([unit for unit in app.units.keys()])}"
             ),
             parallel=False,
@@ -234,7 +234,7 @@ async def test_generate_plan(mock_generate_data_plane, model, cli_args):
     )
     expected_plan.add_step(
         PreUpgradeStep(
-            description="Backup mysql databases",
+            description="Back up MySQL databases",
             parallel=False,
             coro=backup(model),
         )
@@ -739,7 +739,7 @@ def test_get_pre_upgrade_steps(cli_backup, cli_args, model):
     if cli_backup:
         expected_steps.append(
             PreUpgradeStep(
-                description="Backup mysql databases",
+                description="Back up MySQL databases",
                 parallel=False,
                 coro=backup(model),
             )
@@ -815,7 +815,8 @@ def test_get_ceph_mon_post_upgrade_steps_multiple(model):
 
     exp_steps = 2 * [
         PostUpgradeStep(
-            "Ensure the 'require-osd-release' option in 'ceph-mon' matches the 'ceph-osd' version",
+            "Ensure that the 'require-osd-release' option in 'ceph-mon' matches the "
+            "'ceph-osd' version",
             coro=app_utils.set_require_osd_release_option("ceph-mon/0", model),
         )
     ]

--- a/tests/unit/steps/test_steps_plan.py
+++ b/tests/unit/steps/test_steps_plan.py
@@ -49,18 +49,18 @@ from tests.unit.utils import assert_steps
 def generate_expected_upgrade_plan_principal(app, target, model):
     """Generate expected upgrade plan for principal charms."""
     expected_plan = ApplicationUpgradePlan(
-        description=f"Upgrade plan for '{app.name}' to {target.codename}"
+        description=f"Upgrade plan for '{app.name}' to '{target.codename}'"
     )
     if app.charm in ["rabbitmq-server", "ceph-mon", "keystone"]:
         # apps waiting for whole model
         wait_step = PostUpgradeStep(
-            description=f"Wait for up to 1800s for model {model.name} to reach the idle state",
+            description=f"Wait for up to 1800s for model '{model.name}' to reach the idle state",
             parallel=False,
             coro=model.wait_for_active_idle(1800, apps=None),
         )
     else:
         wait_step = PostUpgradeStep(
-            description=f"Wait for up to 300s for app {app.name} to reach the idle state",
+            description=f"Wait for up to 300s for app '{app.name}' to reach the idle state",
             parallel=False,
             coro=model.wait_for_active_idle(300, apps=[app.name]),
         )
@@ -72,7 +72,7 @@ def generate_expected_upgrade_plan_principal(app, target, model):
     for unit in app.units.values():
         upgrade_packages.add_step(
             UnitUpgradeStep(
-                description=f"Upgrade software packages on unit {unit.name}",
+                description=f"Upgrade software packages on unit '{unit.name}'",
                 coro=app_utils.upgrade_packages(unit.name, model, None),
             )
         )
@@ -124,7 +124,7 @@ def generate_expected_upgrade_plan_principal(app, target, model):
 def generate_expected_upgrade_plan_subordinate(app, target, model):
     """Generate expected upgrade plan for subordiante charms."""
     expected_plan = ApplicationUpgradePlan(
-        description=f"Upgrade plan for '{app.name}' to {target}"
+        description=f"Upgrade plan for '{app.name}' to '{target}'"
     )
     upgrade_steps = [
         PreUpgradeStep(

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -85,7 +85,7 @@ async def test_analyze_and_plan(mock_analyze, mock_generate_plan, cou_model, cli
 async def test_get_upgrade_plan(mock_print_and_debug, mock_analyze_and_plan, cli_args):
     """Test get_upgrade_plan function."""
     plan = UpgradePlan(description="Upgrade cloud from 'ussuri' to 'victoria'")
-    plan.add_step(PreUpgradeStep(description="backup mysql databases", parallel=False))
+    plan.add_step(PreUpgradeStep(description="Back up MySQL databases", parallel=False))
 
     mock_analyze_and_plan.return_value = plan
     await cli.get_upgrade_plan(cli_args)
@@ -123,7 +123,7 @@ async def test_run_upgrade_quiet_no_prompt(
     cli_args.prompt = False
 
     plan = UpgradePlan(description="Upgrade cloud from 'ussuri' to 'victoria'")
-    plan.add_step(PreUpgradeStep(description="backup mysql databases", parallel=False))
+    plan.add_step(PreUpgradeStep(description="Back up MySQL databases", parallel=False))
     mock_analyze_and_plan.return_value = plan
 
     await cli.run_upgrade(cli_args)
@@ -148,7 +148,7 @@ async def test_run_upgrade_with_prompt_continue(
     cli_args.quiet = True
 
     plan = UpgradePlan(description="Upgrade cloud from 'ussuri' to 'victoria'")
-    plan.add_step(PreUpgradeStep(description="backup mysql databases", parallel=False))
+    plan.add_step(PreUpgradeStep(description="Back up MySQL databases", parallel=False))
     mock_analyze_and_plan.return_value = plan
     mock_continue_upgrade.return_value = True
 
@@ -173,7 +173,7 @@ async def test_run_upgrade_with_prompt_abort(
     cli_args.quiet = True
 
     plan = UpgradePlan(description="Upgrade cloud from 'ussuri' to 'victoria'")
-    plan.add_step(PreUpgradeStep(description="backup mysql databases", parallel=False))
+    plan.add_step(PreUpgradeStep(description="Back up MySQL databases", parallel=False))
     mock_analyze_and_plan.return_value = plan
     mock_continue_upgrade.return_value = False
 
@@ -198,7 +198,7 @@ async def test_run_upgrade_with_no_prompt(
     cli_args.quiet = True
 
     plan = UpgradePlan(description="Upgrade cloud from 'ussuri' to 'victoria'")
-    plan.add_step(PreUpgradeStep(description="backup mysql databases", parallel=False))
+    plan.add_step(PreUpgradeStep(description="Back up MySQL databases", parallel=False))
     mock_analyze_and_plan.return_value = plan
 
     await cli.run_upgrade(cli_args)


### PR DESCRIPTION
- Better indicating a timeout step with `Wait for up to...`
- Start the description of "UpgradeStep" with a verb
- No period at the end of the step description
- Quotation mark around variables like app name, unit name, model name, etc
- Other miscellaneous grammar and wording fixes

fixes: #288