### PR TITLE
Add sanity checks to app generate upgrade plan

### DIFF
--- a/cou/apps/base.py
+++ b/cou/apps/base.py
@@ -86,9 +86,6 @@ class OpenStackApplication:
     :type units: list[ApplicationUnit]
     :raises ApplicationError: When there are no compatible OpenStack release for the
         workload version.
-    :raises MismatchedOpenStackVersions: When units part of this application are running mismatched
-        OpenStack versions.
-    :raises HaltUpgradePlanGeneration: When the class halts the upgrade plan generation.
     :raises CommandRunFailed: When a command fails to run.
     :raises RunUpgradeError: When an upgrade fails.
     """
@@ -226,6 +223,20 @@ class OpenStackApplication:
         """
         return self.charm_origin == "cs"
 
+    @property
+    def os_release_units(self) -> dict[OpenStackRelease, list[str]]:
+        """Get the OpenStack release versions from the units.
+
+        :return: OpenStack release versions from the units.
+        :rtype: defaultdict[OpenStackRelease, list[str]]
+        """
+        os_versions = defaultdict(list)
+        for unit in self.units:
+            os_version = self._get_latest_os_version(unit)
+            os_versions[os_version].append(unit.name)
+
+        return dict(os_versions)
+
     def is_valid_track(self, charm_channel: str) -> bool:
         """Check if the channel track is valid.
 
@@ -303,28 +314,10 @@ class OpenStackApplication:
     def current_os_release(self) -> OpenStackRelease:
         """Current OpenStack Release of the application.
 
-        :raises MismatchedOpenStackVersions: When units part of this application are
-        running mismatched OpenStack versions.
         :return: OpenStackRelease object
         :rtype: OpenStackRelease
         """
-        os_versions = defaultdict(list)
-        for unit in self.units:
-            os_versions[unit.os_version].append(unit.name)
-
-        if len(os_versions.keys()) == 1:
-            return next(iter(os_versions))
-
-        # NOTE (gabrielcocenza) on applications that use single-unit or paused-single-unit
-        # upgrade methods, more than one version can be found.
-        mismatched_repr = [
-            f"'{openstack_release.codename}': {units}"
-            for openstack_release, units in os_versions.items()
-        ]
-        raise MismatchedOpenStackVersions(
-            f"Units of application {self.name} are running mismatched OpenStack versions: "
-            f"{', '.join(mismatched_repr)}. This is not currently handled."
-        )
+        return min(self.os_release_units.keys())
 
     @property
     def apt_source_codename(self) -> Optional[OpenStackRelease]:
@@ -440,6 +433,25 @@ class OpenStackApplication:
                 f"Cannot upgrade units '{units_not_upgraded_string}' to {target}."
             )
 
+    def upgrade_plan_sanity_checks(self, target: OpenStackRelease) -> None:
+        """Run sanity checks before generating upgrade plan.
+
+        :param target: OpenStack release as target to upgrade.
+        :type target: OpenStackRelease
+        :raises ApplicationError: When enable-auto-restarts is not enabled.
+        :raises HaltUpgradePlanGeneration: When the application halt the upgrade plan generation.
+        :raises MismatchedOpenStackVersions: When the units of the app are running different
+                                             OpenStack versions.
+        :raises ApplicationError: When enable-auto-restarts is not enabled.
+        """
+        self._check_application_target(target)
+        self._check_mismatched_versions()
+        self._check_auto_restarts()
+        logger.info(
+            "%s application met all the necessary prerequisites to generate the upgrade plan",
+            self.name,
+        )
+
     def pre_upgrade_steps(self, target: OpenStackRelease) -> list[PreUpgradeStep]:
         """Pre Upgrade steps planning.
 
@@ -462,14 +474,6 @@ class OpenStackApplication:
         :return: List of upgrade steps.
         :rtype: list[UpgradeStep]
         """
-        if self.current_os_release >= target and self.apt_source_codename >= target:
-            msg = (
-                f"Application '{self.name}' already configured for release equal or greater "
-                f"than {target}. Ignoring."
-            )
-            logger.info(msg)
-            raise HaltUpgradePlanGeneration(msg)
-
         return [
             self._get_disable_action_managed_step(),
             self._get_upgrade_charm_step(target),
@@ -499,6 +503,8 @@ class OpenStackApplication:
         :return: Full upgrade plan if the Application is able to generate it.
         :rtype: ApplicationUpgradePlan
         """
