### PR TITLE
Sanity check for ovn charms to check enable-version-pinning

### DIFF
--- a/cou/apps/auxiliary.py
+++ b/cou/apps/auxiliary.py
@@ -20,7 +20,11 @@ from cou.apps.base import OpenStackApplication
 from cou.apps.factory import AppFactory
 from cou.exceptions import ApplicationError
 from cou.steps import ApplicationUpgradePlan, PreUpgradeStep
-from cou.utils.app_utils import set_require_osd_release_option, validate_ovn_support
+from cou.utils.app_utils import (
+    check_ovn_version_pinning,
+    set_require_osd_release_option,
+    validate_ovn_support,
+)
 from cou.utils.juju_utils import COUUnit
 from cou.utils.openstack import (
     OPENSTACK_TO_TRACK_MAPPING,
@@ -206,6 +210,19 @@ class CephMon(AuxiliaryApplication):
 @AppFactory.register_application(["ovn-central", "ovn-dedicated-chassis"])
 class OvnPrincipal(AuxiliaryApplication):
     """Ovn principal application class."""
+
+    def upgrade_plan_sanity_checks(
+        self, target: OpenStackRelease, units: Optional[list[COUUnit]]
+    ) -> None:
+        """Run sanity checks before generating upgrade plan.
+
+        :param target: OpenStack release as target to upgrade.
+        :type target: OpenStackRelease
+        :param units: Units to generate upgrade plan, defaults to None
+        :type units: Optional[list[COUUnit]], optional
+        """
+        check_ovn_version_pinning(self.name, self.config["enable-version-pinning"].get("value"))
+        super().upgrade_plan_sanity_checks(target, units)
 
     def pre_upgrade_steps(
         self, target: OpenStackRelease, units: Optional[list[COUUnit]]

--- a/cou/apps/auxiliary_subordinate.py
+++ b/cou/apps/auxiliary_subordinate.py
@@ -18,7 +18,7 @@ from cou.apps.auxiliary import AuxiliaryApplication
 from cou.apps.factory import AppFactory
 from cou.apps.subordinate import SubordinateBase
 from cou.steps import PreUpgradeStep
-from cou.utils.app_utils import validate_ovn_support
+from cou.utils.app_utils import check_ovn_version_pinning, validate_ovn_support
 from cou.utils.juju_utils import COUUnit
 from cou.utils.openstack import AUXILIARY_SUBORDINATES, OpenStackRelease
 
@@ -42,6 +42,19 @@ class AuxiliarySubordinateApplication(SubordinateBase, AuxiliaryApplication):
 @AppFactory.register_application(["ovn-chassis"])
 class OvnSubordinate(AuxiliarySubordinateApplication):
     """Ovn subordinate application class."""
+
+    def upgrade_plan_sanity_checks(
+        self, target: OpenStackRelease, units: Optional[list[COUUnit]]
+    ) -> None:
+        """Run sanity checks before generating upgrade plan.
+
+        :param target: OpenStack release as target to upgrade.
+        :type target: OpenStackRelease
+        :param units: Units to generate upgrade plan, defaults to None
+        :type units: Optional[list[COUUnit]], optional
+        """
+        check_ovn_version_pinning(self.name, self.config["enable-version-pinning"].get("value"))
+        super().upgrade_plan_sanity_checks(target, units)
 
     def pre_upgrade_steps(
         self, target: OpenStackRelease, units: Optional[list[COUUnit]]

--- a/cou/utils/app_utils.py
+++ b/cou/utils/app_utils.py
@@ -91,6 +91,22 @@ def validate_ovn_support(version: str) -> None:
         )
 
 
+def check_ovn_version_pinning(name: str, version_pinning_config: bool) -> None:
+    """Check if application version pinning is disabled.
+
+    Ovn applications need to have the version pinning set to False to ensure e smooth cluster
+    operation.
+
+    :param name: Name of the application. E.g: ovn-chassis
+    :type name: str
+    :param version_pinning_config: 'enable-version-pinning' configuration
+    :type version_pinning_config: bool
+    :raises ApplicationError: When enable-version-pinning is True
+    """
+    if version_pinning_config:
+        raise ApplicationError(f"'{name}' should set 'enable-version-pinning' before upgrading")
+
+
 async def _get_required_osd_release(unit: str, model: COUModel) -> str:
     """Get the value of require-osd-release option on a ceph-mon unit.
 

--- a/tests/unit/apps/test_auxiliary.py
+++ b/tests/unit/apps/test_auxiliary.py
@@ -820,7 +820,7 @@ def test_ovn_workload_ver_lower_than_22_principal(model):
         can_upgrade_to="22.03/stable",
         charm=charm,
         channel="20.03/stable",
-        config={"source": {"value": "distro"}},
+        config={"source": {"value": "distro"}, "enable-version-pinning": {"value": False}},
         machines=machines,
         model=model,
         origin="ch",
@@ -834,6 +834,37 @@ def test_ovn_workload_ver_lower_than_22_principal(model):
             )
         },
         workload_version="20.03.2",
+    )
+
+    with pytest.raises(ApplicationError, match=exp_msg):
+        app.generate_upgrade_plan(target, False)
+
+
+def test_ovn_version_pinning_principal(model):
+    """Test the OvnPrincipal when enable-version-pinning is set to True."""
+    target = OpenStackRelease("victoria")
+    charm = "ovn-central"
+    exp_msg = f"'{charm}' should set 'enable-version-pinning' before upgrading"
+    machines = {"0": MagicMock(spec_set=COUMachine)}
+    app = OvnPrincipal(
+        name=charm,
+        can_upgrade_to="22.03/stable",
+        charm=charm,
+        channel="22.03/stable",
+        config={"source": {"value": "distro"}, "enable-version-pinning": {"value": True}},
+        machines=machines,
+        model=model,
+        origin="ch",
+        series="focal",
+        subordinate_to=[],
+        units={
+            f"{charm}/0": COUUnit(
+                name=f"{charm}/0",
+                workload_version="22.03.2",
+                machine=machines["0"],
+            )
+        },
+        workload_version="22.03.2",
     )
 
     with pytest.raises(ApplicationError, match=exp_msg):
@@ -885,7 +916,7 @@ def test_ovn_principal_upgrade_plan(model):
         can_upgrade_to="22.06/stable",
         charm=charm,
         channel="22.03/stable",
-        config={"source": {"value": "distro"}},
+        config={"source": {"value": "distro"}, "enable-version-pinning": {"value": False}},
         machines=machines,
         model=model,
         origin="ch",

--- a/tests/unit/apps/test_auxiliary_subordinate.py
+++ b/tests/unit/apps/test_auxiliary_subordinate.py
@@ -132,7 +132,7 @@ def test_ovn_workload_ver_lower_than_22_subordinate(model):
         can_upgrade_to="22.03/stable",
         charm="ovn-chassis",
         channel="20.03/stable",
-        config={"source": {"value": "distro"}},
+        config={"source": {"value": "distro"}, "enable-version-pinning": {"value": False}},
         machines=machines,
         model=model,
         origin="ch",
@@ -140,6 +140,31 @@ def test_ovn_workload_ver_lower_than_22_subordinate(model):
         subordinate_to=["nova-compute"],
         units={},
         workload_version="20.3",
+    )
+
+    with pytest.raises(ApplicationError, match=exp_msg):
+        app.generate_upgrade_plan(target, False)
+
+
+def test_ovn_version_pinning_subordinate(model):
+    """Test the OvnSubordinate when enable-version-pinning is set to True."""
+    charm = "ovn-chassis"
+    target = OpenStackRelease("victoria")
+    machines = {"0": MagicMock(spec_set=COUMachine)}
+    exp_msg = f"'{charm}' should set 'enable-version-pinning' before upgrading"
+    app = OvnSubordinate(
+        name=charm,
+        can_upgrade_to="",
+        charm=charm,
+        channel="22.03/stable",
+        config={"source": {"value": "distro"}, "enable-version-pinning": {"value": True}},
+        machines=machines,
+        model=model,
+        origin="ch",
+        series="focal",
+        subordinate_to=["nova-compute"],
+        units={},
+        workload_version="22.3",
     )
 
     with pytest.raises(ApplicationError, match=exp_msg):
@@ -155,7 +180,7 @@ def test_ovn_subordinate_upgrade_plan(model):
         can_upgrade_to="22.03/stable",
         charm="ovn-chassis",
         channel="22.03/stable",
-        config={"source": {"value": "distro"}},
+        config={"source": {"value": "distro"}, "enable-version-pinning": {"value": False}},
         machines=machines,
         model=model,
         origin="ch",
@@ -196,7 +221,7 @@ def test_ovn_subordinate_upgrade_plan_cant_upgrade_charm(model):
         can_upgrade_to="",
         charm="ovn-chassis",
         channel="22.03/stable",
-        config={"source": {"value": "distro"}},
+        config={"source": {"value": "distro"}, "enable-version-pinning": {"value": False}},
         machines=machines,
         model=model,
         origin="ch",

--- a/tests/unit/steps/test_steps_plan.py
+++ b/tests/unit/steps/test_steps_plan.py
@@ -291,7 +291,7 @@ nova-compute/0
         can_upgrade_to="22.03/stable",
         charm="ovn-chassis",
         channel="22.03/stable",
-        config={},
+        config={"enable-version-pinning": {"value": False}},
         machines=machines["1"],
         model=model,
         origin="ch",

--- a/tests/unit/utils/test_app_utils.py
+++ b/tests/unit/utils/test_app_utils.py
@@ -16,7 +16,7 @@ from unittest.mock import AsyncMock, call, patch
 
 import pytest
 
-from cou.exceptions import RunUpgradeError
+from cou.exceptions import ApplicationError, RunUpgradeError
 from cou.utils import app_utils
 
 
@@ -240,3 +240,14 @@ async def test_get_current_osd_release_unsuccessful(model, osd_release_output, e
         command="ceph versions -f json",
         timeout=600,
     )
+
+
+def test_check_ovn_version_pinning():
+    assert app_utils.check_ovn_version_pinning("ovn-foo", False) is None
+
+
+def test_check_ovn_version_pinning_raise():
+    name = "ovn-foo"
+    error_message = f"'{name}' should set 'enable-version-pinning' before upgrading"
+    with pytest.raises(ApplicationError, match=error_message):
+        app_utils.check_ovn_version_pinning("ovn-foo", True)


### PR DESCRIPTION
- enable-version-pinning should be set to False before upgrading [ovn charms](https://docs.openstack.org/charm-guide/latest/project/procedures/ovn-upgrade-2203.html#disable-version-pinning)