### PR TITLE
Add support for latest/stable

### DIFF
--- a/cou/apps/auxiliary.py
+++ b/cou/apps/auxiliary.py
@@ -54,30 +54,21 @@ class AuxiliaryApplication(OpenStackApplication):
             return True
 
         track = self._get_track_from_channel(charm_channel)
-        return (self.charm, self.series, track) in TRACK_TO_OPENSTACK_MAPPING
-
-    @property
-    def possible_current_channels(self) -> list[str]:
-        """Return the possible current channels based on the series and current OpenStack release.
-
-        :return: The possible current channels for the application.
-        :rtype: list[str]
-        :raises ApplicationError: When cannot find tracks.
-        """
         tracks = OPENSTACK_TO_TRACK_MAPPING.get(
             (self.charm, self.series, self.current_os_release.codename)
         )
-        if tracks:
-            return [f"{track}/stable" for track in tracks]
+        return (
+            self.charm,
+            self.series,
+            track,
+        ) in TRACK_TO_OPENSTACK_MAPPING and bool(tracks)
 
-        raise ApplicationError(
-            (
-                f"Cannot find a suitable '{self.charm}' charm channel for "
-                f"{self.current_os_release.codename} on series '{self.series}'. "
-                "Please take a look at the documentation: "
-                "https://docs.openstack.org/charm-guide/latest/project/charm-delivery.html"
-            )
+    @property
+    def possible_current_channel(self) -> str:
+        *_, track = OPENSTACK_TO_TRACK_MAPPING.get(
+            (self.charm, self.series, self.current_os_release.codename), []
         )
+        return f"{track}/stable"
 
     def target_channel(self, target: OpenStackRelease) -> str:
         """Return the appropriate channel for the passed OpenStack target.

--- a/cou/apps/auxiliary.py
+++ b/cou/apps/auxiliary.py
@@ -64,17 +64,19 @@ class AuxiliaryApplication(OpenStackApplication):
         ) in TRACK_TO_OPENSTACK_MAPPING and len(possible_tracks) > 0
 
     @property
-    def possible_current_channel(self) -> str:
-        """Return the possible current channel.
+    def expected_current_channel(self) -> str:
+        """Return the expected current channel.
 
-        Possible current channel is based in the series and in the current OpenStack release of
-        the application.
-        :return: The possible current channel of the application. E.g: "3.9/stable"
+        Expected current channel is the channel that the application is suppose to be using based
+        on the current series, workload version and, by consequence, the OpenStack release
+        identified.
+        :return: The expected current channel of the application. E.g: "3.9/stable"
         :rtype: str
         """
-        *_, track = OPENSTACK_TO_TRACK_MAPPING.get(
-            (self.charm, self.series, self.current_os_release.codename), []
-        )
+        *_, track = OPENSTACK_TO_TRACK_MAPPING[
+            (self.charm, self.series, self.current_os_release.codename)
+        ]
+
         return f"{track}/stable"
 
     def target_channel(self, target: OpenStackRelease) -> str:

--- a/cou/apps/auxiliary.py
+++ b/cou/apps/auxiliary.py
@@ -153,7 +153,7 @@ class AuxiliaryApplication(OpenStackApplication):
             )
         return super().generate_upgrade_plan(target, force, None)
 
-    def _need_to_refresh(self, target: OpenStackRelease) -> bool:
+    def _need_current_channel_refresh(self, target: OpenStackRelease) -> bool:
         """Check if the application needs to refresh the current channel.
 
         :param target: OpenStack release as target to upgrade.

--- a/cou/apps/base.py
+++ b/cou/apps/base.py
@@ -540,12 +540,15 @@ class OpenStackApplication(Application):
             return self._get_charmhub_migration_step()
         if self.channel == LATEST_STABLE:
             return self._get_change_to_openstack_channels_step()
-        if self._need_to_refresh(target):
+        if self._need_current_channel_refresh(target):
             return self._get_refresh_current_channel_step()
+        logger.info(
+            "'%s' does not need to refresh the current channel: %s", self.name, self.channel
+        )
         return PreUpgradeStep()
 
     def _get_charmhub_migration_step(self) -> PreUpgradeStep:
-        """Get the step for charm hub migration from charm store if necessary.
+        """Get the step for charm hub migration from charm store.
 
         :return: Step for charmhub migration
         :rtype: PreUpgradeStep
@@ -558,7 +561,7 @@ class OpenStackApplication(Application):
         )
 
     def _get_change_to_openstack_channels_step(self) -> PreUpgradeStep:
-        """Get the step for changing to OpenStack channels if necessary.
+        """Get the step for changing to OpenStack channels.
 
         :return: Step for changing to OpenStack channels
         :rtype: PreUpgradeStep
@@ -588,7 +591,7 @@ class OpenStackApplication(Application):
             coro=self.model.upgrade_charm(self.name, self.channel),
         )
 
-    def _need_to_refresh(self, target: OpenStackRelease) -> bool:
+    def _need_current_channel_refresh(self, target: OpenStackRelease) -> bool:
         """Check if the application needs to refresh the current channel.
 
         :param target: OpenStack release as target to upgrade.

