### PR TITLE
rename COUModel to Model

### DIFF
--- a/cou/apps/base.py
+++ b/cou/apps/base.py
@@ -38,7 +38,7 @@ from cou.steps import (
     UpgradeStep,
 )
 from cou.utils.app_utils import upgrade_packages
-from cou.utils.juju_utils import COUModel, Machine
+from cou.utils.juju_utils import Machine, Model
 from cou.utils.openstack import (
     DISTRO_TO_OPENSTACK_MAPPING,
     OpenStackCodenameLookup,
@@ -73,8 +73,8 @@ class OpenStackApplication:
     :type status: ApplicationStatus
     :param config: Configuration of the application.
     :type config: dict
-    :param model: COUModel object
-    :type model: COUModel
+    :param model: Model object
+    :type model: Model
     :param charm: Name of the charm.
     :type charm: str
     :param machines: dictionary with Machine
@@ -95,7 +95,7 @@ class OpenStackApplication:
     name: str
     status: ApplicationStatus
     config: dict
-    model: COUModel
+    model: Model
     charm: str
     machines: dict[str, Machine]
     units: list[ApplicationUnit] = field(default_factory=lambda: [])

--- a/cou/apps/factory.py
+++ b/cou/apps/factory.py
@@ -22,7 +22,7 @@ from typing import Optional
 from juju.client._definitions import ApplicationStatus
 
 from cou.apps.base import OpenStackApplication
-from cou.utils.juju_utils import COUModel, Machine
+from cou.utils.juju_utils import Machine, Model
 from cou.utils.openstack import is_charm_supported
 
 logger = logging.getLogger(__name__)
@@ -39,7 +39,7 @@ class AppFactory:
         name: str,
         status: ApplicationStatus,
         config: dict,
-        model: COUModel,
+        model: Model,
         charm: str,
         machines: dict[str, Machine],
     ) -> Optional[OpenStackApplication]:
@@ -55,8 +55,8 @@ class AppFactory:
         :type status: ApplicationStatus
         :param config: Configuration of the application
         :type config: dict
-        :param model: COUModel object
-        :type model: COUModel
+        :param model: Model object
+        :type model: Model
         :param charm: Name of the charm
         :type charm: str
         :return: The OpenStackApplication class or None if not supported.

--- a/cou/cli.py
+++ b/cou/cli.py
@@ -31,7 +31,7 @@ from cou.steps.execute import apply_step
 from cou.steps.plan import generate_plan, manually_upgrade_data_plane
 from cou.utils import print_and_debug, progress_indicator, prompt_input
 from cou.utils.cli import interrupt_handler
-from cou.utils.juju_utils import COUModel
+from cou.utils.juju_utils import Model
 
 AVAILABLE_OPTIONS = "cas"
 
@@ -113,7 +113,7 @@ async def analyze_and_plan(args: CLIargs) -> tuple[Analysis, UpgradePlan]:
     :return: Generated analysis and upgrade plan.
     :rtype: tuple[Analysis, UpgradePlan]
     """
-    model = COUModel(args.model_name)
+    model = Model(args.model_name)
     progress_indicator.start(f"Connecting to '{model.name}' model...")
     await model.connect()
     logger.info("Using model: %s", model.name)

--- a/cou/steps/analyze.py
+++ b/cou/steps/analyze.py
@@ -31,15 +31,15 @@ logger = logging.getLogger(__name__)
 class Analysis:
     """Analyze result.
 
-    :param model: COUModel object
-    :type model: COUModel
+    :param model: Model object
+    :type model: Model
     :param apps_control_plane: Control plane applications in the model
     :type apps_control_plane:  list[OpenStackApplication]
     :param apps_data_plane: Data plane applications in the model
     :type apps_data_plane:  list[OpenStackApplication]
     """
 
-    model: juju_utils.COUModel
+    model: juju_utils.Model
     apps_control_plane: list[OpenStackApplication]
     apps_data_plane: list[OpenStackApplication]
     min_os_version_control_plane: Optional[OpenStackRelease] = None
@@ -92,11 +92,11 @@ class Analysis:
         return control_plane, data_plane
 
     @classmethod
-    async def create(cls, model: juju_utils.COUModel) -> Analysis:
+    async def create(cls, model: juju_utils.Model) -> Analysis:
         """Analyze the deployment before planning.
 
