### PR TITLE
Fix apps split between control-plane and data-plane

### DIFF
--- a/cou/steps/analyze.py
+++ b/cou/steps/analyze.py
@@ -84,7 +84,7 @@ class Analysis:
         for app in apps:
             if is_data_plane(app):
                 data_plane.append(app)
-            elif any(unit.machine in data_plane_machines for unit in app.units.values()):
+            elif any(machine in data_plane_machines for machine in app.machines.values()):
                 data_plane.append(app)
             else:
                 control_plane.append(app)


### PR DESCRIPTION
- subordinates charms don't have units, so accessing machines from units is not possible and this makes all subordinate charms being considered as control-plane
- acessing machines directly from apps solves the issue.