--- a/cou/apps/subordinate.py
+++ b/cou/apps/subordinate.py
@@ -46,19 +46,17 @@ class SubordinateBase(OpenStackApplication):
                 f"than {target}. Ignoring."
             )
 
-    def pre_upgrade_steps(
-        self, target: OpenStackRelease, units: Optional[list[Unit]]
-    ) -> list[PreUpgradeStep]:
-        """Pre Upgrade steps planning.
+    def _get_upgrade_current_release_packages_step(
+        self, units: Optional[list[Unit]]
+    ) -> PreUpgradeStep:
+        """Get step for upgrading software packages to the latest of the current release.
 
-        :param target: OpenStack release as target to upgrade.
-        :type target: OpenStackRelease
         :param units: Units to generate upgrade plan
         :type units: Optional[list[Unit]]
-        :return: List of pre upgrade steps.
-        :rtype: list[PreUpgradeStep]
+        :return: Step for upgrading software packages to the latest of the current release.
+        :rtype: PreUpgradeStep
         """
-        return [self._get_refresh_charm_step(target)]
+        return PreUpgradeStep()
 
     def upgrade_steps(
         self, target: OpenStackRelease, units: Optional[list[Unit]], force: bool

--- a/tests/mocked_plans/sample_plans/base.yaml
+++ b/tests/mocked_plans/sample_plans/base.yaml
@@ -39,6 +39,7 @@ plan: |
                 Verify that all 'nova-compute' units has been upgraded
                 Upgrade software packages of 'ceph-osd' from the current APT repositories
                     Upgrade software packages on unit 'ceph-osd/0'
+                Refresh 'ceph-osd' to the latest revision of 'octopus/stable'
                 Change charm config of 'ceph-osd' 'source' to 'cloud:focal-victoria'
                 Wait for up to 300s for app 'ceph-osd' to reach the idle state
                 Verify that the workload of 'ceph-osd' has been upgraded on units: ceph-osd/0
@@ -99,13 +100,13 @@ applications:
     origin: ch
     series: focal
     subordinate_to: []
-    workload_version: 17.0.1
+    workload_version: 15.2.0
     units:
       ceph-osd/0:
         name: ceph-osd/0
         machine: '2'
-        workload_version: 17.0.1
-        os_version: xena
+        workload_version: 15.2.0
+        os_version: victoria
     machines:
       '2':
         id: '2'

--- a/tests/unit/apps/test_auxiliary.py
+++ b/tests/unit/apps/test_auxiliary.py
@@ -151,7 +151,7 @@ def test_auxiliary_upgrade_plan_ussuri_to_victoria_change_channel(model):
         PreUpgradeStep(
             description=f"Refresh '{app.name}' to the latest revision of '3.8/stable'",
             parallel=False,
-            coro=model.upgrade_charm(app.name, "3.8/stable", switch=None),
+            coro=model.upgrade_charm(app.name, "3.8/stable"),
         ),
         UpgradeStep(
             description=f"Upgrade '{app.name}' to the new channel: '3.9/stable'",
@@ -227,8 +227,7 @@ def test_auxiliary_upgrade_plan_ussuri_to_victoria(model):
         upgrade_packages,
         PreUpgradeStep(
             description=f"Refresh '{app.name}' to the latest revision of '3.9/stable'",
-            parallel=False,
-            coro=model.upgrade_charm(app.name, "3.9/stable", switch=None),
+            coro=model.upgrade_charm(app.name, "3.9/stable"),
         ),
         UpgradeStep(
             description=f"Change charm config of '{app.name}' "
@@ -298,8 +297,7 @@ def test_auxiliary_upgrade_plan_ussuri_to_victoria_ch_migration(model):
     upgrade_steps = [
         upgrade_packages,
         PreUpgradeStep(
-            description=f"Migrate '{app.name}' from charmstore to charmhub",
-            parallel=False,
+            f"Migrate '{app.name}' from charmstore to charmhub",
             coro=model.upgrade_charm(app.name, "3.9/stable", switch="ch:rabbitmq-server"),
         ),
         UpgradeStep(
@@ -330,7 +328,6 @@ def test_auxiliary_upgrade_plan_ussuri_to_victoria_ch_migration(model):
     expected_plan.add_steps(upgrade_steps)
 
     upgrade_plan = app.generate_upgrade_plan(target, False)
-
     assert_steps(upgrade_plan, expected_plan)
 
 
@@ -374,28 +371,27 @@ def test_auxiliary_app_unknown_version_raise_ApplicationError(model):
     exp_msg = f"'{charm}' with workload version {version} has no compatible OpenStack release."
 
     machines = {"0": MagicMock(spec_set=Machine)}
-    app = RabbitMQServer(
-        name=charm,
-        can_upgrade_to="3.8/stable",
-        charm=charm,
-        channel="3.8/stable",
-        config={"source": {"value": "distro"}},
-        machines=machines,
-        model=model,
-        origin="ch",
-        series="focal",
-        subordinate_to=[],
-        units={
-            f"{charm}/0": Unit(
-                name=f"{charm}/0",
-                workload_version=version,
-                machine=machines["0"],
-            )
-        },
-        workload_version=version,
-    )
     with pytest.raises(ApplicationError, match=exp_msg):
-        app.get_latest_os_version(app.units[f"{charm}/0"])
+        RabbitMQServer(
+            name=charm,
+            can_upgrade_to="3.8/stable",
+            charm=charm,
+            channel="3.8/stable",
+            config={"source": {"value": "distro"}},
+            machines=machines,
+            model=model,
+            origin="ch",
+            series="focal",
+            subordinate_to=[],
+            units={
+                f"{charm}/0": Unit(
+                    name=f"{charm}/0",
+                    workload_version=version,
+                    machine=machines["0"],
+                )
+            },
+            workload_version=version,
+        )
 
 
 def test_auxiliary_raise_error_unknown_series(model):
@@ -441,29 +437,27 @@ def test_auxiliary_raise_error_os_not_on_lookup(current_os_release, model):
     current_os_release.return_value = OpenStackRelease("diablo")
 
     machines = {"0": MagicMock(spec_set=Machine)}
-    app = RabbitMQServer(
-        name="rabbitmq-server",
-        can_upgrade_to="",
-        charm="rabbitmq-server",
-        channel="3.8/stable",
-        config={"source": {"value": "distro"}},
-        machines=machines,
-        model=model,
-        origin="ch",
-        series="focal",
-        subordinate_to=[],
-        units={
-            "rabbitmq-server/0": Unit(
-                name="rabbitmq-server/0",
-                workload_version="3.8",
-                machine=machines["0"],
-            )
-        },
-        workload_version="3.8",
-    )
-
     with pytest.raises(ApplicationError):
-        app.possible_current_channels
+        app = RabbitMQServer(
+            name="rabbitmq-server",
+            can_upgrade_to="",
+            charm="rabbitmq-server",
+            channel="3.8/stable",
+            config={"source": {"value": "distro"}},
+            machines=machines,
+            model=model,
+            origin="ch",
+            series="focal",
+            subordinate_to=[],
+            units={
+                "rabbitmq-server/0": Unit(
+                    name="rabbitmq-server/0",
+                    workload_version="3.8",
+                    machine=machines["0"],
+                )
+            },
+            workload_version="3.8",
+        )
 
 
 def test_auxiliary_raise_halt_upgrade(model):
@@ -618,7 +612,7 @@ def test_ceph_mon_upgrade_plan_xena_to_yoga(model):
         PreUpgradeStep(
             description=f"Refresh '{app.name}' to the latest revision of 'pacific/stable'",
             parallel=False,
-            coro=model.upgrade_charm(app.name, "pacific/stable", switch=None),
+            coro=model.upgrade_charm(app.name, "pacific/stable"),
         ),
         PreUpgradeStep(
             description="Ensure that the 'require-osd-release' option matches the 'ceph-osd' "
@@ -702,7 +696,7 @@ def test_ceph_mon_upgrade_plan_ussuri_to_victoria(model):
         PreUpgradeStep(
             description=f"Refresh '{app.name}' to the latest revision of 'octopus/stable'",
             parallel=False,
-            coro=model.upgrade_charm(app.name, "octopus/stable", switch=None),
+            coro=model.upgrade_charm(app.name, "octopus/stable"),
         ),
         PreUpgradeStep(
             "Ensure that the 'require-osd-release' option matches the 'ceph-osd' version",
@@ -917,7 +911,7 @@ def test_ovn_principal_upgrade_plan(model):
         PreUpgradeStep(
             description=f"Refresh '{app.name}' to the latest revision of '22.03/stable'",
             parallel=False,
-            coro=model.upgrade_charm(app.name, "22.03/stable", switch=None),
+            coro=model.upgrade_charm(app.name, "22.03/stable"),
         ),
         UpgradeStep(
             description=f"Change charm config of '{app.name}' "
@@ -990,7 +984,7 @@ def test_mysql_innodb_cluster_upgrade(model):
         PreUpgradeStep(
             description=f"Refresh '{app.name}' to the latest revision of '8.0/stable'",
             parallel=False,
-            coro=model.upgrade_charm(app.name, "8.0/stable", switch=None),
+            coro=model.upgrade_charm(app.name, "8.0/stable"),
         ),
         UpgradeStep(
             description=f"Change charm config of '{app.name}' "
@@ -1024,18 +1018,26 @@ def test_mysql_innodb_cluster_upgrade(model):
 def test_ceph_osd_pre_upgrade_steps(mock_pre_upgrade_steps, target, model):
     """Test Ceph-osd pre upgrade steps."""
     mock_pre_upgrade_steps.return_value = [MagicMock(spec_set=UpgradeStep)()]
+    machines = {f"{i}": generate_cou_machine(f"{i}", f"az-{i}") for i in range(3)}
     app = CephOsd(
         name="ceph-osd",
         can_upgrade_to="octopus/stable",
         charm="ceph-osd",
         channel="octopus/stable",
         config={"source": {"value": "distro"}},
-        machines={},
+        machines=machines,
         model=model,
         origin="ch",
         series="focal",
         subordinate_to=[],
-        units={},
+        units={
+            f"ceph-osd/{i}": Unit(
+                name=f"ceph-osd/{i}",
+                workload_version="17.0.1",
+                machine=machines[f"{i}"],
+            )
+            for i in range(3)
+        },
         workload_version="17.0.1",
     )
     steps = app.pre_upgrade_steps(target, None)
@@ -1051,22 +1053,29 @@ def test_ceph_osd_pre_upgrade_steps(mock_pre_upgrade_steps, target, model):
 
 
 @pytest.mark.asyncio
-@patch("cou.utils.openstack.OpenStackCodenameLookup.find_compatible_versions")
-async def test_ceph_osd_verify_nova_compute_no_app(mock_lookup, model):
+async def test_ceph_osd_verify_nova_compute_no_app(model):
     """Test Ceph-osd verifying all nova computes."""
     target = OpenStackRelease("victoria")
+    machines = {f"{i}": generate_cou_machine(f"{i}", f"az-{i}") for i in range(3)}
     app = CephOsd(
         name="ceph-osd",
         can_upgrade_to="octopus/stable",
         charm="ceph-osd",
         channel="octopus/stable",
         config={"source": {"value": "distro"}},
-        machines={},
+        machines=machines,
         model=model,
         origin="ch",
         series="focal",
         subordinate_to=[],
-        units={},
+        units={
+            f"ceph-osd/{i}": Unit(
+                name=f"ceph-osd/{i}",
+                workload_version="17.0.1",
+                machine=machines[f"{i}"],
+            )
+            for i in range(3)
+        },
         workload_version="17.0.1",
     )
     model.get_applications.return_value = [app]
@@ -1074,7 +1083,6 @@ async def test_ceph_osd_verify_nova_compute_no_app(mock_lookup, model):
     await app._verify_nova_compute(target)
 
     model.get_applications.assert_awaited_once_with()
-    mock_lookup.assert_not_called()
 
 
 @patch("cou.apps.base.OpenStackApplication.generate_upgrade_plan")
@@ -1130,6 +1138,7 @@ def test_auxiliary_upgrade_by_unit(mock_super, model):
 async def test_ceph_osd_verify_nova_compute_pass(mock_lookup, model):
     """Test Ceph-osd verifying all nova computes."""
     target = OpenStackRelease("victoria")
+    machines = {f"{i}": generate_cou_machine(f"{i}", f"az-{i}") for i in range(3)}
     mock_lookup.return_value = [target]
     nova_compute = MagicMock(spec_set=NovaCompute)()
     nova_compute.charm = "nova-compute"
@@ -1140,12 +1149,19 @@ async def test_ceph_osd_verify_nova_compute_pass(mock_lookup, model):
         charm="ceph-osd",
         channel="octopus/stable",
         config={"source": {"value": "distro"}},
-        machines={},
+        machines=machines,
         model=model,
         origin="ch",
         series="focal",
         subordinate_to=[],
-        units={},
+        units={
+            f"ceph-osd/{i}": Unit(
+                name=f"ceph-osd/{i}",
+                workload_version="17.0.1",
+                machine=machines[f"{i}"],
+            )
+            for i in range(3)
+        },
         workload_version="17.0.1",
     )
     model.get_applications.return_value = [app, nova_compute]
@@ -1153,7 +1169,7 @@ async def test_ceph_osd_verify_nova_compute_pass(mock_lookup, model):
     await app._verify_nova_compute(target)
 
     model.get_applications.assert_awaited_once_with()
-    mock_lookup.assert_called_once_with("nova-compute", "22.0.0")
+    mock_lookup.assert_any_call("nova-compute", "22.0.0")
 
 
 @pytest.mark.asyncio
@@ -1162,6 +1178,7 @@ async def test_ceph_osd_verify_nova_compute_fail(mock_lookup, model):
     """Test Ceph-osd verifying all nova computes."""
     mock_lookup.return_value = [OpenStackRelease("ussuri")]
     target = OpenStackRelease("victoria")
+    machines = {f"{i}": generate_cou_machine(f"{i}", f"az-{i}") for i in range(3)}
     nova_compute = MagicMock(spec_set=NovaCompute)()
     nova_compute.charm = "nova-compute"
     nova_compute.units = {"nova-compute/0": Unit("nova-compute/0", None, "22.0.0")}
@@ -1171,12 +1188,19 @@ async def test_ceph_osd_verify_nova_compute_fail(mock_lookup, model):
         charm="ceph-osd",
         channel="octopus/stable",
         config={"source": {"value": "distro"}},
-        machines={},
+        machines=machines,
         model=model,
         origin="ch",
         series="focal",
         subordinate_to=[],
-        units={},
+        units={
+            f"ceph-osd/{i}": Unit(
+                name=f"ceph-osd/{i}",
+                workload_version="17.0.1",
+                machine=machines[f"{i}"],
+            )
+            for i in range(3)
+        },
         workload_version="17.0.1",
     )
     model.get_applications.return_value = [app, nova_compute]
@@ -1195,6 +1219,7 @@ def test_ceph_osd_upgrade_plan(model):
             Upgrade software packages on unit 'ceph-osd/0'
             Upgrade software packages on unit 'ceph-osd/1'
             Upgrade software packages on unit 'ceph-osd/2'
+        Refresh 'ceph-osd' to the latest revision of 'octopus/stable'
         Change charm config of 'ceph-osd' 'source' to 'cloud:focal-victoria'
         Wait for up to 300s for app 'ceph-osd' to reach the idle state
         Verify that the workload of 'ceph-osd' has been upgraded on units: ceph-osd/0, ceph-osd/1, ceph-osd/2

--- a/tests/unit/apps/test_auxiliary.py
+++ b/tests/unit/apps/test_auxiliary.py
@@ -1282,7 +1282,7 @@ def test_ceph_osd_upgrade_plan(model):
 )
 @patch("cou.apps.auxiliary.AuxiliaryApplication._verify_channel", return_value=None)
 @patch("cou.apps.auxiliary.TRACK_TO_OPENSTACK_MAPPING")
-def test_need_to_refresh_auxiliary(
+def test_need_current_channel_refresh_auxiliary(
     mock_track_os_mapping, _, model, can_upgrade_to, compatible_os_releases, exp_result
 ):
     mock_track_os_mapping.__getitem__.return_value = compatible_os_releases
@@ -1291,4 +1291,4 @@ def test_need_to_refresh_auxiliary(
     app = AuxiliaryApplication(
         app_name, can_upgrade_to, app_name, "3.9/stable", {}, {}, model, "ch", "focal", [], {}, "1"
     )
-    assert app._need_to_refresh(target) is exp_result
+    assert app._need_current_channel_refresh(target) is exp_result

--- a/tests/unit/apps/test_auxiliary_subordinate.py
+++ b/tests/unit/apps/test_auxiliary_subordinate.py
@@ -79,7 +79,7 @@ def test_auxiliary_subordinate_upgrade_plan_to_victoria(model):
         PreUpgradeStep(
             description=f"Refresh '{app.name}' to the latest revision of '8.0/stable'",
             parallel=False,
-            coro=model.upgrade_charm(app.name, "8.0/stable", switch=None),
+            coro=model.upgrade_charm(app.name, "8.0/stable"),
         ),
     )
 
@@ -194,7 +194,7 @@ def test_ovn_subordinate_upgrade_plan(model):
         PreUpgradeStep(
             description=f"Refresh '{app.name}' to the latest revision of '22.03/stable'",
             parallel=False,
-            coro=model.upgrade_charm(app.name, "22.03/stable", switch=None),
+            coro=model.upgrade_charm(app.name, "22.03/stable"),
         )
     ]
     expected_plan.add_steps(upgrade_steps)
@@ -261,7 +261,7 @@ def test_ceph_dashboard_upgrade_plan_ussuri_to_victoria(model):
         PreUpgradeStep(
             description=f"Refresh '{app.name}' to the latest revision of 'octopus/stable'",
             parallel=False,
-            coro=model.upgrade_charm(app.name, "octopus/stable", switch=None),
+            coro=model.upgrade_charm(app.name, "octopus/stable"),
         )
     ]
 
@@ -299,7 +299,7 @@ def test_ceph_dashboard_upgrade_plan_xena_to_yoga(model):
         PreUpgradeStep(
             description=f"Refresh '{app.name}' to the latest revision of 'pacific/stable'",
             parallel=False,
-            coro=model.upgrade_charm(app.name, "pacific/stable", switch=None),
+            coro=model.upgrade_charm(app.name, "pacific/stable"),
         ),
         UpgradeStep(
             description=f"Upgrade '{app.name}' to the new channel: 'quincy/stable'",

--- a/tests/unit/apps/test_base.py
+++ b/tests/unit/apps/test_base.py
@@ -540,7 +540,7 @@ def test_get_change_to_openstack_channels_step(current_os_release, model):
 
 
 def test_get_refresh_current_channel_step(model):
-    """Expect an pre-upgrade for application that does need to refresh the current channel."""
+    """Expect a pre-upgrade step for application that needs to refresh the current channel."""
     app = OpenStackApplication(
         name="app",
         can_upgrade_to="ch:amd64/focal/my-app-723",
@@ -569,7 +569,7 @@ def test_get_refresh_current_channel_step(model):
 def test_get_refresh_charm_step_skip(
     mock_ch_migration, mock_change_os_channels, mock_refresh_current_channel, model
 ):
-    """Expect an empty pre-upgrade for application that does not need to refresh."""
+    """Expect an empty pre-upgrade step for application that does not need to refresh."""
     target = OpenStackRelease("victoria")
 
     app = OpenStackApplication(
@@ -600,7 +600,7 @@ def test_get_refresh_charm_step_skip(
 def test_get_refresh_charm_step_refresh_current_channel(
     mock_ch_migration, mock_change_os_channels, mock_refresh_current_channel, model
 ):
-    """Expect an pre-upgrade for application that does need to refresh current channel."""
+    """Expect a pre-upgrade step for application that needs to refresh current channel."""
     target = OpenStackRelease("victoria")
 
     app = OpenStackApplication(
@@ -641,7 +641,7 @@ def test_get_refresh_charm_step_change_to_openstack_channels(
     mock_refresh_current_channel,
     model,
 ):
-    """Expect an pre-upgrade for application that does need to change to OpenStack channel."""
+    """Expect a pre-upgrade step for application that needs to change to OpenStack channel."""
     current_os_release.return_value = OpenStackRelease("ussuri")
     target = OpenStackRelease("victoria")
 
@@ -686,7 +686,7 @@ def test_get_refresh_charm_step_charmhub_migration(
     mock_refresh_current_channel,
     model,
 ):
-    """Expect an pre-upgrade for application that does need to migrate to charmhub."""
+    """Expect a pre-upgrade step for application that needs to migrate to charmhub."""
     current_os_release.return_value = OpenStackRelease("ussuri")
     target = OpenStackRelease("victoria")
 
@@ -728,7 +728,7 @@ def test_get_refresh_charm_step_charmhub_migration(
         ("", "wallaby/stable", False),
     ],
 )
-def test_need_to_refresh(model, can_upgrade_to, channel, exp_result):
+def test_need_current_channel_refresh(model, can_upgrade_to, channel, exp_result):
     """Test when the application needs to refresh."""
     target = OpenStackRelease("victoria")
 
@@ -746,4 +746,4 @@ def test_need_to_refresh(model, can_upgrade_to, channel, exp_result):
         units={},
         workload_version="1",
     )
-    assert app._need_to_refresh(target) is exp_result
+    assert app._need_current_channel_refresh(target) is exp_result

--- a/tests/unit/apps/test_base.py
+++ b/tests/unit/apps/test_base.py
@@ -560,7 +560,7 @@ def test_get_change_to_openstack_channels_step_latest_stable(current_os_release,
 
 
 @patch("cou.apps.base.OpenStackApplication.current_os_release", new_callable=PropertyMock)
-def test_get_change_to_openstack_channels_step_openstack_channel(current_os_release, model):
+def test_get_change_to_openstack_channels_step(current_os_release, model):
     """Expect an empty pre-upgrade step for applications using release-specific channel."""
     current_os_release.return_value = OpenStackRelease("ussuri")
     app_name = "app"
@@ -720,7 +720,7 @@ def test_get_refresh_charm_step_charmhub_migration(
     mock_refresh_current_channel,
     model,
 ):
-    """Expect an pre-upgrade for application that does need to refresh current channel."""
+    """Expect an pre-upgrade for application that does need to migrate to charmhub."""
     current_os_release.return_value = OpenStackRelease("ussuri")
     target = OpenStackRelease("victoria")
     app_name = "app"

--- a/tests/unit/apps/test_channel_based.py
+++ b/tests/unit/apps/test_channel_based.py
@@ -201,7 +201,7 @@ def test_application_versionless_upgrade_plan_ussuri_to_victoria(model):
         PreUpgradeStep(
             description=f"Refresh '{app.name}' to the latest revision of 'ussuri/stable'",
             parallel=False,
-            coro=model.upgrade_charm(app.name, "ussuri/stable", switch=None),
+            coro=model.upgrade_charm(app.name, "ussuri/stable"),
         ),
         UpgradeStep(
             description=f"Upgrade '{app.name}' to the new channel: 'victoria/stable'",
@@ -275,7 +275,7 @@ def test_application_gnocchi_upgrade_plan_ussuri_to_victoria(model):
         PreUpgradeStep(
             description=f"Refresh '{app.name}' to the latest revision of 'ussuri/stable'",
             parallel=False,
-            coro=model.upgrade_charm(app.name, "ussuri/stable", switch=None),
+            coro=model.upgrade_charm(app.name, "ussuri/stable"),
         ),
         UpgradeStep(
             description=f"Upgrade '{app.name}' to the new channel: 'victoria/stable'",
@@ -358,7 +358,7 @@ def test_application_designate_bind_upgrade_plan_ussuri_to_victoria(model):
         PreUpgradeStep(
             description=f"Refresh '{app.name}' to the latest revision of 'ussuri/stable'",
             parallel=False,
-            coro=model.upgrade_charm(app.name, "ussuri/stable", switch=None),
+            coro=model.upgrade_charm(app.name, "ussuri/stable"),
         ),
         UpgradeStep(
             description=f"Upgrade '{app.name}' to the new channel: 'victoria/stable'",

--- a/tests/unit/apps/test_core.py
+++ b/tests/unit/apps/test_core.py
@@ -134,39 +134,6 @@ def test_application_empty_origin_config(model):
     assert app.apt_source_codename is None
 
 
-def test_application_unexpected_channel(model):
-    """Test Keystone application with unexpected channel."""
-    target = OpenStackRelease("xena")
-    exp_msg = (
-        "'keystone' has unexpected channel: 'ussuri/stable' for the current workload version "
-        "and OpenStack release: 'wallaby'. Possible channels are: wallaby/stable"
-    )
-    machines = {"0": MagicMock(spec_set=Machine)}
-    app = Keystone(
-        name="keystone",
-        can_upgrade_to="ussuri/stable",
-        charm="keystone",
-        channel="ussuri/stable",
-        config={"source": {"value": ""}},
-        machines=machines,
-        model=model,
-        origin="ch",
-        series="focal",
-        subordinate_to=[],
-        units={
-            "keystone/0": Unit(
-                name="keystone/0",
-                workload_version="19.0.1",
-                machine=machines["0"],
-            )
-        },
-        workload_version="19.1.0",
-    )
-
-    with pytest.raises(ApplicationError, match=exp_msg):
-        app.generate_upgrade_plan(target, False)
-
-
 @pytest.mark.parametrize(
     "source_value",
     ["ppa:myteam/ppa", "cloud:xenial-proposed/ocata", "http://my.archive.com/ubuntu main"],
@@ -330,7 +297,7 @@ def test_upgrade_plan_ussuri_to_victoria(model):
         PreUpgradeStep(
             description=f"Refresh '{app.name}' to the latest revision of 'ussuri/stable'",
             parallel=False,
-            coro=model.upgrade_charm(app.name, "ussuri/stable", switch=None),
+            coro=model.upgrade_charm(app.name, "ussuri/stable"),
         ),
         UpgradeStep(
             description=f"Change charm config of '{app.name}' 'action-managed-upgrade' to 'False'",
@@ -461,7 +428,7 @@ def test_upgrade_plan_channel_on_next_os_release(model):
     machines = {"0": MagicMock(spec_set=Machine)}
     app = Keystone(
         name="keystone",
-        can_upgrade_to="victoria/stable",
+        can_upgrade_to="",
         charm="keystone",
         channel="victoria/stable",
         config={
@@ -579,7 +546,7 @@ def test_upgrade_plan_origin_already_on_next_openstack_release(model):
         PreUpgradeStep(
             description=f"Refresh '{app.name}' to the latest revision of 'ussuri/stable'",
             parallel=False,
-            coro=model.upgrade_charm(app.name, "ussuri/stable", switch=None),
+            coro=model.upgrade_charm(app.name, "ussuri/stable"),
         ),
         UpgradeStep(
             description=f"Change charm config of '{app.name}' 'action-managed-upgrade' to 'False'",
@@ -693,7 +660,7 @@ def test_upgrade_plan_application_already_disable_action_managed(model):
         PreUpgradeStep(
             description=f"Refresh '{app.name}' to the latest revision of 'ussuri/stable'",
             parallel=False,
-            coro=model.upgrade_charm(app.name, "ussuri/stable", switch=None),
+            coro=model.upgrade_charm(app.name, "ussuri/stable"),
         ),
         UpgradeStep(
             description=f"Upgrade '{app.name}' to the new channel: 'victoria/stable'",
@@ -884,7 +851,7 @@ def _generate_nova_compute_app(model):
     channel = "ussuri/stable"
 
     units = {
-        f"nova-compute/{unit_num}": Unit(f"nova-compute/{unit_num}", MagicMock(), MagicMock())
+        f"nova-compute/{unit_num}": Unit(f"nova-compute/{unit_num}", MagicMock(), "21.0.1")
         for unit_num in range(3)
     }
     app = NovaCompute(

--- a/tests/unit/apps/test_subordinate.py
+++ b/tests/unit/apps/test_subordinate.py
@@ -71,7 +71,7 @@ def test_generate_upgrade_plan(model):
         PreUpgradeStep(
             description=f"Refresh '{app.name}' to the latest revision of 'ussuri/stable'",
             parallel=False,
-            coro=model.upgrade_charm(app.name, "ussuri/stable", switch=None),
+            coro=model.upgrade_charm(app.name, "ussuri/stable"),
         ),
         UpgradeStep(
             description=f"Upgrade '{app.name}' to the new channel: 'victoria/stable'",
@@ -122,7 +122,6 @@ def test_channel_valid(model, channel):
     [
         "focal/edge",
         "latest/edge",
-        "latest/stable",
         "something/stable",
     ],
 )
@@ -224,7 +223,7 @@ def test_generate_plan_from_to(model, from_os, to_os):
         PreUpgradeStep(
             description=f"Refresh '{app.name}' to the latest revision of '{from_os}/stable'",
             parallel=False,
-            coro=model.upgrade_charm(app.name, f"{from_os}/stable", switch=None),
+            coro=model.upgrade_charm(app.name, f"{from_os}/stable"),
         ),
         UpgradeStep(
             description=f"Upgrade '{app.name}' to the new channel: '{to_os}/stable'",
@@ -271,7 +270,7 @@ def test_generate_plan_in_same_version(model, from_to):
         PreUpgradeStep(
             description=f"Refresh '{app.name}' to the latest revision of '{from_to}/stable'",
             parallel=False,
-            coro=model.upgrade_charm(app.name, f"{from_to}/stable", switch=None),
+            coro=model.upgrade_charm(app.name, f"{from_to}/stable"),
         ),
     ]
     expected_plan.add_steps(upgrade_steps)

--- a/tests/unit/steps/test_plan.py
+++ b/tests/unit/steps/test_plan.py
@@ -81,7 +81,7 @@ def generate_expected_upgrade_plan_principal(app, target, model):
             description=f"Refresh '{app.name}' to the latest revision of "
             f"'{target.previous_release}/stable'",
             parallel=False,
-            coro=model.upgrade_charm(app.name, f"{target.previous_release}/stable", switch=None),
+            coro=model.upgrade_charm(app.name, f"{target.previous_release}/stable"),
         ),
         UpgradeStep(
             description=f"Change charm config of '{app.name}' 'action-managed-upgrade' to 'False'",
@@ -122,7 +122,7 @@ def generate_expected_upgrade_plan_subordinate(app, target, model):
         PreUpgradeStep(
             f"Refresh '{app.name}' to the latest revision of '{target.previous_release}/stable'",
             parallel=False,
-            coro=model.upgrade_charm(app.name, f"{target.previous_release}/stable", switch=None),
+            coro=model.upgrade_charm(app.name, f"{target.previous_release}/stable"),
         ),
         UpgradeStep(
             f"Upgrade '{app.name}' to the new channel: '{target.codename}/stable'",
@@ -181,6 +181,7 @@ nova-compute/0
                 Verify that all 'nova-compute' units has been upgraded
                 Upgrade software packages of 'ceph-osd' from the current APT repositories
                     Upgrade software packages on unit 'ceph-osd/0'
+                Refresh 'ceph-osd' to the latest revision of 'octopus/stable'
                 Change charm config of 'ceph-osd' 'source' to 'cloud:focal-victoria'
                 Wait for up to 300s for app 'ceph-osd' to reach the idle state
                 Verify that the workload of 'ceph-osd' has been upgraded on units: ceph-osd/0

--- a/tests/unit/steps/test_plan.py
+++ b/tests/unit/steps/test_plan.py
@@ -268,11 +268,11 @@ nova-compute/0
         units={
             "ceph-osd/0": Unit(
                 name="ceph-osd/0",
-                workload_version="17.0.1",
+                workload_version="15.2.0",
                 machine=machines["2"],
             )
         },
-        workload_version="17.0.1",
+        workload_version="15.2.0",
     )
 
     ovn_chassis = OvnSubordinate(

--- a/tests/unit/steps/test_plan.py
+++ b/tests/unit/steps/test_plan.py
@@ -341,6 +341,7 @@ nova-compute/0
                 Verify that all 'nova-compute' units has been upgraded
                 Upgrade software packages of 'ceph-osd' from the current APT repositories
                     Upgrade software packages on unit 'ceph-osd/0'
+                Refresh 'ceph-osd' to the latest revision of 'octopus/stable'
                 Change charm config of 'ceph-osd' 'source' to 'cloud:focal-victoria'
                 Wait for up to 300s for app 'ceph-osd' to reach the idle state
                 Verify that the workload of 'ceph-osd' has been upgraded on units: ceph-osd/0


### PR DESCRIPTION
- currently if the applications uses `latest/stable` channel it's not considered as a valid channel to upgrade.
- the approach is to move to an OpenStack release channel when this happens, based on the current workload version