-        :param model: COUModel object
-        :type model: COUModel
+        :param model: Model object
+        :type model: Model
         :return: Analysis object populated with the model applications.
         :rtype: Analysis
         """
@@ -108,15 +108,15 @@ class Analysis:
         return Analysis(model=model, apps_data_plane=data_plane, apps_control_plane=control_plane)
 
     @classmethod
-    async def _populate(cls, model: juju_utils.COUModel) -> list[OpenStackApplication]:
+    async def _populate(cls, model: juju_utils.Model) -> list[OpenStackApplication]:
         """Analyze the applications in the model.
 
         Applications that must be upgraded in a specific order will be returned first, followed
         by applications that can be upgraded in any order. Applications that are not supported
         will be ignored.
 
-        :param model: COUModel object
-        :type model: COUModel
+        :param model: Model object
+        :type model: Model
         :return: Application objects with their respective information.
         :rtype: List[OpenStackApplication]
         """

--- a/cou/steps/backup.py
+++ b/cou/steps/backup.py
@@ -19,16 +19,16 @@ from pathlib import Path
 
 from cou.exceptions import UnitNotFound
 from cou.utils import COU_DATA
-from cou.utils.juju_utils import COUModel
+from cou.utils.juju_utils import Model
 
 logger = logging.getLogger(__name__)
 
 
-async def backup(model: COUModel) -> Path:
+async def backup(model: Model) -> Path:
     """Backup mysql database of openstack.
 
-    :param model: COUModel object
-    :type model: COUModel
+    :param model: Model object
+    :type model: Model
     :return: Path of the local file from the backup.
     :rtype: Path
     """
@@ -70,14 +70,14 @@ def _check_db_relations(app_config: dict) -> bool:
     return False
 
 
-async def get_database_app_unit_name(model: COUModel) -> str:
+async def get_database_app_unit_name(model: Model) -> str:
     """Get mysql-innodb-cluster application's first unit's name.
 
     Gets the openstack database mysql-innodb-cluster application if there are more than one
     application the one with the keystone relation is selected.
 
-    :param model: COUModel object
-    :type model: COUModel
+    :param model: Model object
+    :type model: Model
     :raises UnitNotFound: When cannot find a valid unit for 'mysql-innodb-cluster
     :returns: Name of the mysql-innodb-cluster application name
     :rtype: ApplicationStatus

--- a/cou/utils/app_utils.py
+++ b/cou/utils/app_utils.py
@@ -20,19 +20,19 @@ from typing import Optional
 from packaging.version import Version
 
 from cou.exceptions import ApplicationError, RunUpgradeError
-from cou.utils.juju_utils import COUModel
+from cou.utils.juju_utils import Model
 from cou.utils.openstack import CEPH_RELEASES
 
 logger = logging.getLogger(__name__)
 
 
-async def upgrade_packages(unit: str, model: COUModel, packages_to_hold: Optional[list]) -> None:
+async def upgrade_packages(unit: str, model: Model, packages_to_hold: Optional[list]) -> None:
     """Run package updates and upgrades on each unit of an Application.
 
     :param unit: Unit name where the package upgrade runs on.
     :type unit: str
-    :param model: COUModel object
-    :type model: COUModel
+    :param model: Model object
+    :type model: Model
     :param packages_to_hold: A list of packages to put on hold during package upgrade.
     :type packages_to_hold: Optional[list]
     :raises CommandRunFailed: When a command fails to run.
@@ -46,7 +46,7 @@ async def upgrade_packages(unit: str, model: COUModel, packages_to_hold: Optiona
     await model.run_on_unit(unit_name=unit, command=command, timeout=600)
 
 
-async def set_require_osd_release_option(unit: str, model: COUModel) -> None:
+async def set_require_osd_release_option(unit: str, model: Model) -> None:
     """Check and set the correct value for require-osd-release on a ceph-mon unit.
 
     This function compares the value of require-osd-release option with the current release
@@ -54,8 +54,8 @@ async def set_require_osd_release_option(unit: str, model: COUModel) -> None:
     require-osd-release.
     :param unit: The ceph-mon unit name where the check command runs on.
     :type unit: str
-    :param model: COUModel object
-    :type model: COUModel
+    :param model: Model object
+    :type model: Model
     :raises CommandRunFailed: When a command fails to run.
     """
     # The current `require_osd_release` value set on the ceph-mon unit
@@ -89,13 +89,13 @@ def validate_ovn_support(version: str) -> None:
 
 
 # Private functions
-async def _get_required_osd_release(unit: str, model: COUModel) -> str:
+async def _get_required_osd_release(unit: str, model: Model) -> str:
     """Get the value of require-osd-release option on a ceph-mon unit.
 
     :param unit: The ceph-mon unit name where the check command runs on.
     :type unit: str
