### PR TITLE
Enhance clarity and consistency of step descriptions (#302)

### DIFF
--- a/cou/apps/auxiliary.py
+++ b/cou/apps/auxiliary.py
@@ -162,7 +162,9 @@ class CephMonApplication(OpenStackAuxiliaryApplication):
         """
         ceph_mon_unit, *_ = self.units
         return PreUpgradeStep(
-            description="Ensure require-osd-release option matches with ceph-osd version",
+            description=(
+                "Ensure that the 'require-osd-release' option matches the 'ceph-osd' version"
+            ),
             parallel=parallel,
             coro=set_require_osd_release_option(ceph_mon_unit.name, self.model),
         )

--- a/cou/apps/base.py
+++ b/cou/apps/base.py
@@ -499,7 +499,7 @@ class OpenStackApplication:
         :rtype: ApplicationUpgradePlan
         """
         upgrade_steps = ApplicationUpgradePlan(
-            description=f"Upgrade plan for '{self.name}' to {target}",
+            description=f"Upgrade plan for '{self.name}' to '{target}'",
         )
         all_steps = (
             self.pre_upgrade_plan(target)
@@ -561,7 +561,7 @@ class OpenStackApplication:
             )
 
         if self.charm_origin == "cs":
-            description = f"Migration of '{self.name}' from charmstore to charmhub"
+            description = f"Migrate '{self.name}' from charmstore to charmhub"
             switch = f"ch:{self.charm}"
         elif self.channel in self.possible_current_channels:
             channel = self.channel
@@ -674,7 +674,7 @@ class OpenStackApplication:
         :rtype: PostUpgradeStep
         """
         return PostUpgradeStep(
-            description=f"Check if the workload of '{self.name}' has been upgraded",
+            description=f"Verify that the workload of '{self.name}' has been upgraded",
             parallel=parallel,
             coro=self._check_upgrade(target),
         )
@@ -687,11 +687,15 @@ class OpenStackApplication:
         """
         if self.wait_for_model:
             description = (
-                f"Wait {self.wait_timeout}s for model {self.model.name} to reach the idle state."
+                f"Wait for up to {self.wait_timeout}s for model '{self.model.name}' "
+                "to reach the idle state"
             )
             apps = None
         else:
-            description = f"Wait {self.wait_timeout}s for app {self.name} to reach the idle state."
+            description = (
+                f"Wait for up to {self.wait_timeout}s for app '{self.name}' "
+                "to reach the idle state"
+            )
             apps = [self.name]
 
         return PostUpgradeStep(

--- a/cou/steps/plan.py
+++ b/cou/steps/plan.py
@@ -92,7 +92,7 @@ async def generate_plan(analysis_result: Analysis, backup_database: bool) -> Upg
     if backup_database:
         plan.add_step(
             PreUpgradeStep(
-                description="Backup mysql databases",
+                description="Back up MySQL databases",
                 parallel=False,
                 coro=backup(analysis_result.model),
             )
@@ -129,7 +129,7 @@ async def create_upgrade_group(
     :type apps: list[OpenStackApplication]
     :param target: Target OpenStack release.
     :type target: OpenStackRelease
-    :param description: Description of the upgrade step.
+    :param description: Description of the upgrade plan.
     :type description: str
     :param filter_function: Function to filter applications.
     :type filter_function: Callable[[OpenStackApplication], bool]

--- a/docs/how-to/interruption.rst
+++ b/docs/how-to/interruption.rst
@@ -25,13 +25,13 @@ Usage example:
     ...
     Running cloud upgrade...
     Verify that all OpenStack applications are in idle state ✔
-    Backup mysql databases ✔
-    Upgrade plan for 'keystone' to victoria
+    Back up MySQL databases ✔
+    Upgrade plan for 'keystone' to 'victoria'
         Upgrade software packages of 'keystone' from the current APT repositories
         Upgrade 'keystone' to the new channel: 'victoria/stable'
         Change charm config of 'keystone' 'openstack-origin' to 'cloud:focal-victoria'
-        Wait 1800s for model test-model to reach the idle state.
-        Check if the workload of 'keystone' has been upgraded
+        Wait for up to 1800s for model 'test-model' to reach the idle state
+        Verify that the workload of 'keystone' has been upgraded
 
     Would you like to start the upgrade? Continue (y/N): n
 

--- a/docs/how-to/no-backup.rst
+++ b/docs/how-to/no-backup.rst
@@ -21,7 +21,7 @@ Plan:
         Verify that all OpenStack applications are in idle state
         # note that there's no backup step planned
         Control Plane principal(s) upgrade plan
-        Upgrade plan for 'rabbitmq-server' to victoria
+        Upgrade plan for 'rabbitmq-server' to 'victoria'
             Upgrade software packages of 'rabbitmq-server' from the current APT repositories
         ...
 
@@ -39,15 +39,15 @@ Upgrade:
     Verify that all OpenStack applications are in idle state ✔
     # note that there's no backup step being executed
 
-    Upgrade plan for 'rabbitmq-server' to victoria
+    Upgrade plan for 'rabbitmq-server' to 'victoria'
         Upgrade software packages of 'rabbitmq-server' from the current APT repositories
         Upgrade 'rabbitmq-server' to the new channel: '3.9/stable'
         Change charm config of 'rabbitmq-server' 'source' to 'cloud:focal-victoria'
-        Wait 1800s for model test-model to reach the idle state.
-        Check if the workload of 'rabbitmq-server' has been upgraded
+        Wait for up to 1800s for model 'test-model' to reach the idle state
+        Verify that the workload of 'rabbitmq-server' has been upgraded
 
     Continue (y/n): y
-    Upgrade plan for 'rabbitmq-server' to victoria ✔
-    
+    Upgrade plan for 'rabbitmq-server' to 'victoria' ✔
+
     ... # apply steps
     Upgrade completed.

--- a/docs/how-to/plan-upgrade.rst
+++ b/docs/how-to/plan-upgrade.rst
@@ -21,61 +21,61 @@ Usage example
     Generating upgrade plan... ✔
     Upgrade cloud from 'ussuri' to 'victoria'
         Verify that all OpenStack applications are in idle state
-        Backup mysql databases
+        Back up MySQL databases
         Control Plane principal(s) upgrade plan
-        Upgrade plan for 'rabbitmq-server' to victoria
+        Upgrade plan for 'rabbitmq-server' to 'victoria'
             Upgrade software packages of 'rabbitmq-server' from the current APT repositories
             Upgrade 'rabbitmq-server' to the new channel: '3.9/stable'
             Change charm config of 'rabbitmq-server' 'source' to 'cloud:focal-victoria'
-            Wait 1800s for model test-model to reach the idle state.
-            Check if the workload of 'rabbitmq-server' has been upgraded
-        Upgrade plan for 'keystone' to victoria
+            Wait for up to 1800s for model 'test-model' to reach the idle state
+            Verify that the workload of 'rabbitmq-server' has been upgraded
+        Upgrade plan for 'keystone' to 'victoria'
             Upgrade software packages of 'keystone' from the current APT repositories
             Upgrade 'keystone' to the new channel: 'victoria/stable'
             Change charm config of 'keystone' 'openstack-origin' to 'cloud:focal-victoria'
-            Wait 1800s for model test-model to reach the idle state.
-            Check if the workload of 'keystone' has been upgraded
-        Upgrade plan for 'cinder' to victoria
+            Wait for up to 1800s for model 'test-model' to reach the idle state
+            Verify that the workload of 'keystone' has been upgraded
+        Upgrade plan for 'cinder' to 'victoria'
             Upgrade software packages of 'cinder' from the current APT repositories
             Upgrade 'cinder' to the new channel: 'victoria/stable'
             Change charm config of 'cinder' 'openstack-origin' to 'cloud:focal-victoria'
-            Wait 300s for app cinder to reach the idle state.
-            Check if the workload of 'cinder' has been upgraded
-        Upgrade plan for 'glance' to victoria
+            Wait for up to 300s for app 'cinder' to reach the idle state
+            Verify that the workload of 'cinder' has been upgraded
+        Upgrade plan for 'glance' to 'victoria'
             Upgrade software packages of 'glance' from the current APT repositories
             Upgrade 'glance' to the new channel: 'victoria/stable'
             Change charm config of 'glance' 'openstack-origin' to 'cloud:focal-victoria'
-            Wait 300s for app glance to reach the idle state.
-            Check if the workload of 'glance' has been upgraded
-        Upgrade plan for 'neutron-api' to victoria
+            Wait for up to 300s for app 'glance' to reach the idle state
+            Verify that the workload of 'glance' has been upgraded
+        Upgrade plan for 'neutron-api' to 'victoria'
             Upgrade software packages of 'neutron-api' from the current APT repositories
             Upgrade 'neutron-api' to the new channel: 'victoria/stable'
             Change charm config of 'neutron-api' 'openstack-origin' to 'cloud:focal-victoria'
-            Wait 300s for app neutron-api to reach the idle state.
-            Check if the workload of 'neutron-api' has been upgraded
-        Upgrade plan for 'neutron-gateway' to victoria
+            Wait for up to 300s for app 'neutron-api' to reach the idle state
+            Verify that the workload of 'neutron-api' has been upgraded
+        Upgrade plan for 'neutron-gateway' to 'victoria'
             Upgrade software packages of 'neutron-gateway' from the current APT repositories
             Upgrade 'neutron-gateway' to the new channel: 'victoria/stable'
             Change charm config of 'neutron-gateway' 'openstack-origin' to 'cloud:focal-victoria'
-            Wait 300s for app neutron-gateway to reach the idle state.
-            Check if the workload of 'neutron-gateway' has been upgraded
-        Upgrade plan for 'placement' to victoria
+            Wait for up to 300s for app 'neutron-gateway' to reach the idle state
+            Verify that the workload of 'neutron-gateway' has been upgraded
+        Upgrade plan for 'placement' to 'victoria'
             Upgrade software packages of 'placement' from the current APT repositories
             Upgrade 'placement' to the new channel: 'victoria/stable'
             Change charm config of 'placement' 'openstack-origin' to 'cloud:focal-victoria'
-            Wait 300s for app placement to reach the idle state.
-            Check if the workload of 'placement' has been upgraded
-        Upgrade plan for 'nova-cloud-controller' to victoria
+            Wait for up to 300s for app 'placement' to reach the idle state
+            Verify that the workload of 'placement' has been upgraded
+        Upgrade plan for 'nova-cloud-controller' to 'victoria'
             Upgrade software packages of 'nova-cloud-controller' from the current APT repositories
             Upgrade 'nova-cloud-controller' to the new channel: 'victoria/stable'
             Change charm config of 'nova-cloud-controller' 'openstack-origin' to 'cloud:focal-victoria'
-            Wait 300s for app nova-cloud-controller to reach the idle state.
-            Check if the workload of 'nova-cloud-controller' has been upgraded
-        Upgrade plan for 'mysql' to victoria
+            Wait for up to 300s for app 'nova-cloud-controller' to reach the idle state
+            Verify that the workload of 'nova-cloud-controller' has been upgraded
+        Upgrade plan for 'mysql' to 'victoria'
             Upgrade software packages of 'mysql' from the current APT repositories
             Change charm config of 'mysql' 'source' to 'cloud:focal-victoria'
-            Wait 1800s for app mysql to reach the idle state.
-            Check if the workload of 'mysql' has been upgraded
+            Wait for up to 1800s for app 'mysql' to reach the idle state
+            Verify that the workload of 'mysql' has been upgraded
         Control Plane subordinate(s) upgrade plan
-        Upgrade plan for 'neutron-openvswitch' to victoria
+        Upgrade plan for 'neutron-openvswitch' to 'victoria'
             Upgrade 'neutron-openvswitch' to the new channel: 'victoria/stable'

--- a/docs/how-to/upgrade-cloud.rst
+++ b/docs/how-to/upgrade-cloud.rst
@@ -25,87 +25,87 @@ Usage example
     Generating upgrade plan... ✔
     Upgrade cloud from 'ussuri' to 'victoria'
         Verify that all OpenStack applications are in idle state
-        Backup mysql databases
+        Back up MySQL databases
         Control Plane principal(s) upgrade plan
-        Upgrade plan for 'rabbitmq-server' to victoria
+        Upgrade plan for 'rabbitmq-server' to 'victoria'
             Upgrade software packages of 'rabbitmq-server' from the current APT repositories
             Upgrade 'rabbitmq-server' to the new channel: '3.9/stable'
             Change charm config of 'rabbitmq-server' 'source' to 'cloud:focal-victoria'
-            Wait 1800s for model test-model to reach the idle state.
-            Check if the workload of 'rabbitmq-server' has been upgraded
-        Upgrade plan for 'keystone' to victoria
+            Wait for up to 1800s for model 'test-model' to reach the idle state
+            Verify that the workload of 'rabbitmq-server' has been upgraded
+        Upgrade plan for 'keystone' to 'victoria'
             Upgrade software packages of 'keystone' from the current APT repositories
             Upgrade 'keystone' to the new channel: 'victoria/stable'
             Change charm config of 'keystone' 'openstack-origin' to 'cloud:focal-victoria'
-            Wait 1800s for model test-model to reach the idle state.
-            Check if the workload of 'keystone' has been upgraded
-        Upgrade plan for 'cinder' to victoria
+            Wait for up to 1800s for model 'test-model' to reach the idle state
+            Verify that the workload of 'keystone' has been upgraded
+        Upgrade plan for 'cinder' to 'victoria'
             Upgrade software packages of 'cinder' from the current APT repositories
             Refresh 'cinder' to the latest revision of 'ussuri/stable'
             Upgrade 'cinder' to the new channel: 'victoria/stable'
             Change charm config of 'cinder' 'openstack-origin' to 'cloud:focal-victoria'
-            Wait 300s for app cinder to reach the idle state.
-            Check if the workload of 'cinder' has been upgraded
-        Upgrade plan for 'glance' to victoria
+            Wait for up to 300s for app 'cinder' to reach the idle state
+            Verify that the workload of 'cinder' has been upgraded
+        Upgrade plan for 'glance' to 'victoria'
             Upgrade software packages of 'glance' from the current APT repositories
             Upgrade 'glance' to the new channel: 'victoria/stable'
             Change charm config of 'glance' 'openstack-origin' to 'cloud:focal-victoria'
-            Wait 300s for app glance to reach the idle state.
-            Check if the workload of 'glance' has been upgraded
-        Upgrade plan for 'neutron-api' to victoria
+            Wait for up to 300s for app 'glance' to reach the idle state
+            Verify that the workload of 'glance' has been upgraded
+        Upgrade plan for 'neutron-api' to 'victoria'
             Upgrade software packages of 'neutron-api' from the current APT repositories
             Upgrade 'neutron-api' to the new channel: 'victoria/stable'
             Change charm config of 'neutron-api' 'openstack-origin' to 'cloud:focal-victoria'
-            Wait 300s for app neutron-api to reach the idle state.
-            Check if the workload of 'neutron-api' has been upgraded
-        Upgrade plan for 'neutron-gateway' to victoria
+            Wait for up to 300s for app 'neutron-api' to reach the idle state
+            Verify that the workload of 'neutron-api' has been upgraded
+        Upgrade plan for 'neutron-gateway' to 'victoria'
             Upgrade software packages of 'neutron-gateway' from the current APT repositories
             Upgrade 'neutron-gateway' to the new channel: 'victoria/stable'
             Change charm config of 'neutron-gateway' 'openstack-origin' to 'cloud:focal-victoria'
-            Wait 300s for app neutron-gateway to reach the idle state.
-            Check if the workload of 'neutron-gateway' has been upgraded
-        Upgrade plan for 'placement' to victoria
+            Wait for up to 300s for app 'neutron-gateway' to reach the idle state
+            Verify that the workload of 'neutron-gateway' has been upgraded
+        Upgrade plan for 'placement' to 'victoria'
             Upgrade software packages of 'placement' from the current APT repositories
             Upgrade 'placement' to the new channel: 'victoria/stable'
             Change charm config of 'placement' 'openstack-origin' to 'cloud:focal-victoria'
-            Wait 300s for app placement to reach the idle state.
-            Check if the workload of 'placement' has been upgraded
-        Upgrade plan for 'nova-cloud-controller' to victoria
+            Wait for up to 300s for app 'placement' to reach the idle state
+            Verify that the workload of 'placement' has been upgraded
+        Upgrade plan for 'nova-cloud-controller' to 'victoria'
             Upgrade software packages of 'nova-cloud-controller' from the current APT repositories
             Refresh 'nova-cloud-controller' to the latest revision of 'ussuri/stable'
             Upgrade 'nova-cloud-controller' to the new channel: 'victoria/stable'
             Change charm config of 'nova-cloud-controller' 'openstack-origin' to 'cloud:focal-victoria'
-            Wait 300s for app nova-cloud-controller to reach the idle state.
-            Check if the workload of 'nova-cloud-controller' has been upgraded
-        Upgrade plan for 'mysql' to victoria
+            Wait for up to 300s for app 'nova-cloud-controller' to reach the idle state
+            Verify that the workload of 'nova-cloud-controller' has been upgraded
+        Upgrade plan for 'mysql' to 'victoria'
             Upgrade software packages of 'mysql' from the current APT repositories
             Change charm config of 'mysql' 'source' to 'cloud:focal-victoria'
-            Wait 1800s for app mysql to reach the idle state.
-            Check if the workload of 'mysql' has been upgraded
+            Wait for up to 1800s for app 'mysql' to reach the idle state
+            Verify that the workload of 'mysql' has been upgraded
         Control Plane subordinate(s) upgrade plan
-        Upgrade plan for 'neutron-openvswitch' to victoria
+        Upgrade plan for 'neutron-openvswitch' to 'victoria'
             Upgrade 'neutron-openvswitch' to the new channel: 'victoria/stable'
     Would you like to start the upgrade? Continue (y/N): y
     Running cloud upgrade...
     Verify that all OpenStack applications are in idle state ✔
-    Backup mysql databases ✔
+    Back up MySQL databases ✔
 
-    Upgrade plan for 'rabbitmq-server' to victoria
+    Upgrade plan for 'rabbitmq-server' to 'victoria'
         Upgrade software packages of 'rabbitmq-server' from the current APT repositories
         Upgrade 'rabbitmq-server' to the new channel: '3.9/stable'
         Change charm config of 'rabbitmq-server' 'source' to 'cloud:focal-victoria'
-        Wait 1800s for model test-model to reach the idle state.
-        Check if the workload of 'rabbitmq-server' has been upgraded
+        Wait for up to 1800s for model 'test-model' to reach the idle state
+        Verify that the workload of 'rabbitmq-server' has been upgraded
 
     Continue (y/n): y
-    Upgrade plan for 'rabbitmq-server' to victoria ✔
+    Upgrade plan for 'rabbitmq-server' to 'victoria' ✔
 
-    Upgrade plan for 'keystone' to victoria
+    Upgrade plan for 'keystone' to 'victoria'
             Upgrade software packages of 'keystone' from the current APT repositories
             Upgrade 'keystone' to the new channel: 'victoria/stable'
             Change charm config of 'keystone' 'openstack-origin' to 'cloud:focal-victoria'
-            Wait 1800s for model test-model to reach the idle state.
-            Check if the workload of 'keystone' has been upgraded
+            Wait for up to 1800s for model 'test-model' to reach the idle state
+            Verify that the workload of 'keystone' has been upgraded
 
     Continue (y/n): y
     Upgrade software packages of 'keystone' from the current APT repositories \
@@ -137,7 +137,7 @@ Non-interactive mode:
     ...
     Running cloud upgrade...
     Verify that all OpenStack applications are in idle state ✔
-    Backup mysql databases ✔
+    Back up MySQL databases ✔
     Upgrade software packages of 'keystone' from the current APT repositories ✔
     Upgrade 'keystone' to the new channel: 'victoria/stable' ✔
     ...

--- a/tests/functional/tests/smoke.py
+++ b/tests/functional/tests/smoke.py
@@ -131,25 +131,25 @@ class SmokeTest(unittest.TestCase):
         :return: The upgrade plan.
         :rtype: str
         """
-        backup_plan = "\tBackup mysql databases\n" if backup else ""
+        backup_plan = "\tBack up MySQL databases\n" if backup else ""
         return (
             "Upgrade cloud from 'ussuri' to 'victoria'\n"
             "\tVerify that all OpenStack applications are in idle state\n"
             f"{backup_plan}"
             "\tControl Plane principal(s) upgrade plan\n"
-            "\t\tUpgrade plan for 'designate-bind' to victoria\n"
+            "\t\tUpgrade plan for 'designate-bind' to 'victoria'\n"
             "\t\t\tUpgrade software packages of 'designate-bind' "
             "from the current APT repositories\n"
             "\t\t\tUpgrade 'designate-bind' to the new channel: 'victoria/stable'\n"
-            "\t\t\tWait 300s for app designate-bind to reach the idle state.\n"
-            "\t\t\tCheck if the workload of 'designate-bind' has been upgraded\n"
-            "\t\tUpgrade plan for 'mysql-innodb-cluster' to victoria\n"
+            "\t\t\tWait for up to 300s for app 'designate-bind' to reach the idle state\n"
+            "\t\t\tVerify that the workload of 'designate-bind' has been upgraded\n"
+            "\t\tUpgrade plan for 'mysql-innodb-cluster' to 'victoria'\n"
             "\t\t\tUpgrade software packages of 'mysql-innodb-cluster' "
             "from the current APT repositories\n"
             "\t\t\tChange charm config of 'mysql-innodb-cluster' 'source' to "
             "'cloud:focal-victoria'\n"
-            "\t\t\tWait 1800s for app mysql-innodb-cluster to reach the idle state.\n"
-            "\t\t\tCheck if the workload of 'mysql-innodb-cluster' has been upgraded\n"
+            "\t\t\tWait for up to 1800s for app 'mysql-innodb-cluster' to reach the idle state\n"
+            "\t\t\tVerify that the workload of 'mysql-innodb-cluster' has been upgraded\n"
         )
 
     def test_help(self) -> None:
@@ -183,8 +183,8 @@ class SmokeTest(unittest.TestCase):
         """Test cou upgrade."""
         # designate-bind upgrades from ussuri to victoria
         expected_msgs_before_upgrade = [
-            "Upgrade plan for 'designate-bind' to victoria",
-            "Upgrade plan for 'mysql-innodb-cluster' to victoria",
+            "Upgrade plan for 'designate-bind' to 'victoria'",
+            "Upgrade plan for 'mysql-innodb-cluster' to 'victoria'",
         ]
         result_before_upgrade = self.cou(
             ["upgrade", "--model", self.model_name, "--no-backup", "--auto-approve"]
@@ -195,8 +195,8 @@ class SmokeTest(unittest.TestCase):
 
         # designate-bind was upgraded to victoria and next step is to wallaby
         expected_msg_after_upgrade = [
-            "Upgrade plan for 'designate-bind' to wallaby",
-            "Upgrade plan for 'mysql-innodb-cluster' to wallaby",
+            "Upgrade plan for 'designate-bind' to 'wallaby'",
+            "Upgrade plan for 'mysql-innodb-cluster' to 'wallaby'",
         ]
         result_after_upgrade = self.cou(["plan", "--model", self.model_name, "--no-backup"]).stdout
         for expected_msg in expected_msg_after_upgrade:

--- a/tests/unit/apps/test_auxiliary.py
+++ b/tests/unit/apps/test_auxiliary.py
@@ -102,7 +102,7 @@ def test_auxiliary_upgrade_plan_ussuri_to_victoria_change_channel(status, config
     upgrade_plan = app.generate_upgrade_plan(target)
 
     expected_plan = ApplicationUpgradePlan(
-        description=f"Upgrade plan for '{app.name}' to {target}"
+        description=f"Upgrade plan for '{app.name}' to '{target}'"
     )
     upgrade_steps = [
         PreUpgradeStep(
@@ -134,12 +134,12 @@ def test_auxiliary_upgrade_plan_ussuri_to_victoria_change_channel(status, config
             ),
         ),
         PostUpgradeStep(
-            description=f"Wait 1800s for model {model.name} to reach the idle state.",
+            description=f"Wait for up to 1800s for model '{model.name}' to reach the idle state",
             parallel=False,
             coro=model.wait_for_active_idle(1800, apps=None),
         ),
         PostUpgradeStep(
-            description=f"Check if the workload of '{app.name}' has been upgraded",
+            description=f"Verify that the workload of '{app.name}' has been upgraded",
             parallel=False,
             coro=app._check_upgrade(target),
         ),
@@ -165,7 +165,7 @@ def test_auxiliary_upgrade_plan_ussuri_to_victoria(status, config, model):
     upgrade_plan = app.generate_upgrade_plan(target)
 
     expected_plan = ApplicationUpgradePlan(
-        description=f"Upgrade plan for '{app.name}' to {target}"
+        description=f"Upgrade plan for '{app.name}' to '{target}'"
     )
     upgrade_steps = [
         PreUpgradeStep(
@@ -192,12 +192,12 @@ def test_auxiliary_upgrade_plan_ussuri_to_victoria(status, config, model):
             ),
         ),
         PostUpgradeStep(
-            description=f"Wait 1800s for model {model.name} to reach the idle state.",
+            description=f"Wait for up to 1800s for model '{model.name}' to reach the idle state",
             parallel=False,
             coro=model.wait_for_active_idle(1800, apps=None),
         ),
         PostUpgradeStep(
-            description=f"Check if the workload of '{app.name}' has been upgraded",
+            description=f"Verify that the workload of '{app.name}' has been upgraded",
             parallel=False,
             coro=app._check_upgrade(target),
         ),
@@ -221,7 +221,7 @@ def test_auxiliary_upgrade_plan_ussuri_to_victoria_ch_migration(status, config, 
     )
     upgrade_plan = app.generate_upgrade_plan(target)
     expected_plan = ApplicationUpgradePlan(
-        description=f"Upgrade plan for '{app.name}' to {target}",
+        description=f"Upgrade plan for '{app.name}' to '{target}'",
     )
     upgrade_steps = [
         PreUpgradeStep(
@@ -232,7 +232,7 @@ def test_auxiliary_upgrade_plan_ussuri_to_victoria_ch_migration(status, config, 
             coro=app_utils.upgrade_packages(app.status.units.keys(), model, None),
         ),
         PreUpgradeStep(
-            description=f"Migration of '{app.name}' from charmstore to charmhub",
+            description=f"Migrate '{app.name}' from charmstore to charmhub",
             parallel=False,
             coro=model.upgrade_charm(app.name, "3.9/stable", switch="ch:rabbitmq-server"),
         ),
@@ -253,12 +253,12 @@ def test_auxiliary_upgrade_plan_ussuri_to_victoria_ch_migration(status, config, 
             ),
         ),
         PostUpgradeStep(
-            description=f"Wait 1800s for model {model.name} to reach the idle state.",
+            description=f"Wait for up to 1800s for model '{model.name}' to reach the idle state",
             parallel=False,
             coro=model.wait_for_active_idle(1800, apps=None),
         ),
         PostUpgradeStep(
-            description=f"Check if the workload of '{app.name}' has been upgraded",
+            description=f"Verify that the workload of '{app.name}' has been upgraded",
             parallel=False,
             coro=app._check_upgrade(target),
         ),
@@ -397,7 +397,7 @@ def test_ceph_mon_upgrade_plan_xena_to_yoga(
     upgrade_plan = app.generate_upgrade_plan(target)
 
     expected_plan = ApplicationUpgradePlan(
-        description=f"Upgrade plan for '{app.name}' to {target}"
+        description=f"Upgrade plan for '{app.name}' to '{target}'"
     )
     upgrade_steps = [
         PreUpgradeStep(
@@ -413,7 +413,9 @@ def test_ceph_mon_upgrade_plan_xena_to_yoga(
             coro=model.upgrade_charm(app.name, "pacific/stable", switch=None),
         ),
         PreUpgradeStep(
-            description="Ensure require-osd-release option matches with ceph-osd version",
+            description=(
+                "Ensure that the 'require-osd-release' option matches the 'ceph-osd' version"
+            ),
             parallel=False,
             coro=app_utils.set_require_osd_release_option("ceph-mon/0", model),
         ),
@@ -433,12 +435,12 @@ def test_ceph_mon_upgrade_plan_xena_to_yoga(
             ),
         ),
         PostUpgradeStep(
-            description=f"Wait 1800s for model {model.name} to reach the idle state.",
+            description=f"Wait for up to 1800s for model '{model.name}' to reach the idle state",
             parallel=False,
             coro=model.wait_for_active_idle(1800, apps=None),
         ),
         PostUpgradeStep(
-            description=f"Check if the workload of '{app.name}' has been upgraded",
+            description=f"Verify that the workload of '{app.name}' has been upgraded",
             parallel=False,
             coro=app._check_upgrade(target),
         ),
@@ -465,7 +467,7 @@ def test_ceph_mon_upgrade_plan_ussuri_to_victoria(
     upgrade_plan = app.generate_upgrade_plan(target)
 
     expected_plan = ApplicationUpgradePlan(
-        description=f"Upgrade plan for '{app.name}' to {target}"
+        description=f"Upgrade plan for '{app.name}' to '{target}'"
     )
     upgrade_steps = [
         PreUpgradeStep(
@@ -481,7 +483,9 @@ def test_ceph_mon_upgrade_plan_ussuri_to_victoria(
             coro=model.upgrade_charm(app.name, "octopus/stable", switch=None),
         ),
         PreUpgradeStep(
-            description="Ensure require-osd-release option matches with ceph-osd version",
+            description=(
+                "Ensure that the 'require-osd-release' option matches the 'ceph-osd' version"
+            ),
             parallel=False,
             coro=app_utils.set_require_osd_release_option("ceph-mon/0", model),
         ),
@@ -496,12 +500,12 @@ def test_ceph_mon_upgrade_plan_ussuri_to_victoria(
             ),
         ),
         PostUpgradeStep(
-            description=f"Wait 1800s for model {model.name} to reach the idle state.",
+            description=f"Wait for up to 1800s for model '{model.name}' to reach the idle state",
             parallel=False,
             coro=model.wait_for_active_idle(1800, apps=None),
         ),
         PostUpgradeStep(
-            description=f"Check if the workload of '{app.name}' has been upgraded",
+            description=f"Verify that the workload of '{app.name}' has been upgraded",
             parallel=False,
             coro=app._check_upgrade(target),
         ),
@@ -576,7 +580,7 @@ def test_ovn_principal_upgrade_plan(status, config, model):
     upgrade_plan = app.generate_upgrade_plan(target)
 
     expected_plan = ApplicationUpgradePlan(
-        description=f"Upgrade plan for '{app.name}' to {target}"
+        description=f"Upgrade plan for '{app.name}' to '{target}'"
     )
 
     upgrade_steps = [
@@ -603,12 +607,12 @@ def test_ovn_principal_upgrade_plan(status, config, model):
             ),
         ),
         PostUpgradeStep(
-            description=f"Wait 300s for app {app.name} to reach the idle state.",
+            description=f"Wait for up to 300s for app '{app.name}' to reach the idle state",
             parallel=False,
             coro=model.wait_for_active_idle(300, apps=[app.name]),
         ),
         PostUpgradeStep(
-            description=f"Check if the workload of '{app.name}' has been upgraded",
+            description=f"Verify that the workload of '{app.name}' has been upgraded",
             parallel=False,
             coro=app._check_upgrade(target),
         ),
@@ -630,7 +634,7 @@ def test_mysql_innodb_cluster_upgrade(status, config, model):
     )
     upgrade_plan = app.generate_upgrade_plan(target)
     expected_plan = ApplicationUpgradePlan(
-        description=f"Upgrade plan for '{app.name}' to {target}"
+        description=f"Upgrade plan for '{app.name}' to '{target}'"
     )
     upgrade_steps = [
         PreUpgradeStep(
@@ -658,12 +662,12 @@ def test_mysql_innodb_cluster_upgrade(status, config, model):
             ),
         ),
         PostUpgradeStep(
-            description=f"Wait 1800s for app {app.name} to reach the idle state.",
+            description=f"Wait for up to 1800s for app '{app.name}' to reach the idle state",
             parallel=False,
             coro=model.wait_for_active_idle(1800, apps=[app.name]),
         ),
         PostUpgradeStep(
-            description=f"Check if the workload of '{app.name}' has been upgraded",
+            description=f"Verify that the workload of '{app.name}' has been upgraded",
             parallel=False,
             coro=app._check_upgrade(target),
         ),

--- a/tests/unit/apps/test_auxiliary_subordinate.py
+++ b/tests/unit/apps/test_auxiliary_subordinate.py
@@ -42,7 +42,7 @@ def test_auxiliary_subordinate_upgrade_plan_to_victoria(apps, model):
 
     upgrade_plan = app.generate_upgrade_plan(target)
     expected_plan = ApplicationUpgradePlan(
-        description=f"Upgrade plan for '{app.name}' to {target}",
+        description=f"Upgrade plan for '{app.name}' to '{target}'",
     )
     expected_plan.add_step(
         PreUpgradeStep(
@@ -106,7 +106,7 @@ def test_ovn_subordinate_upgrade_plan(status, model):
     upgrade_plan = app.generate_upgrade_plan(target)
 
     expected_plan = ApplicationUpgradePlan(
-        description=f"Upgrade plan for '{app.name}' to {target}"
+        description=f"Upgrade plan for '{app.name}' to '{target}'"
     )
 
     upgrade_steps = [
@@ -136,7 +136,7 @@ def test_ovn_subordinate_upgrade_plan_cant_upgrade_charm(status, model):
     )
 
     expected_plan = ApplicationUpgradePlan(
-        description=f"Upgrade plan for '{app.name}' to {target}"
+        description=f"Upgrade plan for '{app.name}' to '{target}'"
     )
 
     upgrade_plan = app.generate_upgrade_plan(target)
@@ -158,7 +158,7 @@ def test_ceph_dashboard_upgrade_plan_ussuri_to_victoria(status, config, model):
     upgrade_plan = app.generate_upgrade_plan(target)
 
     expected_plan = ApplicationUpgradePlan(
-        description=f"Upgrade plan for '{app.name}' to {target}"
+        description=f"Upgrade plan for '{app.name}' to '{target}'"
     )
 
     upgrade_steps = [
@@ -187,7 +187,7 @@ def test_ceph_dashboard_upgrade_plan_xena_to_yoga(status, config, model):
     upgrade_plan = app.generate_upgrade_plan(target)
 
     expected_plan = ApplicationUpgradePlan(
-        description=f"Upgrade plan for '{app.name}' to {target}"
+        description=f"Upgrade plan for '{app.name}' to '{target}'"
     )
 
     upgrade_steps = [

--- a/tests/unit/apps/test_channel_based.py
+++ b/tests/unit/apps/test_channel_based.py
@@ -92,7 +92,7 @@ def test_application_versionless_upgrade_plan_ussuri_to_victoria(status, config,
     upgrade_plan = app.generate_upgrade_plan(target)
 
     expected_plan = ApplicationUpgradePlan(
-        description=f"Upgrade plan for '{app.name}' to {target}"
+        description=f"Upgrade plan for '{app.name}' to '{target}'"
     )
 
     upgrade_steps = [
@@ -147,7 +147,7 @@ def test_application_gnocchi_upgrade_plan_ussuri_to_victoria(status, config, mod
     upgrade_plan = app.generate_upgrade_plan(target)
 
     expected_plan = ApplicationUpgradePlan(
-        description=f"Upgrade plan for '{app.name}' to {target}"
+        description=f"Upgrade plan for '{app.name}' to '{target}'"
     )
 
     upgrade_steps = [
@@ -180,12 +180,12 @@ def test_application_gnocchi_upgrade_plan_ussuri_to_victoria(status, config, mod
             ),
         ),
         PostUpgradeStep(
-            description=f"Wait 300s for app {app.name} to reach the idle state.",
+            description=f"Wait for up to 300s for app '{app.name}' to reach the idle state",
             parallel=False,
             coro=model.wait_for_active_idle(300, apps=[app.name]),
         ),
         PostUpgradeStep(
-            description=f"Check if the workload of '{app.name}' has been upgraded",
+            description=f"Verify that the workload of '{app.name}' has been upgraded",
             parallel=False,
             coro=app._check_upgrade(target),
         ),
@@ -211,7 +211,7 @@ def test_application_designate_bind_upgrade_plan_ussuri_to_victoria(status, conf
     upgrade_plan = app.generate_upgrade_plan(target)
 
     expected_plan = ApplicationUpgradePlan(
-        description=f"Upgrade plan for '{app.name}' to {target}"
+        description=f"Upgrade plan for '{app.name}' to '{target}'"
     )
 
     upgrade_steps = [
@@ -244,12 +244,12 @@ def test_application_designate_bind_upgrade_plan_ussuri_to_victoria(status, conf
             ),
         ),
         PostUpgradeStep(
-            description=f"Wait 300s for app {app.name} to reach the idle state.",
+            description=f"Wait for up to 300s for app '{app.name}' to reach the idle state",
             parallel=False,
             coro=model.wait_for_active_idle(300, apps=[app.name]),
         ),
         PostUpgradeStep(
-            description=f"Check if the workload of '{app.name}' has been upgraded",
+            description=f"Verify that the workload of '{app.name}' has been upgraded",
             parallel=False,
             coro=app._check_upgrade(target),
         ),

--- a/tests/unit/apps/test_core.py
+++ b/tests/unit/apps/test_core.py
@@ -329,7 +329,7 @@ def test_upgrade_plan_ussuri_to_victoria(status, config, model):
     app = Keystone("my_keystone", app_status, app_config, model, "keystone")
     upgrade_plan = app.generate_upgrade_plan(target)
     expected_plan = ApplicationUpgradePlan(
-        description=f"Upgrade plan for '{app.name}' to {target}"
+        description=f"Upgrade plan for '{app.name}' to '{target}'"
     )
     upgrade_steps = [
         PreUpgradeStep(
@@ -365,12 +365,12 @@ def test_upgrade_plan_ussuri_to_victoria(status, config, model):
             ),
         ),
         PostUpgradeStep(
-            description=f"Wait 1800s for model {model.name} to reach the idle state.",
+            description=f"Wait for up to 1800s for model '{model.name}' to reach the idle state",
             parallel=False,
             coro=model.wait_for_active_idle(1800, apps=None),
         ),
         PostUpgradeStep(
-            description=f"Check if the workload of '{app.name}' has been upgraded",
+            description=f"Verify that the workload of '{app.name}' has been upgraded",
             parallel=False,
             coro=app._check_upgrade(target),
         ),
@@ -387,7 +387,7 @@ def test_upgrade_plan_ussuri_to_victoria_ch_migration(status, config, model):
     app = Keystone("my_keystone", app_status, app_config, model, "keystone")
     upgrade_plan = app.generate_upgrade_plan(target)
     expected_plan = ApplicationUpgradePlan(
-        description=f"Upgrade plan for '{app.name}' to {target}"
+        description=f"Upgrade plan for '{app.name}' to '{target}'"
     )
     upgrade_steps = [
         PreUpgradeStep(
@@ -398,7 +398,7 @@ def test_upgrade_plan_ussuri_to_victoria_ch_migration(status, config, model):
             coro=app_utils.upgrade_packages(app.status.units.keys(), model, None),
         ),
         PreUpgradeStep(
-            description=f"Migration of '{app.name}' from charmstore to charmhub",
+            description=f"Migrate '{app.name}' from charmstore to charmhub",
             parallel=False,
             coro=model.upgrade_charm(app.name, "ussuri/stable", switch="ch:keystone"),
         ),
@@ -423,12 +423,12 @@ def test_upgrade_plan_ussuri_to_victoria_ch_migration(status, config, model):
             ),
         ),
         PostUpgradeStep(
-            description=f"Wait 1800s for model {model.name} to reach the idle state.",
+            description=f"Wait for up to 1800s for model '{model.name}' to reach the idle state",
             parallel=False,
             coro=model.wait_for_active_idle(1800, apps=None),
         ),
         PostUpgradeStep(
-            description=f"Check if the workload of '{app.name}' has been upgraded",
+            description=f"Verify that the workload of '{app.name}' has been upgraded",
             parallel=False,
             coro=app._check_upgrade(target),
         ),
@@ -448,7 +448,7 @@ def test_upgrade_plan_channel_on_next_os_release(status, config, model):
     upgrade_plan = app.generate_upgrade_plan(target)
 
     expected_plan = ApplicationUpgradePlan(
-        description=f"Upgrade plan for '{app.name}' to {target}"
+        description=f"Upgrade plan for '{app.name}' to '{target}'"
     )
     # no sub-step for refresh current channel or next channel
     upgrade_steps = [
@@ -475,12 +475,12 @@ def test_upgrade_plan_channel_on_next_os_release(status, config, model):
             ),
         ),
         PostUpgradeStep(
-            description=f"Wait 1800s for model {model.name} to reach the idle state.",
+            description=f"Wait for up to 1800s for model '{model.name}' to reach the idle state",
             parallel=False,
             coro=model.wait_for_active_idle(1800, apps=None),
         ),
         PostUpgradeStep(
-            description=f"Check if the workload of '{app.name}' has been upgraded",
+            description=f"Verify that the workload of '{app.name}' has been upgraded",
             parallel=False,
             coro=app._check_upgrade(target),
         ),
@@ -499,7 +499,7 @@ def test_upgrade_plan_origin_already_on_next_openstack_release(status, config, m
     app = Keystone("my_keystone", app_status, app_config, model, "keystone")
     upgrade_plan = app.generate_upgrade_plan(target)
     expected_plan = ApplicationUpgradePlan(
-        description=f"Upgrade plan for '{app.name}' to {target}"
+        description=f"Upgrade plan for '{app.name}' to '{target}'"
     )
     upgrade_steps = [
         PreUpgradeStep(
@@ -525,12 +525,12 @@ def test_upgrade_plan_origin_already_on_next_openstack_release(status, config, m
             coro=model.upgrade_charm(app.name, "victoria/stable"),
         ),
         PostUpgradeStep(
-            description=f"Wait 1800s for model {model.name} to reach the idle state.",
+            description=f"Wait for up to 1800s for model '{model.name}' to reach the idle state",
             parallel=False,
             coro=model.wait_for_active_idle(1800, apps=None),
         ),
         PostUpgradeStep(
-            description=f"Check if the workload of '{app.name}' has been upgraded",
+            description=f"Verify that the workload of '{app.name}' has been upgraded",
             parallel=False,
             coro=app._check_upgrade(target),
         ),
@@ -568,7 +568,7 @@ def test_upgrade_plan_application_already_disable_action_managed(status, config,
     )
     upgrade_plan = app.generate_upgrade_plan(target)
     expected_plan = ApplicationUpgradePlan(
-        description=f"Upgrade plan for '{app.name}' to {target}"
+        description=f"Upgrade plan for '{app.name}' to '{target}'"
     )
     upgrade_steps = [
         PreUpgradeStep(
@@ -599,12 +599,12 @@ def test_upgrade_plan_application_already_disable_action_managed(status, config,
             ),
         ),
         PostUpgradeStep(
-            description=f"Wait 1800s for model {model.name} to reach the idle state.",
+            description=f"Wait for up to 1800s for model '{model.name}' to reach the idle state",
             parallel=False,
             coro=model.wait_for_active_idle(1800, apps=None),
         ),
         PostUpgradeStep(
-            description=f"Check if the workload of '{app.name}' has been upgraded",
+            description=f"Verify that the workload of '{app.name}' has been upgraded",
             parallel=False,
             coro=app._check_upgrade(target),
         ),

--- a/tests/unit/apps/test_subordinate.py
+++ b/tests/unit/apps/test_subordinate.py
@@ -53,7 +53,7 @@ def test_generate_upgrade_plan(status, model):
     upgrade_plan = app.generate_upgrade_plan(target)
 
     expected_plan = ApplicationUpgradePlan(
-        description=f"Upgrade plan for '{app.name}' to {target}"
+        description=f"Upgrade plan for '{app.name}' to '{target}'"
     )
     upgrade_steps = [
         PreUpgradeStep(
@@ -128,11 +128,11 @@ def test_generate_plan_ch_migration(status, model, channel):
     upgrade_plan = app.generate_upgrade_plan(target)
 
     expected_plan = ApplicationUpgradePlan(
-        description=f"Upgrade plan for '{app.name}' to {target}"
+        description=f"Upgrade plan for '{app.name}' to '{target}'"
     )
     upgrade_steps = [
         PreUpgradeStep(
-            description=f"Migration of '{app.name}' from charmstore to charmhub",
+            description=f"Migrate '{app.name}' from charmstore to charmhub",
             parallel=False,
             coro=model.upgrade_charm(app.name, "ussuri/stable", switch="ch:keystone-ldap"),
         ),
@@ -165,7 +165,9 @@ def test_generate_plan_from_to(status, model, from_os, to_os):
     app.channel = f"{from_os}/stable"
     upgrade_plan = app.generate_upgrade_plan(OpenStackRelease(to_os))
 
-    expected_plan = ApplicationUpgradePlan(description=f"Upgrade plan for '{app.name}' to {to_os}")
+    expected_plan = ApplicationUpgradePlan(
+        description=f"Upgrade plan for '{app.name}' to '{to_os}'"
+    )
     upgrade_steps = [
         PreUpgradeStep(
             description=f"Refresh '{app.name}' to the latest revision of '{from_os}/stable'",
@@ -202,7 +204,7 @@ def test_generate_plan_in_same_version(status, model, from_to):
     app.channel = f"{from_to}/stable"
     upgrade_plan = app.generate_upgrade_plan(OpenStackRelease(from_to))
     expected_plan = ApplicationUpgradePlan(
-        description=f"Upgrade plan for '{app.name}' to {from_to}"
+        description=f"Upgrade plan for '{app.name}' to '{from_to}'"
     )
     upgrade_steps = [
         PreUpgradeStep(

--- a/tests/unit/steps/test_steps_plan.py
+++ b/tests/unit/steps/test_steps_plan.py
@@ -44,18 +44,18 @@ from tests.unit.apps.utils import add_steps
 
 def generate_expected_upgrade_plan_principal(app, target, model):
     expected_plan = ApplicationUpgradePlan(
-        description=f"Upgrade plan for '{app.name}' to {target.codename}"
+        description=f"Upgrade plan for '{app.name}' to '{target.codename}'"
     )
     if app.charm in ["rabbitmq-server", "ceph-mon", "keystone"]:
         # apps waiting for whole model
         wait_step = PostUpgradeStep(
-            description=f"Wait 1800s for model {model.name} to reach the idle state.",
+            description=f"Wait for up to 1800s for model '{model.name}' to reach the idle state",
             parallel=False,
             coro=model.wait_for_active_idle(1800, apps=None),
         )
     else:
         wait_step = PostUpgradeStep(
-            description=f"Wait 300s for app {app.name} to reach the idle state.",
+            description=f"Wait for up to 300s for app '{app.name}' to reach the idle state",
             parallel=False,
             coro=model.wait_for_active_idle(300, apps=[app.name]),
         )
@@ -98,7 +98,7 @@ def generate_expected_upgrade_plan_principal(app, target, model):
         ),
         wait_step,
         PostUpgradeStep(
-            description=f"Check if the workload of '{app.name}' has been upgraded",
+            description=f"Verify that the workload of '{app.name}' has been upgraded",
             parallel=False,
             coro=app._check_upgrade(target),
         ),
@@ -109,7 +109,7 @@ def generate_expected_upgrade_plan_principal(app, target, model):
 
 def generate_expected_upgrade_plan_subordinate(app, target, model):
     expected_plan = ApplicationUpgradePlan(
-        description=f"Upgrade plan for '{app.name}' to {target}"
+        description=f"Upgrade plan for '{app.name}' to '{target}'"
     )
     upgrade_steps = [
         PreUpgradeStep(
@@ -156,7 +156,7 @@ async def test_generate_plan(apps, model):
     )
     expected_plan.add_step(
         PreUpgradeStep(
-            description="Backup mysql databases",
+            description="Back up MySQL databases",
             parallel=False,
             coro=backup(model),
         )

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -85,7 +85,7 @@ async def test_get_upgrade_plan(
 ):
     """Test get_upgrade_plan function."""
     plan = UpgradePlan(description="Upgrade cloud from 'ussuri' to 'victoria'")
-    plan.add_step(PreUpgradeStep(description="backup mysql databases", parallel=False))
+    plan.add_step(PreUpgradeStep(description="Back up MySQL databases", parallel=False))
     mock_analysis_result = MagicMock()
 
     mock_analyze_and_plan.return_value = (mock_analysis_result, plan)
@@ -120,7 +120,7 @@ async def test_run_upgrade_quiet(
 ):
     """Test get_upgrade_plan function in either quiet or non-quiet mode."""
     plan = UpgradePlan(description="Upgrade cloud from 'ussuri' to 'victoria'")
-    plan.add_step(PreUpgradeStep(description="backup mysql databases", parallel=False))
+    plan.add_step(PreUpgradeStep(description="Back up MySQL databases", parallel=False))
     mock_analysis_result = MagicMock()
     mock_analyze_and_plan.return_value = (mock_analysis_result, plan)
 
@@ -145,7 +145,7 @@ async def test_run_upgrade_with_prompt_continue(
     mock_manually_upgrade,
 ):
     plan = UpgradePlan(description="Upgrade cloud from 'ussuri' to 'victoria'")
-    plan.add_step(PreUpgradeStep(description="backup mysql databases", parallel=False))
+    plan.add_step(PreUpgradeStep(description="Back up MySQL databases", parallel=False))
     mock_analysis_result = MagicMock()
     mock_analyze_and_plan.return_value = (mock_analysis_result, plan)
     mock_continue_upgrade.return_value = True
@@ -170,7 +170,7 @@ async def test_run_upgrade_with_prompt_abort(
     mock_manually_upgrade,
 ):
     plan = UpgradePlan(description="Upgrade cloud from 'ussuri' to 'victoria'")
-    plan.add_step(PreUpgradeStep(description="backup mysql databases", parallel=False))
+    plan.add_step(PreUpgradeStep(description="Back up MySQL databases", parallel=False))
     mock_analysis_result = MagicMock()
     mock_analyze_and_plan.return_value = (mock_analysis_result, plan)
     mock_continue_upgrade.return_value = False
@@ -195,7 +195,7 @@ async def test_run_upgrade_with_no_prompt(
     mock_manually_upgrade,
 ):
     plan = UpgradePlan(description="Upgrade cloud from 'ussuri' to 'victoria'")
-    plan.add_step(PreUpgradeStep(description="backup mysql databases", parallel=False))
+    plan.add_step(PreUpgradeStep(description="Back up MySQL databases", parallel=False))
     mock_analysis_result = MagicMock()
     mock_analyze_and_plan.return_value = (mock_analysis_result, plan)
 


### PR DESCRIPTION
(cherry-picked from e058b215d96cbbbf1e3e7ebc7a299d82d082e8c1)

- Better indicating a timeout step with `Wait for up to...`
- Start the description of "UpgradeStep" with a verb
- No period at the end of the step description
- Quotation mark around variables like app name, unit name, model name, etc
- Other miscellaneous grammar and wording fixes

fixes: #288