### PR TITLE
Bypassing application pre-plan sanity checks during plan generation

### DIFF
--- a/cou/steps/__init__.py
+++ b/cou/steps/__init__.py
@@ -340,3 +340,33 @@ class PreUpgradeStep(UpgradeStep):
 
 class PostUpgradeStep(UpgradeStep):
     """Represents the post-upgrade step."""
+
+
+class InformationStep(BaseStep):
+    """Represents the step that host an informative message.
+
+    This class doesn't contain any coroutine to run and is only intended to be
+    used to provide more additional information of a upgrade plan or step.
+
+    E.g. If an application failed to pass sanity checks for planning its upgrade,
+    this step will be generated instead of actual upgrade steps to point the user
+    to the warning log messages.
+    """
+
+    prompt: bool = False
+
+    def __init__(self, description: str):
+        """Initialize upgrade plan.
+
+        :param description: Description of the step.
+        :type description: str
+        """
+        super().__init__(description=description, parallel=False, coro=None)
+
+    async def run(self) -> None:
+        """Run UpgradePlan.
+
+        UpgradePlan should not have contain any coroutine, so simply print a debug
+        message to demonstrate the noop.
+        """
+        logger.debug("No coroutine to run for %s", repr(self))


### PR DESCRIPTION
With this PR, COU generates and prints plan even if some in-scope applications failed their pre-plan sanity checks. These applications will have a dummy sub-step with error information in the plan and their error log messages will be printed after plan generation.

If any error is catched this way during plan generation, upgrades will be possible.

Here is an demonstration of what the output would be like if `rabbitmq-server` and `keystone` fail to pass their sanity checks when running `cou upgrade`
```
$ cou upgrade
Full execution log: '/home/ubuntu/.local/share/cou/log/cou-20231215211917.log'
Connected to 'test-model' ✔
Analyzing cloud... ✔
Generating upgrade plan... ✔
Upgrade cloud from 'ussuri' to 'victoria'
    Verify that all OpenStack applications are in idle state
    Back up MySQL databases
    Control Plane principal(s) upgrade plan
    Upgrade plan for 'rabbitmq-server' to 'victoria'
        Cannot generate plan for 'rabbitmq-server'. See the error message for more info.
    Upgrade plan for 'keystone' to 'victoria'
        Cannot generate plan for 'keystone'. See the error message for more info.
    Upgrade plan for 'cinder' to 'victoria'
        Upgrade software packages of 'cinder' from the current APT repositories
            Upgrade software packages on unit cinder/0
        Refresh 'cinder' to the latest revision of 'ussuri/stable'
        Upgrade 'cinder' to the new channel: 'victoria/stable'
        Change charm config of 'cinder' 'openstack-origin' to 'cloud:focal-victoria'
        Wait for up to 300s for app 'cinder' to reach the idle state
        Verify that the workload of 'cinder' has been upgraded
    ... (other applications in the plan)
Error: Cannot generate plan for 'rabbitmq-server'.
    COU does not currently support upgrading applications that disable service restarts. Please enable charm option enable-auto-restart and rerun COU to upgrade the rabbitmq-server application.
Error: Cannot generate plan for 'keystone'. 
    Units of application keystone are running mismatched OpenStack versions: 'victoria': keystone/0, keystone/2, 'ussuri': keystone/1
Not possible to run upgrades. Please fix the errors before proceeding.
```