-    :param model: COUModel object
-    :type model: COUModel
+    :param model: Model object
+    :type model: Model
     :return: the value of require-osd-release option
     :rtype: str
     :raises CommandRunFailed: When a command fails to run.
@@ -113,15 +113,15 @@ async def _get_required_osd_release(unit: str, model: COUModel) -> str:
     return current_require_osd_release
 
 
-async def _get_current_osd_release(unit: str, model: COUModel) -> str:
+async def _get_current_osd_release(unit: str, model: Model) -> str:
     """Get the current release of OSDs.
 
     The release of OSDs is parsed from the output of running `ceph versions` command
     on a ceph-mon unit.
     :param unit: The ceph-mon unit name where the check command runs on.
     :type unit: str
-    :param model: COUModel object
-    :type model: COUModel
+    :param model: Model object
+    :type model: Model
     :return: the release which OSDs are on
     :rtype: str
     :raises RunUpgradeError: When an upgrade fails.

--- a/cou/utils/juju_utils.py
+++ b/cou/utils/juju_utils.py
@@ -26,7 +26,7 @@ from juju.client._definitions import FullStatus
 from juju.client.connector import NoConnectionException
 from juju.client.jujudata import FileJujuData
 from juju.errors import JujuAppError, JujuError, JujuUnitError
-from juju.model import Model
+from juju.model import Model as JujuModel
 from juju.unit import Unit
 from macaroonbakery.httpbakery import BakeryException
 from six import wraps
@@ -91,7 +91,7 @@ def retry(
     timeout: int = DEFAULT_TIMEOUT,
     no_retry_exceptions: tuple = (),
 ) -> Callable:
-    """Retry function for usage in COUModel.
+    """Retry function for usage in Model.
 
     :param function: function to be wrapped
     :type function: Optional[Callable]
@@ -139,7 +139,7 @@ class Machine:
     az: Optional[str] = None  # simple deployments may not have azs
 
 
-class COUModel:
+class Model:
     """COU model object.
 
     This version of the model provides better waiting for the model to turn idle, auto-reconnection
@@ -149,7 +149,7 @@ class COUModel:
     def __init__(self, name: Optional[str]):
         """COU Model initialization with name and juju.model.Model."""
         self._juju_data = FileJujuData()
-        self._model = Model(max_frame_size=JUJU_MAX_FRAME_SIZE, jujudata=self.juju_data)
+        self._model = JujuModel(max_frame_size=JUJU_MAX_FRAME_SIZE, jujudata=self.juju_data)
         self._name = name
 
     @property
@@ -216,11 +216,11 @@ class COUModel:
 
         return app
 
-    async def _get_model(self) -> Model:
+    async def _get_model(self) -> JujuModel:
         """Get juju.model.Model and make sure that it is connected.
 
         :return: Model
-        :rtype: Model
+        :rtype: JujuModel
         """
         if not self.connected:
             await self.connect()

--- a/docs/.custom_wordlist.txt
+++ b/docs/.custom_wordlist.txt
@@ -5,7 +5,6 @@ Github
 frictionless
 COU
 cou
-Model
 SIGINT
 SIGINTs
 SIGTERM

--- a/docs/.custom_wordlist.txt
+++ b/docs/.custom_wordlist.txt
@@ -5,7 +5,7 @@ Github
 frictionless
 COU
 cou
-COUModel
+Model
 SIGINT
 SIGINTs
 SIGTERM

--- a/docs/how-to/configure-connection.rst
+++ b/docs/how-to/configure-connection.rst
@@ -6,7 +6,7 @@ There are three variables through which the connection behaviour to the Juju mod
 can be tuned. This may be necessary if **COU** is run from behind a VPN or if the network
 is heavily used.
 
-* **COU_TIMEOUT** - set the timeout of retries for any calls by COUModel to libjuju. It's unit-less and the number represents the number of seconds. Defaults to 10 seconds.
+* **COU_TIMEOUT** - set the timeout of retries for any calls by Model to libjuju. It's unit-less and the number represents the number of seconds. Defaults to 10 seconds.
 
 * **COU_MODEL_RETRIES** - set how many times to retry connecting to the Juju model before giving up. Defaults to 5.
 