+        self.upgrade_plan_sanity_checks(target)
+
         upgrade_plan = ApplicationUpgradePlan(
             description=f"Upgrade plan for '{self.name}' to {target}",
         )
@@ -681,3 +687,61 @@ class OpenStackApplication:
             parallel=False,
             coro=self.model.wait_for_active_idle(self.wait_timeout, apps=apps),
         )
+
+    def _check_auto_restarts(self) -> None:
+        """Check if enable-auto-restarts is enabled.
+
+        If the enable-auto-restart option is not enabled, this check will raise an exception.
+
+        :raises ApplicationError: When enable-auto-restarts is not enabled.
+        """
+        if "enable-auto-restarts" not in self.config:
+            logger.debug(
+                "%s application does not have an enable-auto-restarts config option", self.name
+            )
+            return
+
+        if self.config["enable-auto-restarts"].get("value") is False:
+            raise ApplicationError(
+                "COU does not currently support upgrading applications that disable service "
+                "restarts. Please enable charm option enable-auto-restart and rerun COU to "
+                f"upgrade the {self.name} application."
+            )
+
+    def _check_application_target(self, target: OpenStackRelease) -> None:
+        """Check if application release is not lower than or equal to target.
+
+        :param target: OpenStack release as target to upgrade.
+        :type target: OpenStackRelease
+        :raises HaltUpgradePlanGeneration: When the application halt the upgrade plan generation.
+        """
+        logger.debug(
+            "%s application current os_release is %s and apt source is %s",
+            self.name,
+            self.current_os_release,
+            self.apt_source_codename,
+        )
+
+        if self.current_os_release >= target and self.apt_source_codename >= target:
+            raise HaltUpgradePlanGeneration(
+                f"Application '{self.name}' already configured for release equal to or greater "
+                f"than {target}. Ignoring."
+            )
+
+    def _check_mismatched_versions(self) -> None:
+        """Check that there are no mismatched versions on app units.
+
+        :raises MismatchedOpenStackVersions: When the units of the app are running different
+                                             OpenStack versions.
+        """
+        os_versions = self.os_release_units
+        if len(os_versions.keys()) > 1:
+            mismatched_repr = [
+                f"'{openstack_release.codename}': {units}"
+                for openstack_release, units in os_versions.items()
+            ]
+
+            raise MismatchedOpenStackVersions(
+                f"Units of application {self.name} are running mismatched OpenStack versions: "
+                f"{', '.join(mismatched_repr)}. This is not currently handled."
+            )

--- a/cou/apps/base.py
+++ b/cou/apps/base.py
@@ -706,7 +706,7 @@ class OpenStackApplication:
             )
 
     def _check_application_target(self, target: OpenStackRelease) -> None:
-        """Check if application release is not lower than or equal to target.
+        """Check if the application is already upgraded.
 
         :param target: OpenStack release as target to upgrade.
         :type target: OpenStackRelease

--- a/cou/apps/base.py
+++ b/cou/apps/base.py
@@ -85,7 +85,7 @@ class OpenStackApplication:
     :raises RunUpgradeError: When an upgrade fails.
     """
 
-    # pylint: disable=too-many-instance-attributes
+    # pylint: disable=too-many-instance-attributes, too-many-public-methods
 
     name: str
     status: ApplicationStatus

--- a/cou/apps/base.py
+++ b/cou/apps/base.py
@@ -719,7 +719,11 @@ class OpenStackApplication:
             self.apt_source_codename,
         )
 
-        if self.current_os_release >= target and self.apt_source_codename >= target:
+        if (
+            self.current_os_release >= target
+            and self.can_upgrade_current_channel is False
+            and self.apt_source_codename >= target
+        ):
             raise HaltUpgradePlanGeneration(
                 f"Application '{self.name}' already configured for release equal to or greater "
                 f"than {target}. Ignoring."

--- a/cou/apps/subordinate.py
+++ b/cou/apps/subordinate.py
@@ -27,9 +27,10 @@ class SubordinateBase(OpenStackApplication):
     """Subordinate base class."""
 
     def _check_application_target(self, target: OpenStackRelease) -> None:
-        """Check if application release is not lower than or equal to target.
+        """Check if the application is already upgraded.
 
-        Subordinate application are not comparing apt_source_codename with target.
+        Subordinate applications use the apt source of the related principal and don't have an
+        origin/openstack-origin config option.
 
         :param target: OpenStack release as target to upgrade.
         :type target: OpenStackRelease

--- a/cou/apps/subordinate.py
+++ b/cou/apps/subordinate.py
@@ -37,7 +37,7 @@ class SubordinateBase(OpenStackApplication):
         """
         logger.debug("%s application current os_release is %s", self.name, self.current_os_release)
 
