### PR TITLE
Enhance units display

### DIFF
--- a/cou/apps/base.py
+++ b/cou/apps/base.py
@@ -29,6 +29,7 @@ from cou.exceptions import (
     MismatchedOpenStackVersions,
 )
 from cou.steps import (
+    TAB,
     ApplicationUpgradePlan,
     PostUpgradeStep,
     PreUpgradeStep,
@@ -696,10 +697,13 @@ class OpenStackApplication(COUApplication):
         """
         if not units:
             units = list(self.units.values())
+
+        units_repr = "\n".join([f"{TAB}- '{unit.name}'" for unit in units])
+
         return PostUpgradeStep(
             description=(
-                f"Verify that the workload of '{self.name}' has been upgraded on units: "
-                f"{', '.join([unit.name for unit in units])}"
+                f"Verify that the workload of '{self.name}' has been upgraded on units:\n"
+                f"{units_repr}"
             ),
             coro=self._verify_workload_upgrade(target, units),
         )

--- a/cou/steps/__init__.py
+++ b/cou/steps/__init__.py
@@ -27,6 +27,7 @@ from cou.exceptions import CanceledStep
 
 logger = logging.getLogger(__name__)
 DEPENDENCY_DESCRIPTION_PREFIX = "├── "
+TAB = "\t"
 
 
 def compare_step_coroutines(coro1: Optional[Coroutine], coro2: Optional[Coroutine]) -> bool:
@@ -133,11 +134,12 @@ class BaseStep:
         :rtype: str
         """
         result = ""
-        tab = "\t"
         steps_to_visit = [(self, 0)]
         while steps_to_visit:
             step, indent = steps_to_visit.pop()
-            result += f"{tab * indent}{step.description}{os.linesep}" if step else ""
+            # add tab in the beginning and also on new lines that the description might have
+            description = f"{TAB * indent}{step.description}".replace("\n", f"\n{TAB * indent}")
+            result += f"{description}{os.linesep}" if step else ""
             steps_to_visit.extend([(s, indent + 1) for s in reversed(step.sub_steps)])
 
         return result

--- a/tests/unit/apps/test_auxiliary.py
+++ b/tests/unit/apps/test_auxiliary.py
@@ -27,6 +27,7 @@ from cou.apps.auxiliary import (
 from cou.apps.core import NovaCompute
 from cou.exceptions import ApplicationError, HaltUpgradePlanGeneration
 from cou.steps import (
+    TAB,
     ApplicationUpgradePlan,
     PostUpgradeStep,
     PreUpgradeStep,
@@ -149,6 +150,8 @@ def test_auxiliary_upgrade_plan_ussuri_to_victoria_change_channel(model):
             )
         )
 
+    units_repr = "\n".join([f"{TAB}- '{unit}'" for unit in app.units])
+
     upgrade_steps = [
         expected_upgrade_package_step,
         PreUpgradeStep(
@@ -179,8 +182,8 @@ def test_auxiliary_upgrade_plan_ussuri_to_victoria_change_channel(model):
         ),
         PostUpgradeStep(
             description=(
-                f"Verify that the workload of '{app.name}' has been upgraded on units: "
-                f"{', '.join([unit for unit in app.units.keys()])}"
+                f"Verify that the workload of '{app.name}' has been upgraded on units:\n"
+                f"{units_repr}"
             ),
             parallel=False,
             coro=app._verify_workload_upgrade(target, list(app.units.values())),
@@ -231,6 +234,7 @@ def test_auxiliary_upgrade_plan_ussuri_to_victoria(model):
                 coro=app_utils.upgrade_packages(unit.name, model, None),
             )
         )
+    units_repr = "\n".join([f"{TAB}- '{unit}'" for unit in app.units])
 
     upgrade_steps = [
         upgrade_packages,
@@ -257,8 +261,8 @@ def test_auxiliary_upgrade_plan_ussuri_to_victoria(model):
         ),
         PostUpgradeStep(
             description=(
-                f"Verify that the workload of '{app.name}' has been upgraded on units: "
-                f"{', '.join([unit for unit in app.units.keys()])}"
+                f"Verify that the workload of '{app.name}' has been upgraded on units:\n"
+                f"{units_repr}"
             ),
             parallel=False,
             coro=app._verify_workload_upgrade(target, list(app.units.values())),
@@ -311,6 +315,8 @@ def test_auxiliary_upgrade_plan_ussuri_to_victoria_ch_migration(model):
             )
         )
 
