### PR TITLE
Move _verify_channel to sanity checks

### DIFF
--- a/cou/apps/base.py
+++ b/cou/apps/base.py
@@ -337,7 +337,7 @@ class OpenStackApplication(Application):
         :type target: OpenStackRelease
         :param units: Units to generate upgrade plan, defaults to None
         :type units: Optional[list[Unit]], optional
-        :raises ApplicationError: When enable-auto-restarts is not enabled.
+        :raises ApplicationError: When application is wrongly configured.
         :raises HaltUpgradePlanGeneration: When the application halt the upgrade plan generation.
         """
         self._check_channel()

--- a/tests/unit/apps/test_auxiliary.py
+++ b/tests/unit/apps/test_auxiliary.py
@@ -344,27 +344,29 @@ def test_auxiliary_upgrade_plan_unknown_track(model):
         "to see if you are using the right track."
     )
     machines = {"0": MagicMock(spec_set=Machine)}
+    app = RabbitMQServer(
+        name="rabbitmq-server",
+        can_upgrade_to="3.9/stable",
+        charm="rabbitmq-server",
+        channel=channel,
+        config={"source": {"value": "distro"}},
+        machines=machines,
+        model=model,
+        origin="ch",
+        series="focal",
+        subordinate_to=[],
+        units={
+            "rabbitmq-server/0": Unit(
+                name="rabbitmq-server/0",
+                workload_version="3.8",
+                machine=machines["0"],
+            )
+        },
+        workload_version="3.8",
+    )
+
     with pytest.raises(ApplicationError, match=exp_msg):
-        RabbitMQServer(
-            name="rabbitmq-server",
-            can_upgrade_to="3.9/stable",
-            charm="rabbitmq-server",
-            channel=channel,
-            config={"source": {"value": "distro"}},
-            machines=machines,
-            model=model,
-            origin="ch",
-            series="focal",
-            subordinate_to=[],
-            units={
-                "rabbitmq-server/0": Unit(
-                    name="rabbitmq-server/0",
-                    workload_version="3.8",
-                    machine=machines["0"],
-                )
-            },
-            workload_version="3.8",
-        )
+        app._check_channel()
 
 
 def test_auxiliary_app_unknown_version_raise_ApplicationError(model):
@@ -409,27 +411,28 @@ def test_auxiliary_raise_error_unknown_series(model):
         "to see if you are using the right track."
     )
     machines = {"0": MagicMock(spec_set=Machine)}
+    app = RabbitMQServer(
+        name="rabbitmq-server",
+        can_upgrade_to="3.9/stable",
+        charm="rabbitmq-server",
+        channel=channel,
+        config={"source": {"value": "distro"}},
+        machines=machines,
+        model=model,
+        origin="ch",
+        series=series,
+        subordinate_to=[],
+        units={
+            "rabbitmq-server/0": Unit(
+                name="rabbitmq-server/0",
+                workload_version="3.8",
+                machine=machines["0"],
+            )
+        },
+        workload_version="3.8",
+    )
     with pytest.raises(ApplicationError, match=exp_msg):
-        RabbitMQServer(
-            name="rabbitmq-server",
-            can_upgrade_to="3.9/stable",
-            charm="rabbitmq-server",
-            channel=channel,
-            config={"source": {"value": "distro"}},
-            machines=machines,
-            model=model,
-            origin="ch",
-            series=series,
-            subordinate_to=[],
-            units={
-                "rabbitmq-server/0": Unit(
-                    name="rabbitmq-server/0",
-                    workload_version="3.8",
-                    machine=machines["0"],
-                )
-            },
-            workload_version="3.8",
-        )
+        app._check_channel()
 
 
 @patch("cou.apps.core.OpenStackApplication.current_os_release")
@@ -846,28 +849,29 @@ def test_ovn_no_compatible_os_release(channel, model):
         "https://docs.openstack.org/charm-guide/latest/project/charm-delivery.html "
         "to see if you are using the right track."
     )
+    app = OvnPrincipal(
+        name=charm,
+        can_upgrade_to="quincy/stable",
+        charm=charm,
+        channel=channel,
+        config={"source": {"value": "distro"}},
+        machines=machines,
+        model=model,
+        origin="ch",
+        series="focal",
+        subordinate_to=[],
+        units={
+            f"{charm}/0": Unit(
+                name=f"{charm}/0",
+                workload_version="22.03",
+                machine=machines["0"],
+            )
+        },
+        workload_version="22.03",
+    )
 
     with pytest.raises(ApplicationError, match=exp_msg):
-        OvnPrincipal(
-            name=charm,
-            can_upgrade_to="quincy/stable",
-            charm=charm,
-            channel=channel,
-            config={"source": {"value": "distro"}},
-            machines=machines,
-            model=model,
-            origin="ch",
-            series="focal",
-            subordinate_to=[],
-            units={
-                f"{charm}/0": Unit(
-                    name=f"{charm}/0",
-                    workload_version="22.03",
-                    machine=machines["0"],
-                )
-            },
-            workload_version="22.03",
-        )
+        app._check_channel()
 
 
 def test_ovn_principal_upgrade_plan(model):

--- a/tests/unit/apps/test_auxiliary.py
+++ b/tests/unit/apps/test_auxiliary.py
@@ -435,7 +435,12 @@ def test_auxiliary_raise_error_os_not_on_lookup(current_os_release, model):
     Using OpenStack release version that is not on openstack_to_track_mapping.csv table.
     """
     current_os_release.return_value = OpenStackRelease("diablo")