--- a/tests/functional/tests/backup.py
+++ b/tests/functional/tests/backup.py
@@ -9,7 +9,7 @@ import zaza
 
 from cou.steps.backup import backup
 from cou.utils import COU_DATA
-from cou.utils.juju_utils import COUModel
+from cou.utils.juju_utils import Model
 
 logger = logging.getLogger(__name__)
 
@@ -20,7 +20,7 @@ class BackupTest(unittest.TestCase):
     def setUp(self) -> None:
         zaza.get_or_create_libjuju_thread()
         model_name = zaza.model.get_juju_model()
-        self.model = COUModel(model_name)
+        self.model = Model(model_name)
         zaza.sync_wrapper(self.model.connect)()
 
     def tearDown(self) -> None:

--- a/tests/functional/tests/model.py
+++ b/tests/functional/tests/model.py
@@ -5,7 +5,7 @@ import unittest
 import zaza
 import zaza.model
 
-from cou.utils.juju_utils import COUModel
+from cou.utils.juju_utils import Model
 
 log = logging.getLogger(__name__)
 
@@ -13,13 +13,13 @@ TESTED_APP = "designate-bind"
 TESTED_UNIT = f"{TESTED_APP}/0"
 
 
-class COUModelTest(unittest.TestCase):
-    """COUModel functional tests."""
+class ModelTest(unittest.TestCase):
+    """Model functional tests."""
 
     def setUp(self) -> None:
         zaza.get_or_create_libjuju_thread()
         model_name = zaza.model.get_juju_model()
-        self.model = COUModel(model_name)
+        self.model = Model(model_name)
 
     def tearDown(self) -> None:
         zaza.sync_wrapper(self.model._model.disconnect)()
@@ -38,7 +38,7 @@ class COUModelTest(unittest.TestCase):
         self.assertEqual(TESTED_APP, charm)
 
     def test_get_status(self):
-        """Test COUModel.get_status."""
+        """Test Model.get_status."""
         status = zaza.sync_wrapper(self.model.get_status)()
         self.assertIn(TESTED_APP, status.applications)
 

--- a/tests/functional/tests/tests.yaml
+++ b/tests/functional/tests/tests.yaml
@@ -1,5 +1,5 @@
 tests:
-  - tests.functional.tests.model.COUModelTest
+  - tests.functional.tests.model.ModelTest
   - tests.functional.tests.smoke.SmokeTest
   - tests.functional.tests.backup.BackupTest
 gate_bundles:

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -563,14 +563,14 @@ async def get_charm_name(value: str):
 
 @pytest.fixture
 def model(config, apps_machines):
-    """Define test COUModel object."""
+    """Define test Model object."""
     machines = {}
     for sub_machines in apps_machines.values():
         machines = {**machines, **sub_machines}
     model_name = "test_model"
     from cou.utils import juju_utils
 
-    model = AsyncMock(spec_set=juju_utils.COUModel)
+    model = AsyncMock(spec_set=juju_utils.Model)
     type(model).name = PropertyMock(return_value=model_name)
     model.run_on_unit = AsyncMock()
     model.run_action = AsyncMock()

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -60,7 +60,7 @@ def test_get_log_level(quiet, verbosity, level):
 
 
 @pytest.mark.asyncio
-@patch("cou.cli.COUModel")
+@patch("cou.cli.Model")
 @patch("cou.cli.generate_plan", new_callable=AsyncMock)
 @patch("cou.cli.Analysis.create", new_callable=AsyncMock)
 async def test_analyze_and_plan(mock_analyze, mock_generate_plan, cou_model, cli_args):

--- a/tests/unit/utils/test_juju_utils.py
+++ b/tests/unit/utils/test_juju_utils.py
@@ -189,13 +189,13 @@ def test_machine_eq():
 
 @patch("cou.utils.juju_utils.FileJujuData")
 def test_coumodel_init(mock_juju_data, mocker):
-    """Test COUModel initialization."""
+    """Test Model initialization."""
     model_mocker = mocker.patch("cou.utils.juju_utils.Model")
     mocked_model = model_mocker.return_value
     mocked_model.connection.side_effect = NoConnectionException  # simulate an unconnected model
     name = "test-model"
 
