### PR TITLE
add global and func test concurrency (#301)

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -1,9 +1,5 @@
 name: Check workflow running linter, unit and functional tests
 
-concurrency:
-  group: ${{ github.workflow }}
-
-
 on:
   workflow_call:
   workflow_dispatch:
@@ -13,6 +9,11 @@ on:
     paths-ignore:
       - '**.md'
       - '**.rst'
+
+concurrency:
+      # We do not want to run multiple jobs for single PR.
+      group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+      cancel-in-progress: true
 
 jobs:
   lint-unit:
@@ -60,7 +61,7 @@ jobs:
   func:
     name: Functional tests
     needs: snap-build
-    runs-on: [self-hosted, large]
+    runs-on: ubuntu-latest
     timeout-minutes: 120
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Right now we are using global concurrency for workflow name and like this we are not running even lint and unit tests, which are run on GitHub runner instead of self-hosted one. That's why I do not see reason to block them to be run.

We also decided to use official GitHub runner for functional tests instead of self-hosted runner.