-        if self.current_os_release >= target:
+        if self.current_os_release >= target and self.can_upgrade_current_channel is False:
             raise HaltUpgradePlanGeneration(
                 f"Application '{self.name}' already configured for release equal to or greater "
                 f"than {target}. Ignoring."

--- a/tests/unit/apps/test_auxiliary.py
+++ b/tests/unit/apps/test_auxiliary.py
@@ -358,6 +358,7 @@ def test_auxiliary_raise_error_os_not_on_lookup(status, config, model, mocker, a
 def test_auxiliary_raise_halt_upgrade(status, config, model, apps_machines):
     target = OpenStackRelease("victoria")
     # source is already configured to wallaby, so the plan halt with target victoria
+    status["rabbitmq_server"].can_upgrade_to = []
     app = RabbitMQServer(
         "rabbitmq-server",
         status["rabbitmq_server"],
@@ -366,6 +367,7 @@ def test_auxiliary_raise_halt_upgrade(status, config, model, apps_machines):
         "rabbitmq-server",
         apps_machines["rmq"],
     )
+
     with pytest.raises(HaltUpgradePlanGeneration):
         app.generate_upgrade_plan(target)
 

--- a/tests/unit/apps/test_auxiliary_subordinate.py
+++ b/tests/unit/apps/test_auxiliary_subordinate.py
@@ -19,7 +19,7 @@ from cou.apps.auxiliary_subordinate import (
     AuxiliarySubordinateApplication,
     OvnSubordinate,
 )
-from cou.exceptions import ApplicationError
+from cou.exceptions import ApplicationError, HaltUpgradePlanGeneration
 from cou.steps import ApplicationUpgradePlan, PreUpgradeStep, UpgradeStep
 from cou.utils.openstack import OpenStackRelease
 from tests.unit.apps.utils import add_steps
@@ -123,6 +123,10 @@ def test_ovn_subordinate_upgrade_plan_cant_upgrade_charm(status, model):
     # ovn chassis 22.03 is considered yoga. If it's not necessary to upgrade
     # the charm code, there is no steps to upgrade.
     target = OpenStackRelease("victoria")
+    exp_message = (
+        "Application 'ovn-chassis' already configured for release equal to or greater than "
+        "victoria. Ignoring"
+    )
     app_status = status["ovn_chassis_focal_22"]
     app_status.can_upgrade_to = ""
     app = OvnSubordinate(
@@ -134,13 +138,8 @@ def test_ovn_subordinate_upgrade_plan_cant_upgrade_charm(status, model):
         {},
     )
 
-    expected_plan = ApplicationUpgradePlan(
-        description=f"Upgrade plan for '{app.name}' to {target}"
-    )
-
-    upgrade_plan = app.generate_upgrade_plan(target)
-    assert upgrade_plan == expected_plan
-    assert str(upgrade_plan) == ""
+    with pytest.raises(HaltUpgradePlanGeneration, match=exp_message):
+        app.generate_upgrade_plan(target)
 
 
 def test_ceph_dashboard_upgrade_plan_ussuri_to_victoria(status, config, model):

--- a/tests/unit/apps/test_base.py
+++ b/tests/unit/apps/test_base.py
@@ -1,0 +1,79 @@
+#  Copyright 2023 Canonical Limited
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+from unittest.mock import MagicMock, PropertyMock, patch
+
+import pytest
+
+from cou.apps.base import OpenStackApplication
+from cou.exceptions import ApplicationError, HaltUpgradePlanGeneration
+from cou.utils.openstack import OpenStackRelease
+
+
+@pytest.mark.parametrize("config", ({}, {"enable-auto-restarts": {"value": True}}))
+@patch("cou.apps.base.OpenStackApplication.channel", new_callable=PropertyMock)
+def test_check_auto_restarts(_, config):
+    """Test function to verify that enable-auto-restarts is disabled."""
+    app_name = "app"
+    app = OpenStackApplication(app_name, MagicMock(), config, MagicMock(), "", "ch", "")
+
+    app._check_auto_restarts()
+
+
+@patch("cou.apps.base.OpenStackApplication.channel", new_callable=PropertyMock)
+def test_check_auto_restarts_error(_):
+    """Test function to verify that enable-auto-restarts is disabled raising error."""
+    app_name = "app"
+    exp_error_msg = (
+        "COU does not currently support upgrading applications that disable service restarts. "
+        f"Please enable charm option enable-auto-restart and rerun COU to upgrade the {app_name} "
+        "application."
+    )
+    config = {"enable-auto-restarts": {"value": False}}
+    app = OpenStackApplication(app_name, MagicMock(), config, MagicMock(), "", "ch", "")
+
+    with pytest.raises(ApplicationError, match=exp_error_msg):
+        app._check_auto_restarts()
+
+
+@patch("cou.apps.base.OpenStackApplication.channel", new_callable=PropertyMock)
+@patch("cou.apps.base.OpenStackApplication.apt_source_codename", new_callable=PropertyMock)
+@patch("cou.apps.base.OpenStackApplication.current_os_release", new_callable=PropertyMock)
+def test_check_application_target(current_os_release, apt_source_codename, _):
+    """Test function to verify target."""
+    target = OpenStackRelease("victoria")
+    release = OpenStackRelease("ussuri")
+    app_name = "app"
+    app = OpenStackApplication(app_name, MagicMock(), {}, MagicMock(), "", "ch", "")
+    current_os_release.return_value = apt_source_codename.return_value = release
+
+    app._check_application_target(target)
+
+
+@patch("cou.apps.base.OpenStackApplication.channel", new_callable=PropertyMock)
+@patch("cou.apps.base.OpenStackApplication.apt_source_codename", new_callable=PropertyMock)
+@patch("cou.apps.base.OpenStackApplication.current_os_release", new_callable=PropertyMock)
+def test_check_application_target_error(current_os_release, apt_source_codename, _):
+    """Test function to verify target raising error."""
+    target = OpenStackRelease("victoria")
+    app_name = "app"
+    exp_error_msg = (
+        f"Application '{app_name}' already configured for release equal to or greater than "
+        f"{target}. Ignoring."
+    )
+    app = OpenStackApplication(app_name, MagicMock(), {}, MagicMock(), "", "ch", "")
+    current_os_release.return_value = apt_source_codename.return_value = target
+
+    with pytest.raises(HaltUpgradePlanGeneration, match=exp_error_msg):
+        app._check_application_target(target)

--- a/tests/unit/apps/test_core.py
+++ b/tests/unit/apps/test_core.py
@@ -148,7 +148,7 @@ def test_application_different_wl(status, config, model):
 
     app = Keystone("my_keystone", app_status, app_config, model, "keystone")
     with pytest.raises(MismatchedOpenStackVersions, match=exp_error_msg):
-        app.current_os_release
+        app._check_mismatched_versions()
 
 
 def test_application_cs(status, config, units, model):
@@ -567,7 +567,7 @@ def test_upgrade_plan_origin_already_on_next_openstack_release(status, config, m
 
 def test_upgrade_plan_application_already_upgraded(status, config, model):
     exp_error_msg = (
-        "Application 'my_keystone' already configured for release equal or greater "
+        "Application 'my_keystone' already configured for release equal to or greater "
         "than victoria. Ignoring."
     )
     target = OpenStackRelease("victoria")

--- a/tests/unit/apps/test_core.py
+++ b/tests/unit/apps/test_core.py
@@ -641,6 +641,7 @@ def test_upgrade_plan_application_already_upgraded(status, config, model, apps_m
     )
     target = OpenStackRelease("victoria")
     app_status = status["keystone_focal_wallaby"]
+    app_status.can_upgrade_to = []
     app_config = config["openstack_wallaby"]
     app = Keystone(
         "my_keystone", app_status, app_config, model, "keystone", apps_machines["keystone"]


### PR DESCRIPTION
Like this we can create app without these error beeing raised and thay will be raised during generation of upgrade plan.