### PR TITLE
Adjust RTD site header

### DIFF
--- a/docs/.sphinx/_templates/header.html
+++ b/docs/.sphinx/_templates/header.html
@@ -12,16 +12,12 @@
         </a>
       </li>
 
-      <li class="nav-ubuntu-com">
-        <a href="https://{{ product_page }}" class="p-navigation__link">{{ product_page }}</a>
-      </li>
-
       <li>
         <a href="#" class="p-navigation__link nav-more-links">More resources</a>
         <ul class="more-links-dropdown">
 
           <li>
-            <a href="{{ discourse }}" class="p-navigation__sub-link p-dropdown__link">Forum</a>
+            <a href="https://{{ product_page }}" class="p-navigation__sub-link p-dropdown__link">Snap Store</a>
           </li>
 
           <li>


### PR DESCRIPTION
Move the explicitly displayed snapcraft link from header to the "More Resources" dropdown list.

Also remove "Forum" from the dropdown list because COU doesn't have a discourse page.

fixes: #218