-
+    exp_error_msg = (
+        "Channel: 3.8/stable for charm 'rabbitmq-server' on series 'focal' is currently not "
+        "supported in this tool. Please take a look at the documentation: "
+        "https://docs.openstack.org/charm-guide/latest/project/charm-delivery.html to see if you "
+        "are using the right track."
+    )
     machines = {"0": MagicMock(spec_set=Machine)}
     app = RabbitMQServer(
         name="rabbitmq-server",
@@ -458,7 +463,7 @@ def test_auxiliary_raise_error_os_not_on_lookup(current_os_release, model):
         workload_version="3.8",
     )
 
-    with pytest.raises(ApplicationError):
+    with pytest.raises(ApplicationError, match=exp_error_msg):
         app._check_channel()
 
 

--- a/tests/unit/apps/test_auxiliary.py
+++ b/tests/unit/apps/test_auxiliary.py
@@ -373,6 +373,7 @@ def test_auxiliary_app_unknown_version_raise_ApplicationError(model):
     exp_msg = f"'{charm}' with workload version {version} has no compatible OpenStack release."
 
     machines = {"0": MagicMock(spec_set=Machine)}
+    unit = Unit(name=f"{charm}/0", workload_version=version, machine=machines["0"])
     app = RabbitMQServer(
         name=charm,
         can_upgrade_to="3.8/stable",
@@ -384,18 +385,12 @@ def test_auxiliary_app_unknown_version_raise_ApplicationError(model):
         origin="ch",
         series="focal",
         subordinate_to=[],
-        units={
-            f"{charm}/0": Unit(
-                name=f"{charm}/0",
-                workload_version=version,
-                machine=machines["0"],
-            )
-        },
+        units={unit.name: unit},
         workload_version=version,
     )
 
     with pytest.raises(ApplicationError, match=exp_msg):
-        app._check_channel()
+        app.get_latest_os_version(unit)
 
 
 def test_auxiliary_raise_error_unknown_series(model):

--- a/tests/unit/apps/test_auxiliary.py
+++ b/tests/unit/apps/test_auxiliary.py
@@ -367,7 +367,7 @@ def test_auxiliary_upgrade_plan_unknown_track(model):
 
 
 def test_auxiliary_app_unknown_version_raise_ApplicationError(model):
-    """Test auxiliary upgrade plan with unknown version."""
+    """Test auxiliary application with unknown workload version."""
     version = "80.5"
     charm = "rabbitmq-server"
     exp_msg = f"'{charm}' with workload version {version} has no compatible OpenStack release."