-    model = juju_utils.COUModel(name)
+    model = juju_utils.Model(name)
 
     mock_juju_data.assert_called_once_with()
     model_mocker.assert_called_once_with(
@@ -205,49 +205,49 @@ def test_coumodel_init(mock_juju_data, mocker):
 
 
 def test_coumodel_connected_no_connection(mocked_model):
-    """Test COUModel connected property."""
+    """Test Model connected property."""
     mocked_model.connection.side_effect = NoConnectionException
 
-    model = juju_utils.COUModel("test-model")
+    model = juju_utils.Model("test-model")
 
     assert model.connected is False
 
 
 def test_coumodel_connected(mocked_model):
-    """Test COUModel connected property."""
+    """Test Model connected property."""
     mocked_model.connection.return_value.is_open = True
 
-    model = juju_utils.COUModel("test-model")
+    model = juju_utils.Model("test-model")
 
     assert model.connected is True
 
 
 def test_coumodel_name(mocked_model):
-    """Test COUModel name property without model name."""
+    """Test Model name property without model name."""
     exp_model_name = "test-model"
     mocked_model.connection.side_effect = NoConnectionException  # simulate an unconnected model
 
-    model = juju_utils.COUModel(exp_model_name)
+    model = juju_utils.Model(exp_model_name)
 
     assert model.name == exp_model_name
     model.juju_data.current_model.assert_not_called()
 
 
 def test_coumodel_name_no_name(mocked_model):
-    """Test COUModel name property without model name."""
+    """Test Model name property without model name."""
     mocked_model.connection.side_effect = NoConnectionException  # simulate an unconnected model
 
-    model = juju_utils.COUModel(None)
+    model = juju_utils.Model(None)
 
     assert model.name == model.juju_data.current_model.return_value
     model.juju_data.current_model.assert_called_once_with(model_only=True)
 
 
 def test_coumodel_name_connected(mocked_model):
-    """Test COUModel initialization without model name, but connected."""
+    """Test Model initialization without model name, but connected."""
     mocked_model.connection.return_value.is_open = True
 
-    model = juju_utils.COUModel(None)
+    model = juju_utils.Model(None)
 
     assert model.name == mocked_model.name
     model.juju_data.current_model.assert_not_called()
@@ -255,9 +255,9 @@ def test_coumodel_name_connected(mocked_model):
 
 @pytest.mark.asyncio
 async def test_coumodel_connect(mocked_model):
-    """Test COUModel connection."""
+    """Test Model connection."""
     name = "test-model"
-    model = juju_utils.COUModel(name)
+    model = juju_utils.Model(name)
     await model.connect()
 
     mocked_model.disconnect.assert_awaited_once_with()
@@ -270,9 +270,9 @@ async def test_coumodel_connect(mocked_model):
 
 @pytest.mark.asyncio
 async def test_coumodel_get_application(mocked_model):
-    """Test COUModel get application."""
+    """Test Model get application."""
     app_name = "test-app"
-    model = juju_utils.COUModel("test-model")
+    model = juju_utils.Model("test-model")
 
     app = await model._get_application(app_name)
 
@@ -282,8 +282,8 @@ async def test_coumodel_get_application(mocked_model):
 
 @pytest.mark.asyncio
 async def test_coumodel_get_application_failure(mocked_model):
-    """Test COUModel get not existing application."""
-    model = juju_utils.COUModel("test-model")
+    """Test Model get not existing application."""
+    model = juju_utils.Model("test-model")
     mocked_model.applications.get.return_value = None
 
     with pytest.raises(ApplicationNotFound):
@@ -292,10 +292,10 @@ async def test_coumodel_get_application_failure(mocked_model):
 
 @pytest.mark.asyncio
 async def test_coumodel_get_model(mocked_model):
-    """Test COUModel get connected model object."""
+    """Test Model get connected model object."""
     mocked_model.connection.return_value = None  # simulate disconnected model
 
-    model = juju_utils.COUModel("test-model")
+    model = juju_utils.Model("test-model")
     juju_model = await model._get_model()
 
     mocked_model.disconnect.assert_awaited_once()
@@ -305,9 +305,9 @@ async def test_coumodel_get_model(mocked_model):
 
 @pytest.mark.asyncio
 async def test_coumodel_get_unit(mocked_model):
-    """Test COUModel get unit."""
+    """Test Model get unit."""
     unit_name = "test-unit"
-    model = juju_utils.COUModel("test-model")
+    model = juju_utils.Model("test-model")
 
     unit = await model._get_unit(unit_name)
 
@@ -317,8 +317,8 @@ async def test_coumodel_get_unit(mocked_model):
 
 @pytest.mark.asyncio
 async def test_coumodel_get_unit_failure(mocked_model):
-    """Test COUModel get not existing unit."""
-    model = juju_utils.COUModel("test-model")
+    """Test Model get not existing unit."""
+    model = juju_utils.Model("test-model")
     mocked_model.units.get.return_value = None
 
     with pytest.raises(UnitNotFound):
@@ -328,9 +328,9 @@ async def test_coumodel_get_unit_failure(mocked_model):
 @pytest.mark.asyncio
 @patch("cou.utils.juju_utils.is_charm_supported")
 async def test_coumodel_get_supported_apps(mock_is_charm_supported, mocked_model):
-    """Test COUModel providing list of supported applications."""
+    """Test Model providing list of supported applications."""
     mock_is_charm_supported.side_effect = [False, True]
-    model = juju_utils.COUModel("test-model")
+    model = juju_utils.Model("test-model")
     app = MagicMock(spec_set=Application).return_value
     mocked_model.applications = {"unsupported": app, "supported": app}
 
@@ -342,9 +342,9 @@ async def test_coumodel_get_supported_apps(mock_is_charm_supported, mocked_model
 
 @pytest.mark.asyncio
 async def test_coumodel_get_application_configs(mocked_model):
-    """Test COUModel get application configuration."""
+    """Test Model get application configuration."""
     mocked_model.applications.get.return_value = mocked_app = AsyncMock(Application)
-    model = juju_utils.COUModel("test-model")
+    model = juju_utils.Model("test-model")
 
     app = await model.get_application_config("test-app")
 
@@ -354,9 +354,9 @@ async def test_coumodel_get_application_configs(mocked_model):
 
 @pytest.mark.asyncio
 async def test_coumodel_get_charm_name(mocked_model):
-    """Test COUModel get charm name from application by application name."""
+    """Test Model get charm name from application by application name."""
     mocked_model.applications.get.return_value = mocked_app = AsyncMock(Application)
-    model = juju_utils.COUModel("test-model")
+    model = juju_utils.Model("test-model")
 
     charm_name = await model.get_charm_name("test-app")
 
@@ -365,11 +365,11 @@ async def test_coumodel_get_charm_name(mocked_model):
 
 @pytest.mark.asyncio
 async def test_coumodel_get_charm_name_failure(mocked_model):
-    """Test COUModel get charm name from application by application name."""
+    """Test Model get charm name from application by application name."""
     mocked_model.applications.get.return_value = mocked_app = AsyncMock(Application)
     mocked_app.charm_name = None
     app_name = "test-app"
-    model = juju_utils.COUModel("test-model")
+    model = juju_utils.Model("test-model")
 
     with pytest.raises(ApplicationError, match=f"Cannot obtain charm_name for {app_name}"):
         await model.get_charm_name("test-app")
@@ -377,8 +377,8 @@ async def test_coumodel_get_charm_name_failure(mocked_model):
 
 @pytest.mark.asyncio
 async def test_coumodel_get_status(mocked_model):
-    """Test COUModel get model status."""
-    model = juju_utils.COUModel("test-model")
+    """Test Model get model status."""
+    model = juju_utils.Model("test-model")
 
     status = await model.get_status()
 
@@ -388,9 +388,9 @@ async def test_coumodel_get_status(mocked_model):
 
 @pytest.mark.asyncio
 async def test_coumodel_get_action_result(mocked_model):
-    """Test COUModel get action result."""
+    """Test Model get action result."""
     mocked_action = AsyncMock(spec_set=Action).return_value
-    model = juju_utils.COUModel("test-model")
+    model = juju_utils.Model("test-model")
 
     action = await model._get_action_result(mocked_action, False)
 
@@ -401,10 +401,10 @@ async def test_coumodel_get_action_result(mocked_model):
 
 @pytest.mark.asyncio
 async def test_coumodel_get_action_result_failure(mocked_model):
-    """Test COUModel get action result failing."""
+    """Test Model get action result failing."""
     mocked_action = AsyncMock(spec_set=Action).return_value
     mocked_model.get_action_status.return_value = "failed"
-    model = juju_utils.COUModel("test-model")
+    model = juju_utils.Model("test-model")
 
     with pytest.raises(ActionFailed):
         await model._get_action_result(mocked_action, True)
@@ -416,14 +416,14 @@ async def test_coumodel_get_action_result_failure(mocked_model):
 
 
 @pytest.mark.asyncio
-@patch("cou.utils.juju_utils.COUModel._get_action_result")
+@patch("cou.utils.juju_utils.Model._get_action_result")
 async def test_coumodel_run_action(mock_get_action_result, mocked_model):
-    """Test COUModel run action."""
+    """Test Model run action."""
     action_name = "test-action"
     action_params = {"test-arg": "test"}
     mocked_model.units.get.return_value = mocked_unit = AsyncMock(Unit)
     mock_get_action_result.return_value = mocked_result = AsyncMock(Action)
-    model = juju_utils.COUModel("test-model")
+    model = juju_utils.Model("test-model")
 
     action = await model.run_action("test_unit/0", action_name, action_params=action_params)
 
@@ -435,13 +435,13 @@ async def test_coumodel_run_action(mock_get_action_result, mocked_model):
 @pytest.mark.asyncio
 @patch("cou.utils.juju_utils._normalize_action_results")
 async def test_coumodel_run_on_unit(mock_normalize_action_results, mocked_model):
-    """Test COUModel run on unit."""
+    """Test Model run on unit."""
     command = "test-command"
     mocked_model.units.get.return_value = mocked_unit = AsyncMock(Unit)
     mocked_unit.run.return_value = mocked_action = AsyncMock(Action)
     results = mocked_action.data.get.return_value
     mock_normalize_action_results.return_value = {"Code": "0", "Stdout": "some results"}
-    model = juju_utils.COUModel("test-model")
+    model = juju_utils.Model("test-model")
 
     await model.run_on_unit("test-unit/0", command)
 
@@ -452,13 +452,13 @@ async def test_coumodel_run_on_unit(mock_normalize_action_results, mocked_model)
 @pytest.mark.asyncio
 @patch("cou.utils.juju_utils._normalize_action_results")
 async def test_coumodel_run_on_unit_failed_command(mock_normalize_action_results, mocked_model):
-    """Test COUModel run on unit."""
+    """Test Model run on unit."""
     command = "test-command"
     mocked_model.units.get.return_value = mocked_unit = AsyncMock(Unit)
     mocked_unit.run.return_value = mocked_action = AsyncMock(Action)
     results = mocked_action.data.get.return_value
     mock_normalize_action_results.return_value = {"Code": "1", "Stderr": "Error!"}
-    model = juju_utils.COUModel("test-model")
+    model = juju_utils.Model("test-model")
 
     with pytest.raises(CommandRunFailed):
         await model.run_on_unit("test-unit/0", command)
@@ -469,10 +469,10 @@ async def test_coumodel_run_on_unit_failed_command(mock_normalize_action_results
 
 @pytest.mark.asyncio
 async def test_coumodel_set_application_configs(mocked_model):
-    """Test COUModel set application configuration."""
+    """Test Model set application configuration."""
     test_config = {"test-key": "test-value"}
     mocked_model.applications.get.return_value = mocked_app = AsyncMock(Application)
-    model = juju_utils.COUModel("test-model")
+    model = juju_utils.Model("test-model")
 
     await model.set_application_config("test-app", test_config)
 
@@ -481,10 +481,10 @@ async def test_coumodel_set_application_configs(mocked_model):
 
 @pytest.mark.asyncio
 async def test_coumodel_scp_from_unit(mocked_model):
-    """Test COUModel scp from unit to destination."""
+    """Test Model scp from unit to destination."""
     source, destination = "/tmp/source", "/tmp/destination"
     mocked_model.units.get.return_value = mocked_unit = AsyncMock(Unit)
-    model = juju_utils.COUModel("test-model")
+    model = juju_utils.Model("test-model")
 
     await model.scp_from_unit("test-unit/0", source, destination)
 
@@ -495,11 +495,11 @@ async def test_coumodel_scp_from_unit(mocked_model):
 
 @pytest.mark.asyncio
 async def test_coumodel_upgrade_charm(mocked_model):
-    """Test COUModel upgrade application."""
+    """Test Model upgrade application."""
     application_name = "test-app"
     channel = "latest/edge"
     mocked_model.applications.get.return_value = mocked_app = AsyncMock(Application)
-    model = juju_utils.COUModel("test-model")
+    model = juju_utils.Model("test-model")
 
     await model.upgrade_charm(application_name, channel)
 
@@ -514,11 +514,11 @@ async def test_coumodel_upgrade_charm(mocked_model):
 
 
 @pytest.mark.asyncio
-@patch("cou.utils.juju_utils.COUModel._get_supported_apps")
+@patch("cou.utils.juju_utils.Model._get_supported_apps")
 async def test_coumodel_wait_for_active_idle(mock_get_supported_apps, mocked_model):
-    """Test COUModel wait for related apps to be active idle."""
+    """Test Model wait for related apps to be active idle."""
     timeout = 60
-    model = juju_utils.COUModel("test-model")
+    model = juju_utils.Model("test-model")
     mock_get_supported_apps.return_value = ["app1", "app2"]
 
     await model.wait_for_active_idle(timeout)
@@ -534,11 +534,11 @@ async def test_coumodel_wait_for_active_idle(mock_get_supported_apps, mocked_mod
 
 
 @pytest.mark.asyncio
-@patch("cou.utils.juju_utils.COUModel._get_supported_apps")
+@patch("cou.utils.juju_utils.Model._get_supported_apps")
 async def test_coumodel_wait_for_active_idle_apps(mock_get_supported_apps, mocked_model):
-    """Test COUModel wait for specific apps to be active idle."""
+    """Test Model wait for specific apps to be active idle."""
     timeout = 60
-    model = juju_utils.COUModel("test-model")
+    model = juju_utils.Model("test-model")
 
     await model.wait_for_active_idle(timeout, apps=["app1"])
 
@@ -553,13 +553,13 @@ async def test_coumodel_wait_for_active_idle_apps(mock_get_supported_apps, mocke
 
 
 @pytest.mark.asyncio
-@patch("cou.utils.juju_utils.COUModel._get_supported_apps")
+@patch("cou.utils.juju_utils.Model._get_supported_apps")
 async def test_coumodel_wait_for_active_idle_timeout(mock_get_supported_apps, mocked_model):
-    """Test COUModel wait for model to be active idle reach timeout."""
+    """Test Model wait for model to be active idle reach timeout."""
     timeout = 60
     exp_apps = ["app1", "app2"]
     mocked_model.wait_for_idle.side_effect = asyncio.exceptions.TimeoutError
-    model = juju_utils.COUModel(None)
+    model = juju_utils.Model(None)
 
     with pytest.raises(WaitForApplicationsTimeout):
         await model.wait_for_active_idle(timeout, apps=exp_apps)
@@ -576,7 +576,7 @@ async def test_coumodel_wait_for_active_idle_timeout(mock_get_supported_apps, mo
 
 @pytest.mark.asyncio
 async def test_get_machines(mocked_model):
-    """Test COUModel getting machines from model."""
+    """Test Model getting machines from model."""
     expected_machines = {
         "0": juju_utils.Machine(
             "0",
@@ -601,7 +601,7 @@ async def test_get_machines(mocked_model):
         "app2": MagicMock(spec_set=Application)(),
     }
 
-    model = juju_utils.COUModel("test-model")
+    model = juju_utils.Model("test-model")
     machines = await model.get_machines()
 
     assert machines == expected_machines

--- a/tests/unit/utils/test_juju_utils.py
+++ b/tests/unit/utils/test_juju_utils.py
@@ -38,7 +38,7 @@ from cou.utils import juju_utils
 def mocked_model(mocker):
     """Fixture providing mocked juju.model.Model object."""
     mocker.patch("cou.utils.juju_utils.FileJujuData")
-    model_mocker = mocker.patch("cou.utils.juju_utils.Model", return_value=AsyncMock(Model))
+    model_mocker = mocker.patch("cou.utils.juju_utils.JujuModel", return_value=AsyncMock(Model))
     model = model_mocker.return_value
     model.connection.return_value.is_open = True  # simulate already connected model
     yield model
@@ -190,7 +190,7 @@ def test_machine_eq():
 @patch("cou.utils.juju_utils.FileJujuData")
 def test_coumodel_init(mock_juju_data, mocker):
     """Test Model initialization."""
-    model_mocker = mocker.patch("cou.utils.juju_utils.Model")
+    model_mocker = mocker.patch("cou.utils.juju_utils.JujuModel")
     mocked_model = model_mocker.return_value
     mocked_model.connection.side_effect = NoConnectionException  # simulate an unconnected model
     name = "test-model"


### PR DESCRIPTION
We agreed that from all object from juju_utils we will remove prefix `COU`, so this is first part to make next PR little bit smaller. 