### PR TITLE
Add Swift application class

### DIFF
--- a/cou/exceptions.py
+++ b/cou/exceptions.py
@@ -147,3 +147,7 @@ class InterruptError(KeyboardInterrupt):
         """
         self.exit_code = exit_code
         super().__init__(message)
+
+
+class ApplicationNotSupported(COUException):
+    """COU exception when the application is known but not supported by COU."""

--- a/cou/steps/plan.py
+++ b/cou/steps/plan.py
@@ -32,7 +32,7 @@ from cou.apps.auxiliary_subordinate import (  # noqa: F401
 )
 from cou.apps.base import OpenStackApplication
 from cou.apps.channel_based import ChannelBasedApplication  # noqa: F401
-from cou.apps.core import Keystone, Octavia  # noqa: F401
+from cou.apps.core import Keystone, Octavia, Swift  # noqa: F401
 from cou.apps.subordinate import SubordinateApplication, SubordinateBase  # noqa: F401
 from cou.commands import CONTROL_PLANE, DATA_PLANE, HYPERVISORS, CLIargs
 from cou.exceptions import (

--- a/cou/utils/openstack.py
+++ b/cou/utils/openstack.py
@@ -44,7 +44,7 @@ CHARM_FAMILIES = {
     "mysql": ["mysql-innodb-cluster", "mysql-router"],
 }
 
-DATA_PLANE_CHARMS = ["nova-compute", "ceph-osd"]
+DATA_PLANE_CHARMS = ["nova-compute", "ceph-osd", "swift-proxy", "swift-storage"]
 
 # https://docs.openstack.org/charm-guide/latest/admin/upgrades/openstack.html#list-the-upgrade-order
 UPGRADE_ORDER = [

--- a/tests/unit/apps/test_core.py
+++ b/tests/unit/apps/test_core.py
@@ -17,8 +17,12 @@ import pytest
 from juju.client._definitions import ApplicationStatus, UnitStatus
 
 from cou.apps.base import OpenStackApplication
-from cou.apps.core import Keystone, NovaCompute
-from cou.exceptions import ApplicationError, HaltUpgradePlanGeneration
+from cou.apps.core import Keystone, NovaCompute, Swift
+from cou.exceptions import (
+    ApplicationError,
+    ApplicationNotSupported,
+    HaltUpgradePlanGeneration,
+)
 from cou.steps import (
     ApplicationUpgradePlan,
     PostUpgradeStep,
@@ -1032,3 +1036,37 @@ def test_cinder_upgrade_plan_single_unit(model):
     plan = cinder.generate_upgrade_plan(target, False, [units["cinder/0"]])
 
     assert str(plan) == exp_plan
+
+
+def test_swift_application_not_supported(model):
+    """Test Swift application raising ApplicationNotSupported error."""
+    target = OpenStackRelease("victoria")
+    machines = {"0": MagicMock(spec_set=Machine)}
+    app = Swift(
+        name="swift-proxy",
+        can_upgrade_to="ussuri/stable",
+        charm="swift-proxy",
+        channel="ussuri/stable",
+        config={},
+        machines=machines,
+        model=model,
+        origin="ch",
+        series="focal",
+        subordinate_to=[],
+        units={
+            "swift-proxy/0": Unit(
+                name="swift-proxy/0",
+                workload_version="2.25.0",
+                machine=machines["0"],
+            )
+        },
+        workload_version="2.25.0",
+    )
+
+    exp_error = (
+        "'swift-proxy' application is not currently supported by COU. Please manually "
+        "upgrade it."
+    )
+
+    with pytest.raises(ApplicationNotSupported, match=exp_error):
+        app.generate_upgrade_plan(target, False)


### PR DESCRIPTION
Add a new Swift application class for swift-proxy and swift-storage. This class will also raise ApplicationNotSupported exception when generating a plan.

Also make sure both swift-proxy and swift-storage are considered as data-plane applications.

fixes: #310 