@@ -399,7 +399,7 @@ def test_auxiliary_app_unknown_version_raise_ApplicationError(model):
 
 
 def test_auxiliary_raise_error_unknown_series(model):
-    """Test auxiliary upgrade plan with unknown series."""
+    """Test auxiliary application with unknown series."""
     series = "foo"
     channel = "3.8/stable"
     exp_msg = (

--- a/tests/unit/apps/test_base.py
+++ b/tests/unit/apps/test_base.py
@@ -299,7 +299,7 @@ def test_get_reached_expected_target_step(mock_workload_upgrade, units, model):
 @pytest.mark.parametrize("origin", ["cs", "ch"])
 @patch("cou.apps.base.OpenStackApplication.is_valid_track", return_value=True)
 def test_check_channel(_, origin):
-    """Test function to verify that enable-auto-restarts is disabled."""
+    """Test function to verify validity of the charm channel."""
     app_name = "app"
     app = OpenStackApplication(
         app_name, "", app_name, "stable", {}, {}, MagicMock(), origin, "focal", [], {}, "1"

--- a/tests/unit/apps/test_base.py
+++ b/tests/unit/apps/test_base.py
@@ -310,7 +310,7 @@ def test_check_channel(_, origin):
 
 @patch("cou.apps.base.OpenStackApplication.is_valid_track", return_value=False)
 def test_check_channel_error(_):
-    """Test function to verify that enable-auto-restarts is disabled."""
+    """Test function to verify validity of the charm channel when it's not valid."""
     name = "app"
     channel = "stable"
     series = "focal"

--- a/tests/unit/apps/test_subordinate.py
+++ b/tests/unit/apps/test_subordinate.py
@@ -129,22 +129,23 @@ def test_channel_valid(model, channel):
 def test_channel_setter_invalid(model, channel):
     """Test unsuccessful validation of channel upgrade plan for SubordinateApplication."""
     machines = {"0": MagicMock(spec_set=Machine)}
+    app = SubordinateApplication(
+        name="keystone-ldap",
+        can_upgrade_to=channel,
+        charm="keystone-ldap",
+        channel=channel,
+        config={},
+        machines=machines,
+        model=model,
+        origin="ch",
+        series="focal",
+        subordinate_to=["nova-compute"],
+        units={},
+        workload_version="18.1.0",
+    )
 
     with pytest.raises(ApplicationError):
-        SubordinateApplication(
-            name="keystone-ldap",
-            can_upgrade_to=channel,
-            charm="keystone-ldap",
-            channel=channel,
-            config={},
-            machines=machines,
-            model=model,
-            origin="ch",
-            series="focal",
-            subordinate_to=["nova-compute"],
-            units={},
-            workload_version="18.1.0",
-        )
+        app._check_channel()
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/apps/test_subordinate.py
+++ b/tests/unit/apps/test_subordinate.py
@@ -128,6 +128,12 @@ def test_channel_valid(model, channel):
 def test_channel_setter_invalid(model, channel):
     """Test unsuccessful validation of channel upgrade plan for SubordinateApplication."""
     machines = {"0": MagicMock(spec_set=Machine)}
+    exp_error_msg = (
+        f"Channel: {channel} for charm 'keystone-ldap' on series 'focal' is currently not "
+        "supported in this tool. Please take a look at the documentation: "
+        "https://docs.openstack.org/charm-guide/latest/project/charm-delivery.html to see if you "
+        "are using the right track."
+    )
     app = SubordinateApplication(
         name="keystone-ldap",
         can_upgrade_to=channel,
@@ -143,7 +149,7 @@ def test_channel_setter_invalid(model, channel):
         workload_version="18.1.0",
     )
 
-    with pytest.raises(ApplicationError):
+    with pytest.raises(ApplicationError, match=exp_error_msg):
         app._check_channel()
 
 


### PR DESCRIPTION
Renamed the _verify_channel to _check_channel and move it to upgrade plan sanity checks.

fixes: #357