### PR TITLE
Fix enable and disable scheduler order on upgrade

### DIFF
--- a/cou/steps/hypervisor.py
+++ b/cou/steps/hypervisor.py
@@ -229,12 +229,7 @@ class HypervisorUpgradePlanner:
             units = group.app_units[app.name]
             logger.info("generating upgrade steps for %s units of %s app", app.name, units)
 
-            if app.charm == "nova-compute":
-                # NOTE(gabrielcocenza) it's important to disable the scheduler before upgrading
-                # any application, that is why we insert in the first position.
-                steps = app.upgrade_steps(target, units, force) + steps
-            else:
-                steps.extend(app.upgrade_steps(target, units, force))
+            steps.extend(app.upgrade_steps(target, units, force))
 
         return steps
 
@@ -265,12 +260,7 @@ class HypervisorUpgradePlanner:
 
             units = group.app_units[app.name]
             logger.info("generating post-upgrade steps for %s units of %s app", app.name, units)
-            if app.charm == "nova-compute":
-                # NOTE(gabrielcocenza) it's important to enable the scheduler after upgrading
-                # all applications.
-                steps.extend(app.post_upgrade_steps(target, units=units))
-            else:
-                steps = app.post_upgrade_steps(target, units) + steps
+            steps.extend(app.post_upgrade_steps(target, units=units))
 
         return steps
 

--- a/tests/unit/steps/test_hypervisor.py
+++ b/tests/unit/steps/test_hypervisor.py
@@ -294,14 +294,6 @@ def test_hypervisor_upgrade_plan(model):
             Upgrade software packages of 'nova-compute' from the current APT repositories
                 Upgrade software packages on unit 'nova-compute/0'
             Refresh 'nova-compute' to the latest revision of 'ussuri/stable'
-            Change charm config of 'cinder' 'action-managed-upgrade' to True
-            Upgrade 'cinder' to the new channel: 'victoria/stable'
-            Change charm config of 'cinder' 'openstack-origin' to 'cloud:focal-victoria'
-            Upgrade plan for units: cinder/0
-                Upgrade plan for unit 'cinder/0'
-                    Pause the unit: 'cinder/0'
-                    Upgrade the unit: 'cinder/0'
-                    Resume the unit: 'cinder/0'
             Change charm config of 'nova-compute' 'action-managed-upgrade' to True
             Upgrade 'nova-compute' to the new channel: 'victoria/stable'
             Change charm config of 'nova-compute' 'source' to 'cloud:focal-victoria'
@@ -312,11 +304,19 @@ def test_hypervisor_upgrade_plan(model):
                     ├── Pause the unit: 'nova-compute/0'
                     ├── Upgrade the unit: 'nova-compute/0'
                     ├── Resume the unit: 'nova-compute/0'
-                    Enable nova-compute scheduler from unit: 'nova-compute/0'
-            Wait for up to 1800s for model 'test_model' to reach the idle state
-            Verify that the workload of 'nova-compute' has been upgraded on units: nova-compute/0
+            Change charm config of 'cinder' 'action-managed-upgrade' to True
+            Upgrade 'cinder' to the new channel: 'victoria/stable'
+            Change charm config of 'cinder' 'openstack-origin' to 'cloud:focal-victoria'
+            Upgrade plan for units: cinder/0
+                Upgrade plan for unit 'cinder/0'
+                    Pause the unit: 'cinder/0'
+                    Upgrade the unit: 'cinder/0'
+                    Resume the unit: 'cinder/0'
             Wait for up to 300s for app 'cinder' to reach the idle state
             Verify that the workload of 'cinder' has been upgraded on units: cinder/0
+            Enable nova-compute scheduler from unit: 'nova-compute/0'
+            Wait for up to 1800s for model 'test_model' to reach the idle state
+            Verify that the workload of 'nova-compute' has been upgraded on units: nova-compute/0
         Upgrade plan for 'az-1' to 'victoria'
             Upgrade software packages of 'nova-compute' from the current APT repositories
                 Upgrade software packages on unit 'nova-compute/1'
@@ -331,7 +331,7 @@ def test_hypervisor_upgrade_plan(model):
                     ├── Pause the unit: 'nova-compute/1'
                     ├── Upgrade the unit: 'nova-compute/1'
                     ├── Resume the unit: 'nova-compute/1'