+    units_repr = "\n".join([f"{TAB}- '{unit}'" for unit in app.units])
+
     upgrade_steps = [
         upgrade_packages,
         PreUpgradeStep(
@@ -341,8 +347,8 @@ def test_auxiliary_upgrade_plan_ussuri_to_victoria_ch_migration(model):
         ),
         PostUpgradeStep(
             description=(
-                f"Verify that the workload of '{app.name}' has been upgraded on units: "
-                f"{', '.join([unit for unit in app.units.keys()])}"
+                f"Verify that the workload of '{app.name}' has been upgraded on units:\n"
+                f"{units_repr}"
             ),
             parallel=False,
             coro=app._verify_workload_upgrade(target, list(app.units.values())),
@@ -636,6 +642,8 @@ def test_ceph_mon_upgrade_plan_xena_to_yoga(model):
             )
         )
 
+    units_repr = "\n".join([f"{TAB}- '{unit}'" for unit in app.units])
+
     upgrade_steps = [
         upgrade_packages,
         PreUpgradeStep(
@@ -672,8 +680,8 @@ def test_ceph_mon_upgrade_plan_xena_to_yoga(model):
         ),
         PostUpgradeStep(
             description=(
-                f"Verify that the workload of '{app.name}' has been upgraded on units: "
-                f"{', '.join([unit for unit in app.units.keys()])}"
+                f"Verify that the workload of '{app.name}' has been upgraded on units:\n"
+                f"{units_repr}"
             ),
             parallel=False,
             coro=app._verify_workload_upgrade(target, list(app.units.values())),
@@ -727,6 +735,8 @@ def test_ceph_mon_upgrade_plan_ussuri_to_victoria(model):
             )
         )
 
+    units_repr = "\n".join([f"{TAB}- '{unit}'" for unit in app.units])
+
     upgrade_steps = [
         upgrade_packages,
         PreUpgradeStep(
@@ -758,8 +768,8 @@ def test_ceph_mon_upgrade_plan_ussuri_to_victoria(model):
         ),
         PostUpgradeStep(
             description=(
-                f"Verify that the workload of '{app.name}' has been upgraded on units: "
-                f"{', '.join([unit for unit in app.units.keys()])}"
+                f"Verify that the workload of '{app.name}' has been upgraded on units:\n"
+                f"{units_repr}"
             ),
             parallel=False,
             coro=app._verify_workload_upgrade(target, list(app.units.values())),
@@ -917,6 +927,8 @@ def test_ovn_principal_upgrade_plan(model):
             )
         )
 
+    units_repr = "\n".join([f"{TAB}- '{unit}'" for unit in app.units])
+
     upgrade_steps = [
         upgrade_packages,
         PreUpgradeStep(
@@ -941,8 +953,8 @@ def test_ovn_principal_upgrade_plan(model):
         ),
         PostUpgradeStep(
             description=(
-                f"Verify that the workload of '{app.name}' has been upgraded on units: "
-                f"{', '.join([unit for unit in app.units.keys()])}"
+                f"Verify that the workload of '{app.name}' has been upgraded on units:\n"
+                f"{units_repr}"
             ),
             parallel=False,
             coro=app._verify_workload_upgrade(target, list(app.units.values())),
@@ -996,6 +1008,8 @@ def test_mysql_innodb_cluster_upgrade(model):
             )
         )
 