-                    Enable nova-compute scheduler from unit: 'nova-compute/1'
+            Enable nova-compute scheduler from unit: 'nova-compute/1'
             Wait for up to 1800s for model 'test_model' to reach the idle state
             Verify that the workload of 'nova-compute' has been upgraded on units: nova-compute/1
         Upgrade plan for 'az-2' to 'victoria'
@@ -348,7 +348,7 @@ def test_hypervisor_upgrade_plan(model):
                     ├── Pause the unit: 'nova-compute/2'
                     ├── Upgrade the unit: 'nova-compute/2'
                     ├── Resume the unit: 'nova-compute/2'
-                    Enable nova-compute scheduler from unit: 'nova-compute/2'
+            Enable nova-compute scheduler from unit: 'nova-compute/2'
             Wait for up to 1800s for model 'test_model' to reach the idle state
             Verify that the workload of 'nova-compute' has been upgraded on units: nova-compute/2
     """
@@ -421,14 +421,6 @@ def test_hypervisor_upgrade_plan_single_machine(model):
             Upgrade software packages of 'nova-compute' from the current APT repositories
                 Upgrade software packages on unit 'nova-compute/0'
             Refresh 'nova-compute' to the latest revision of 'ussuri/stable'
-            Change charm config of 'cinder' 'action-managed-upgrade' to True
-            Upgrade 'cinder' to the new channel: 'victoria/stable'
-            Change charm config of 'cinder' 'openstack-origin' to 'cloud:focal-victoria'
-            Upgrade plan for units: cinder/0
-                Upgrade plan for unit 'cinder/0'
-                    Pause the unit: 'cinder/0'
-                    Upgrade the unit: 'cinder/0'
-                    Resume the unit: 'cinder/0'
             Change charm config of 'nova-compute' 'action-managed-upgrade' to True
             Upgrade 'nova-compute' to the new channel: 'victoria/stable'
             Change charm config of 'nova-compute' 'source' to 'cloud:focal-victoria'
@@ -439,11 +431,19 @@ def test_hypervisor_upgrade_plan_single_machine(model):
                     ├── Pause the unit: 'nova-compute/0'
                     ├── Upgrade the unit: 'nova-compute/0'
                     ├── Resume the unit: 'nova-compute/0'
-                    Enable nova-compute scheduler from unit: 'nova-compute/0'
-            Wait for up to 1800s for model 'test_model' to reach the idle state
-            Verify that the workload of 'nova-compute' has been upgraded on units: nova-compute/0
+            Change charm config of 'cinder' 'action-managed-upgrade' to True
+            Upgrade 'cinder' to the new channel: 'victoria/stable'
+            Change charm config of 'cinder' 'openstack-origin' to 'cloud:focal-victoria'
+            Upgrade plan for units: cinder/0
+                Upgrade plan for unit 'cinder/0'
+                    Pause the unit: 'cinder/0'
+                    Upgrade the unit: 'cinder/0'
+                    Resume the unit: 'cinder/0'
             Wait for up to 300s for app 'cinder' to reach the idle state
             Verify that the workload of 'cinder' has been upgraded on units: cinder/0
+            Enable nova-compute scheduler from unit: 'nova-compute/0'
+            Wait for up to 1800s for model 'test_model' to reach the idle state
+            Verify that the workload of 'nova-compute' has been upgraded on units: nova-compute/0
     """
     )
     machines = {f"{i}": generate_cou_machine(f"{i}", f"az-{i}") for i in range(3)}
@@ -519,11 +519,6 @@ def test_hypervisor_upgrade_plan_some_units_upgraded(model):
                 Upgrade software packages on unit 'cinder/2'
             Upgrade software packages of 'nova-compute' from the current APT repositories
                 Upgrade software packages on unit 'nova-compute/2'
-            Upgrade plan for units: cinder/2
-                Upgrade plan for unit 'cinder/2'
-                    Pause the unit: 'cinder/2'
-                    Upgrade the unit: 'cinder/2'
-                    Resume the unit: 'cinder/2'
             Upgrade plan for units: nova-compute/2
                 Upgrade plan for unit 'nova-compute/2'
                     Disable nova-compute scheduler from unit: 'nova-compute/2'
@@ -531,11 +526,16 @@ def test_hypervisor_upgrade_plan_some_units_upgraded(model):
                     ├── Pause the unit: 'nova-compute/2'
                     ├── Upgrade the unit: 'nova-compute/2'
                     ├── Resume the unit: 'nova-compute/2'
-                    Enable nova-compute scheduler from unit: 'nova-compute/2'
-            Wait for up to 1800s for model 'test_model' to reach the idle state
-            Verify that the workload of 'nova-compute' has been upgraded on units: nova-compute/2
+            Upgrade plan for units: cinder/2
+                Upgrade plan for unit 'cinder/2'
+                    Pause the unit: 'cinder/2'
+                    Upgrade the unit: 'cinder/2'
+                    Resume the unit: 'cinder/2'
             Wait for up to 300s for app 'cinder' to reach the idle state
             Verify that the workload of 'cinder' has been upgraded on units: cinder/2
+            Enable nova-compute scheduler from unit: 'nova-compute/2'
+            Wait for up to 1800s for model 'test_model' to reach the idle state
+            Verify that the workload of 'nova-compute' has been upgraded on units: nova-compute/2
     """
     )
     machines = {f"{i}": generate_cou_machine(f"{i}", f"az-{i}") for i in range(3)}

--- a/tests/unit/steps/test_hypervisor.py
+++ b/tests/unit/steps/test_hypervisor.py
@@ -291,19 +291,10 @@ def test_hypervisor_upgrade_plan(model):
             Upgrade software packages of 'cinder' from the current APT repositories
                 Upgrade software packages on unit 'cinder/0'
             Refresh 'cinder' to the latest revision of 'ussuri/stable'
+            Disable nova-compute scheduler from unit: 'nova-compute/0'
             Upgrade software packages of 'nova-compute' from the current APT repositories
                 Upgrade software packages on unit 'nova-compute/0'
             Refresh 'nova-compute' to the latest revision of 'ussuri/stable'
-            Change charm config of 'nova-compute' 'action-managed-upgrade' to True
-            Upgrade 'nova-compute' to the new channel: 'victoria/stable'
-            Change charm config of 'nova-compute' 'source' to 'cloud:focal-victoria'
-            Upgrade plan for units: nova-compute/0
-                Upgrade plan for unit 'nova-compute/0'
-                    Disable nova-compute scheduler from unit: 'nova-compute/0'
-                    Verify that unit 'nova-compute/0' has no VMs running
-                    ├── Pause the unit: 'nova-compute/0'
-                    ├── Upgrade the unit: 'nova-compute/0'
-                    ├── Resume the unit: 'nova-compute/0'
             Change charm config of 'cinder' 'action-managed-upgrade' to True
             Upgrade 'cinder' to the new channel: 'victoria/stable'
             Change charm config of 'cinder' 'openstack-origin' to 'cloud:focal-victoria'
@@ -312,12 +303,22 @@ def test_hypervisor_upgrade_plan(model):
                     Pause the unit: 'cinder/0'
                     Upgrade the unit: 'cinder/0'
                     Resume the unit: 'cinder/0'
+            Change charm config of 'nova-compute' 'action-managed-upgrade' to True
+            Upgrade 'nova-compute' to the new channel: 'victoria/stable'
+            Change charm config of 'nova-compute' 'source' to 'cloud:focal-victoria'
+            Upgrade plan for units: nova-compute/0
+                Upgrade plan for unit 'nova-compute/0'
+                    Verify that unit 'nova-compute/0' has no VMs running
+                    ├── Pause the unit: 'nova-compute/0'
+                    ├── Upgrade the unit: 'nova-compute/0'
+                    ├── Resume the unit: 'nova-compute/0'
             Wait for up to 300s for app 'cinder' to reach the idle state
             Verify that the workload of 'cinder' has been upgraded on units: cinder/0
             Enable nova-compute scheduler from unit: 'nova-compute/0'
             Wait for up to 1800s for model 'test_model' to reach the idle state
             Verify that the workload of 'nova-compute' has been upgraded on units: nova-compute/0
         Upgrade plan for 'az-1' to 'victoria'
+            Disable nova-compute scheduler from unit: 'nova-compute/1'
             Upgrade software packages of 'nova-compute' from the current APT repositories
                 Upgrade software packages on unit 'nova-compute/1'
             Refresh 'nova-compute' to the latest revision of 'ussuri/stable'
@@ -326,7 +327,6 @@ def test_hypervisor_upgrade_plan(model):
             Change charm config of 'nova-compute' 'source' to 'cloud:focal-victoria'
             Upgrade plan for units: nova-compute/1
                 Upgrade plan for unit 'nova-compute/1'
-                    Disable nova-compute scheduler from unit: 'nova-compute/1'
                     Verify that unit 'nova-compute/1' has no VMs running
                     ├── Pause the unit: 'nova-compute/1'
                     ├── Upgrade the unit: 'nova-compute/1'
@@ -335,6 +335,7 @@ def test_hypervisor_upgrade_plan(model):
             Wait for up to 1800s for model 'test_model' to reach the idle state
             Verify that the workload of 'nova-compute' has been upgraded on units: nova-compute/1
         Upgrade plan for 'az-2' to 'victoria'
+            Disable nova-compute scheduler from unit: 'nova-compute/2'
             Upgrade software packages of 'nova-compute' from the current APT repositories
                 Upgrade software packages on unit 'nova-compute/2'
             Refresh 'nova-compute' to the latest revision of 'ussuri/stable'
@@ -343,7 +344,6 @@ def test_hypervisor_upgrade_plan(model):
             Change charm config of 'nova-compute' 'source' to 'cloud:focal-victoria'
             Upgrade plan for units: nova-compute/2
                 Upgrade plan for unit 'nova-compute/2'
-                    Disable nova-compute scheduler from unit: 'nova-compute/2'
                     Verify that unit 'nova-compute/2' has no VMs running
                     ├── Pause the unit: 'nova-compute/2'
                     ├── Upgrade the unit: 'nova-compute/2'
@@ -418,19 +418,10 @@ def test_hypervisor_upgrade_plan_single_machine(model):
             Upgrade software packages of 'cinder' from the current APT repositories
                 Upgrade software packages on unit 'cinder/0'
             Refresh 'cinder' to the latest revision of 'ussuri/stable'
+            Disable nova-compute scheduler from unit: 'nova-compute/0'
             Upgrade software packages of 'nova-compute' from the current APT repositories
                 Upgrade software packages on unit 'nova-compute/0'
             Refresh 'nova-compute' to the latest revision of 'ussuri/stable'
-            Change charm config of 'nova-compute' 'action-managed-upgrade' to True
-            Upgrade 'nova-compute' to the new channel: 'victoria/stable'
-            Change charm config of 'nova-compute' 'source' to 'cloud:focal-victoria'
-            Upgrade plan for units: nova-compute/0
-                Upgrade plan for unit 'nova-compute/0'
-                    Disable nova-compute scheduler from unit: 'nova-compute/0'
-                    Verify that unit 'nova-compute/0' has no VMs running
-                    ├── Pause the unit: 'nova-compute/0'
-                    ├── Upgrade the unit: 'nova-compute/0'
-                    ├── Resume the unit: 'nova-compute/0'
             Change charm config of 'cinder' 'action-managed-upgrade' to True
             Upgrade 'cinder' to the new channel: 'victoria/stable'
             Change charm config of 'cinder' 'openstack-origin' to 'cloud:focal-victoria'
@@ -439,6 +430,15 @@ def test_hypervisor_upgrade_plan_single_machine(model):
                     Pause the unit: 'cinder/0'
                     Upgrade the unit: 'cinder/0'
                     Resume the unit: 'cinder/0'
+            Change charm config of 'nova-compute' 'action-managed-upgrade' to True
+            Upgrade 'nova-compute' to the new channel: 'victoria/stable'
+            Change charm config of 'nova-compute' 'source' to 'cloud:focal-victoria'
+            Upgrade plan for units: nova-compute/0
+                Upgrade plan for unit 'nova-compute/0'
+                    Verify that unit 'nova-compute/0' has no VMs running
+                    ├── Pause the unit: 'nova-compute/0'
+                    ├── Upgrade the unit: 'nova-compute/0'
+                    ├── Resume the unit: 'nova-compute/0'
             Wait for up to 300s for app 'cinder' to reach the idle state
             Verify that the workload of 'cinder' has been upgraded on units: cinder/0
             Enable nova-compute scheduler from unit: 'nova-compute/0'
@@ -517,20 +517,20 @@ def test_hypervisor_upgrade_plan_some_units_upgraded(model):
         Upgrade plan for 'az-2' to 'victoria'
             Upgrade software packages of 'cinder' from the current APT repositories
                 Upgrade software packages on unit 'cinder/2'
+            Disable nova-compute scheduler from unit: 'nova-compute/2'
             Upgrade software packages of 'nova-compute' from the current APT repositories
                 Upgrade software packages on unit 'nova-compute/2'
-            Upgrade plan for units: nova-compute/2
-                Upgrade plan for unit 'nova-compute/2'
-                    Disable nova-compute scheduler from unit: 'nova-compute/2'
-                    Verify that unit 'nova-compute/2' has no VMs running
-                    ├── Pause the unit: 'nova-compute/2'
-                    ├── Upgrade the unit: 'nova-compute/2'
-                    ├── Resume the unit: 'nova-compute/2'
             Upgrade plan for units: cinder/2
                 Upgrade plan for unit 'cinder/2'
                     Pause the unit: 'cinder/2'
                     Upgrade the unit: 'cinder/2'
                     Resume the unit: 'cinder/2'
+            Upgrade plan for units: nova-compute/2
+                Upgrade plan for unit 'nova-compute/2'
+                    Verify that unit 'nova-compute/2' has no VMs running
+                    ├── Pause the unit: 'nova-compute/2'
+                    ├── Upgrade the unit: 'nova-compute/2'
+                    ├── Resume the unit: 'nova-compute/2'
             Wait for up to 300s for app 'cinder' to reach the idle state
             Verify that the workload of 'cinder' has been upgraded on units: cinder/2
             Enable nova-compute scheduler from unit: 'nova-compute/2'

--- a/tests/unit/steps/test_steps_plan.py
+++ b/tests/unit/steps/test_steps_plan.py
@@ -184,7 +184,7 @@ async def test_generate_plan(mock_filter_hypervisors, model, cli_args):
                         ├── Pause the unit: 'nova-compute/0'
                         ├── Upgrade the unit: 'nova-compute/0'
                         ├── Resume the unit: 'nova-compute/0'
-                        Enable nova-compute scheduler from unit: 'nova-compute/0'
+                Enable nova-compute scheduler from unit: 'nova-compute/0'
                 Wait for up to 1800s for model 'test_model' to reach the idle state
                 Verify that the workload of 'nova-compute' has been upgraded on units: \
 nova-compute/0

--- a/tests/unit/steps/test_steps_plan.py
+++ b/tests/unit/steps/test_steps_plan.py
@@ -171,6 +171,7 @@ async def test_generate_plan(mock_filter_hypervisors, model, cli_args):
                 Upgrade 'keystone-ldap' to the new channel: 'victoria/stable'
         Upgrading all applications deployed on machines with hypervisor.
             Upgrade plan for 'az-1' to 'victoria'
+                Disable nova-compute scheduler from unit: 'nova-compute/0'
                 Upgrade software packages of 'nova-compute' from the current APT repositories
                     Upgrade software packages on unit 'nova-compute/0'
                 Refresh 'nova-compute' to the latest revision of 'ussuri/stable'
@@ -179,7 +180,6 @@ async def test_generate_plan(mock_filter_hypervisors, model, cli_args):
                 Change charm config of 'nova-compute' 'source' to 'cloud:focal-victoria'
                 Upgrade plan for units: nova-compute/0
                     Upgrade plan for unit 'nova-compute/0'
-                        Disable nova-compute scheduler from unit: 'nova-compute/0'
                         Verify that unit 'nova-compute/0' has no VMs running
                         ├── Pause the unit: 'nova-compute/0'
                         ├── Upgrade the unit: 'nova-compute/0'


### PR DESCRIPTION
- disable the nova-compute scheduler should happen before upgrading any colocated application. E.g: It's not good practice to start upgrading cinder, colocated with nova-compute,  without disabling the scheduler before
- enable the nova-compute scheduler should happen after all apps of the hypervisor are done. E.g: It's not good practice enable the nova-compute scheduler if cinder, colocated with nova-compute, didn't upgrade yet.