+    units_repr = "\n".join([f"{TAB}- '{unit}'" for unit in app.units])
+
     upgrade_steps = [
         upgrade_packages,
         PreUpgradeStep(
@@ -1020,8 +1034,8 @@ def test_mysql_innodb_cluster_upgrade(model):
         ),
         PostUpgradeStep(
             description=(
-                f"Verify that the workload of '{app.name}' has been upgraded on units: "
-                f"{', '.join([unit for unit in app.units.keys()])}"
+                f"Verify that the workload of '{app.name}' has been upgraded on units:\n"
+                f"{units_repr}"
             ),
             parallel=False,
             coro=app._verify_workload_upgrade(target, list(app.units.values())),
@@ -1212,7 +1226,10 @@ def test_ceph_osd_upgrade_plan(model):
             Upgrade software packages on unit 'ceph-osd/2'
         Change charm config of 'ceph-osd' 'source' to 'cloud:focal-victoria'
         Wait for up to 300s for app 'ceph-osd' to reach the idle state
-        Verify that the workload of 'ceph-osd' has been upgraded on units: ceph-osd/0, ceph-osd/1, ceph-osd/2
+        Verify that the workload of 'ceph-osd' has been upgraded on units:
+            - 'ceph-osd/0'
+            - 'ceph-osd/1'
+            - 'ceph-osd/2'
     """  # noqa: E501 line too long
     )
     target = OpenStackRelease("victoria")

--- a/tests/unit/apps/test_channel_based.py
+++ b/tests/unit/apps/test_channel_based.py
@@ -14,6 +14,7 @@ from unittest.mock import MagicMock
 
 from cou.apps.channel_based import ChannelBasedApplication
 from cou.steps import (
+    TAB,
     ApplicationUpgradePlan,
     PostUpgradeStep,
     PreUpgradeStep,
@@ -278,6 +279,8 @@ def test_application_gnocchi_upgrade_plan_ussuri_to_victoria(model):
             )
         )
 
+    units_repr = "\n".join([f"{TAB}- '{unit}'" for unit in app.units])
+
     upgrade_steps = [
         upgrade_packages,
         PreUpgradeStep(
@@ -308,8 +311,8 @@ def test_application_gnocchi_upgrade_plan_ussuri_to_victoria(model):
         ),
         PostUpgradeStep(
             description=(
-                f"Verify that the workload of '{app.name}' has been upgraded on units: "
-                f"{', '.join([unit for unit in app.units.keys()])}"
+                f"Verify that the workload of '{app.name}' has been upgraded on units:\n"
+                f"{units_repr}"
             ),
             parallel=False,
             coro=app._verify_workload_upgrade(target, list(app.units.values())),
@@ -367,6 +370,8 @@ def test_application_designate_bind_upgrade_plan_ussuri_to_victoria(model):
             )
         )
 
+    units_repr = "\n".join([f"{TAB}- '{unit}'" for unit in app.units])
+
     upgrade_steps = [
         upgrade_packages,
         PreUpgradeStep(
@@ -397,8 +402,8 @@ def test_application_designate_bind_upgrade_plan_ussuri_to_victoria(model):
         ),
         PostUpgradeStep(
             description=(
-                f"Verify that the workload of '{app.name}' has been upgraded on units: "
-                f"{', '.join([unit for unit in app.units.keys()])}"
+                f"Verify that the workload of '{app.name}' has been upgraded on units:\n"
+                f"{units_repr}"
             ),
             parallel=False,
             coro=app._verify_workload_upgrade(target, list(app.units.values())),

--- a/tests/unit/apps/test_core.py
+++ b/tests/unit/apps/test_core.py
@@ -20,6 +20,7 @@ from cou.apps.base import OpenStackApplication
 from cou.apps.core import Keystone, NovaCompute
 from cou.exceptions import ApplicationError, HaltUpgradePlanGeneration
 from cou.steps import (
+    TAB,
     ApplicationUpgradePlan,
     PostUpgradeStep,
     PreUpgradeStep,
@@ -324,6 +325,8 @@ def test_upgrade_plan_ussuri_to_victoria(model):
             )
         )
 
+    units_repr = "\n".join([f"{TAB}- '{unit}'" for unit in app.units])
+
     upgrade_steps = [
         upgrade_packages,
         PreUpgradeStep(
@@ -358,8 +361,8 @@ def test_upgrade_plan_ussuri_to_victoria(model):
         ),
         PostUpgradeStep(
             description=(
-                f"Verify that the workload of '{app.name}' has been upgraded on units: "
-                f"{', '.join([unit for unit in app.units.keys()])}"
+                f"Verify that the workload of '{app.name}' has been upgraded on units:\n"
+                f"{units_repr}"
             ),
             parallel=False,
             coro=app._verify_workload_upgrade(target, list(app.units.values())),
@@ -414,6 +417,8 @@ def test_upgrade_plan_ussuri_to_victoria_ch_migration(model):
             )
         )
 
+    units_repr = "\n".join([f"{TAB}- '{unit}'" for unit in app.units])
+
     upgrade_steps = [
         upgrade_packages,
         PreUpgradeStep(
@@ -448,8 +453,8 @@ def test_upgrade_plan_ussuri_to_victoria_ch_migration(model):
         ),
         PostUpgradeStep(
             description=(
-                f"Verify that the workload of '{app.name}' has been upgraded on units: "
-                f"{', '.join([unit for unit in app.units.keys()])}"
+                f"Verify that the workload of '{app.name}' has been upgraded on units:\n"
+                f"{units_repr}"
             ),
             parallel=False,
             coro=app._verify_workload_upgrade(target, list(app.units.values())),
@@ -508,6 +513,8 @@ def test_upgrade_plan_channel_on_next_os_release(model):
             )
         )
 
+    units_repr = "\n".join([f"{TAB}- '{unit}'" for unit in app.units])
+
     upgrade_steps = [
         upgrade_packages,
         UpgradeStep(
@@ -532,8 +539,8 @@ def test_upgrade_plan_channel_on_next_os_release(model):
         ),
         PostUpgradeStep(
             description=(
-                f"Verify that the workload of '{app.name}' has been upgraded on units: "
-                f"{', '.join([unit for unit in app.units.keys()])}"
+                f"Verify that the workload of '{app.name}' has been upgraded on units:\n"
+                f"{units_repr}"
             ),
             parallel=False,
             coro=app._verify_workload_upgrade(target, list(app.units.values())),
@@ -591,6 +598,8 @@ def test_upgrade_plan_origin_already_on_next_openstack_release(model):
             )
         )
 
+    units_repr = "\n".join([f"{TAB}- '{unit}'" for unit in app.units])
+
     upgrade_steps = [
         upgrade_packages,
         PreUpgradeStep(
@@ -615,8 +624,8 @@ def test_upgrade_plan_origin_already_on_next_openstack_release(model):
         ),
         PostUpgradeStep(
             description=(
-                f"Verify that the workload of '{app.name}' has been upgraded on units: "
-                f"{', '.join([unit for unit in app.units.keys()])}"
+                f"Verify that the workload of '{app.name}' has been upgraded on units:\n"
+                f"{units_repr}"
             ),
             parallel=False,
             coro=app._verify_workload_upgrade(target, list(app.units.values())),
@@ -709,6 +718,8 @@ def test_upgrade_plan_application_already_disable_action_managed(model):
             )
         )
 
+    units_repr = "\n".join([f"{TAB}- '{unit}'" for unit in app.units])
+
     upgrade_steps = [
         upgrade_packages,
         PreUpgradeStep(
@@ -738,8 +749,8 @@ def test_upgrade_plan_application_already_disable_action_managed(model):
         ),
         PostUpgradeStep(
             description=(
-                f"Verify that the workload of '{app.name}' has been upgraded on units: "
-                f"{', '.join([unit for unit in app.units.keys()])}"
+                f"Verify that the workload of '{app.name}' has been upgraded on units:\n"
+                f"{units_repr}"
             ),
             parallel=False,
             coro=app._verify_workload_upgrade(target, list(app.units.values())),
@@ -875,8 +886,11 @@ def test_nova_compute_upgrade_plan(model):
                 ├── Resume the unit: 'nova-compute/2'
                 Enable nova-compute scheduler from unit: 'nova-compute/2'
         Wait for up to 1800s for model 'test_model' to reach the idle state
-        Verify that the workload of 'nova-compute' has been upgraded on units: nova-compute/0, nova-compute/1, nova-compute/2
-    """  # noqa: E501 line too long
+        Verify that the workload of 'nova-compute' has been upgraded on units:
+            - 'nova-compute/0'
+            - 'nova-compute/1'
+            - 'nova-compute/2'
+    """
     )
     machines = {f"{i}": generate_cou_machine(f"{i}", f"az-{i}") for i in range(3)}
     units = {
@@ -928,7 +942,8 @@ def test_nova_compute_upgrade_plan_single_unit(model):
                 ├── Resume the unit: 'nova-compute/0'
                 Enable nova-compute scheduler from unit: 'nova-compute/0'
         Wait for up to 1800s for model 'test_model' to reach the idle state
-        Verify that the workload of 'nova-compute' has been upgraded on units: nova-compute/0
+        Verify that the workload of 'nova-compute' has been upgraded on units:
+            - 'nova-compute/0'
     """
     )
     machines = {f"{i}": generate_cou_machine(f"{i}", f"az-{i}") for i in range(3)}
@@ -974,8 +989,10 @@ def test_cinder_upgrade_plan(model):
         Upgrade 'cinder' to the new channel: 'victoria/stable'
         Change charm config of 'cinder' 'openstack-origin' to 'cloud:focal-victoria'
         Wait for up to 300s for app 'cinder' to reach the idle state
-        Verify that the workload of 'cinder' has been upgraded on units: \
-cinder/0, cinder/1, cinder/2
+        Verify that the workload of 'cinder' has been upgraded on units:
+            - 'cinder/0'
+            - 'cinder/1'
+            - 'cinder/2'
     """
     )
     machines = {f"{i}": generate_cou_machine(f"{i}", f"az-{i}") for i in range(3)}
@@ -1028,7 +1045,8 @@ def test_cinder_upgrade_plan_single_unit(model):
                 Upgrade the unit: 'cinder/0'
                 Resume the unit: 'cinder/0'
         Wait for up to 300s for app 'cinder' to reach the idle state
-        Verify that the workload of 'cinder' has been upgraded on units: cinder/0
+        Verify that the workload of 'cinder' has been upgraded on units:
+            - 'cinder/0'
     """
     )
     machines = {f"{i}": generate_cou_machine(f"{i}", f"az-{i}") for i in range(3)}

--- a/tests/unit/steps/test_hypervisor.py
+++ b/tests/unit/steps/test_hypervisor.py
@@ -208,9 +208,11 @@ def test_hypervisor_upgrade_plan(model):
                     ├── Resume the unit: 'nova-compute/0'
                     Enable nova-compute scheduler from unit: 'nova-compute/0'
             Wait for up to 1800s for model 'test_model' to reach the idle state
-            Verify that the workload of 'nova-compute' has been upgraded on units: nova-compute/0
+            Verify that the workload of 'nova-compute' has been upgraded on units:
+                - 'nova-compute/0'
             Wait for up to 300s for app 'cinder' to reach the idle state
-            Verify that the workload of 'cinder' has been upgraded on units: cinder/0
+            Verify that the workload of 'cinder' has been upgraded on units:
+                - 'cinder/0'
         Upgrade plan for 'az-1' to 'victoria'
             Upgrade software packages of 'nova-compute' from the current APT repositories
                 Upgrade software packages on unit 'nova-compute/1'
@@ -227,7 +229,8 @@ def test_hypervisor_upgrade_plan(model):
                     ├── Resume the unit: 'nova-compute/1'
                     Enable nova-compute scheduler from unit: 'nova-compute/1'
             Wait for up to 1800s for model 'test_model' to reach the idle state
-            Verify that the workload of 'nova-compute' has been upgraded on units: nova-compute/1
+            Verify that the workload of 'nova-compute' has been upgraded on units:
+                - 'nova-compute/1'
         Upgrade plan for 'az-2' to 'victoria'
             Upgrade software packages of 'nova-compute' from the current APT repositories
                 Upgrade software packages on unit 'nova-compute/2'
@@ -244,7 +247,8 @@ def test_hypervisor_upgrade_plan(model):
                     ├── Resume the unit: 'nova-compute/2'
                     Enable nova-compute scheduler from unit: 'nova-compute/2'
             Wait for up to 1800s for model 'test_model' to reach the idle state
-            Verify that the workload of 'nova-compute' has been upgraded on units: nova-compute/2
+            Verify that the workload of 'nova-compute' has been upgraded on units:
+                - 'nova-compute/2'
     """
     )
     machines = {f"{i}": generate_cou_machine(f"{i}", f"az-{i}") for i in range(3)}
@@ -335,9 +339,11 @@ def test_hypervisor_upgrade_plan_single_machine(model):
                     ├── Resume the unit: 'nova-compute/0'
                     Enable nova-compute scheduler from unit: 'nova-compute/0'
             Wait for up to 1800s for model 'test_model' to reach the idle state
-            Verify that the workload of 'nova-compute' has been upgraded on units: nova-compute/0
+            Verify that the workload of 'nova-compute' has been upgraded on units:
+                - 'nova-compute/0'
             Wait for up to 300s for app 'cinder' to reach the idle state
-            Verify that the workload of 'cinder' has been upgraded on units: cinder/0
+            Verify that the workload of 'cinder' has been upgraded on units:
+                - 'cinder/0'
     """
     )
     machines = {f"{i}": generate_cou_machine(f"{i}", f"az-{i}") for i in range(3)}

--- a/tests/unit/steps/test_steps_plan.py
+++ b/tests/unit/steps/test_steps_plan.py
@@ -29,6 +29,7 @@ from cou.exceptions import (
     OutOfSupportRange,
 )
 from cou.steps import (
+    TAB,
     ApplicationUpgradePlan,
     PostUpgradeStep,
     PreUpgradeStep,
@@ -77,6 +78,8 @@ def generate_expected_upgrade_plan_principal(app, target, model):
             )
         )
 
+    units_repr = "\n".join([f"{TAB}- '{unit}'" for unit in app.units])
+
     upgrade_steps = [
         upgrade_packages,
         PreUpgradeStep(
@@ -110,8 +113,8 @@ def generate_expected_upgrade_plan_principal(app, target, model):
         wait_step,
         PostUpgradeStep(
             description=(
-                f"Verify that the workload of '{app.name}' has been upgraded on units: "
-                f"{', '.join([unit for unit in app.units.keys()])}"
+                f"Verify that the workload of '{app.name}' has been upgraded on units:\n"
+                f"{units_repr}"
             ),
             parallel=False,
             coro=app._verify_workload_upgrade(target, list(app.units.values())),


### PR DESCRIPTION
- If an app has multiple units, the line to verify that the workload of an app has been upgraded can be big. This PR split the units into multiple lines
- All new lines in a description will have the same indent as the first line