### PR TITLE
Support OVN apps that don't have "enable-versiong-pinning" config

### DIFF
--- a/cou/apps/auxiliary.py
+++ b/cou/apps/auxiliary.py
@@ -237,6 +237,12 @@ class Ovn(AuxiliaryApplication):
 
         :raises ApplicationError: When version pinning is True
         """
+        if "enable-version-pinning" not in self.config:
+            logger.debug(
+                "Ovn application: '%s' does not have the 'enable-version-pinning' configuration.",
+                self.name,
+            )
+            return
         if self.config["enable-version-pinning"].get("value"):
             raise ApplicationError(
                 f"Cannot upgrade '{self.name}'. 'enable-version-pinning' must be set to 'false'."

--- a/cou/apps/auxiliary.py
+++ b/cou/apps/auxiliary.py
@@ -218,8 +218,8 @@ class CephMon(AuxiliaryApplication):
         )
 
 
-class Ovn(AuxiliaryApplication):
-    """Ovn generic application class."""
+class OVN(AuxiliaryApplication):
+    """OVN generic application class."""
 
     @abc.abstractmethod
     def _check_ovn_support(self) -> None:
@@ -252,7 +252,7 @@ class Ovn(AuxiliaryApplication):
         """
         if "enable-version-pinning" not in self.config:
             logger.debug(
-                "Ovn application: '%s' does not have the 'enable-version-pinning' configuration.",
+                "OVN application: '%s' does not offer the 'enable-version-pinning' configuration.",
                 self.name,
             )
             return
@@ -281,8 +281,8 @@ class Ovn(AuxiliaryApplication):
 
 
 @AppFactory.register_application(["ovn-central", "ovn-dedicated-chassis"])
-class OvnPrincipal(Ovn):
-    """Ovn principal application class."""
+class OVNPrincipal(OVN):
+    """OVN principal application class."""
 
     def _check_ovn_support(self) -> None:
         """Check OVN version.
@@ -290,7 +290,7 @@ class OvnPrincipal(Ovn):
         :raises ApplicationError: When workload version is lower than 22.03.0.
         """
         for unit in self.units.values():
-            OvnPrincipal._validate_ovn_support(unit.workload_version)
+            OVNPrincipal._validate_ovn_support(unit.workload_version)
 
 
 @AppFactory.register_application(["mysql-innodb-cluster"])

--- a/cou/apps/auxiliary_subordinate.py
+++ b/cou/apps/auxiliary_subordinate.py
@@ -12,7 +12,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 """Auxiliary subordinate application class."""
-from cou.apps.auxiliary import AuxiliaryApplication, Ovn
+from cou.apps.auxiliary import OVN, AuxiliaryApplication
 from cou.apps.factory import AppFactory
 from cou.apps.subordinate import SubordinateBase
 from cou.utils.openstack import AUXILIARY_SUBORDINATES, OpenStackRelease
@@ -36,12 +36,12 @@ class AuxiliarySubordinateApplication(SubordinateBase, AuxiliaryApplication):
 
 
 @AppFactory.register_application(["ovn-chassis"])
-class OvnSubordinate(Ovn, AuxiliarySubordinateApplication):
-    """Ovn subordinate application class."""
+class OVNSubordinate(OVN, AuxiliarySubordinateApplication):
+    """OVN subordinate application class."""
 
     def _check_ovn_support(self) -> None:
         """Check OVN version.
 
         :raises ApplicationError: When workload version is lower than 22.03.0.
         """
-        OvnSubordinate._validate_ovn_support(self.workload_version)
+        OVNSubordinate._validate_ovn_support(self.workload_version)

--- a/cou/steps/plan.py
+++ b/cou/steps/plan.py
@@ -25,12 +25,12 @@ from cou.apps.auxiliary import (  # noqa: F401
     AuxiliaryApplication,
     CephMon,
     CephOsd,
-    OvnPrincipal,
+    OVNPrincipal,
     RabbitMQServer,
 )
 from cou.apps.auxiliary_subordinate import (  # noqa: F401
     AuxiliarySubordinateApplication,
-    OvnSubordinate,
+    OVNSubordinate,
 )
 from cou.apps.base import OpenStackApplication
 from cou.apps.channel_based import ChannelBasedApplication  # noqa: F401

--- a/tests/unit/apps/test_auxiliary.py
+++ b/tests/unit/apps/test_auxiliary.py
@@ -807,7 +807,7 @@ def test_ovn_workload_ver_lower_than_22_principal(model):
 def test_ovn_version_pinning_principal(model):
     """Test the OvnPrincipal when enable-version-pinning is set to True."""
     target = OpenStackRelease("victoria")
-    charm = "ovn-central"
+    charm = "ovn-dedicated-chassis"
     exp_msg = f"Cannot upgrade '{charm}'. 'enable-version-pinning' must be set to 'false'."
     machines = {"0": MagicMock(spec_set=Machine)}
     app = OvnPrincipal(
@@ -873,6 +873,7 @@ def test_ovn_no_compatible_os_release(channel, model):
 @patch("cou.apps.auxiliary.logger")
 def test_ovn_check_version_pinning_no_version_pinning_config(mock_logger, model):
     machines = {"0": MagicMock(spec_set=Machine)}
+    # Ovn-central doesn't have enable-version-pinning configuration
     app = OvnPrincipal(
         name="ovn-central",
         can_upgrade_to="",
@@ -901,9 +902,9 @@ def test_ovn_check_version_pinning_no_version_pinning_config(mock_logger, model)
 def test_ovn_check_version_pinning_version_pinning_config_False(mock_logger, model):
     machines = {"0": MagicMock(spec_set=Machine)}
     app = OvnPrincipal(
-        name="ovn-central",
+        name="ovn-dedicated-chassis",
         can_upgrade_to="",
-        charm="ovn-central",
+        charm="ovn-dedicated-chassis",
         channel="22.03/stable",
         config={"source": {"value": "distro"}, "enable-version-pinning": {"value": False}},
         machines=machines,
@@ -912,8 +913,8 @@ def test_ovn_check_version_pinning_version_pinning_config_False(mock_logger, mod
         series="focal",
         subordinate_to=[],
         units={
-            "ovn-central/0": Unit(
-                name="ovn-central/0",
+            "ovn-dedicated-chassis/0": Unit(
+                name="ovn-dedicated-chassis/0",
                 workload_version="22.03",
                 machine=machines["0"],
             )
@@ -927,9 +928,9 @@ def test_ovn_check_version_pinning_version_pinning_config_False(mock_logger, mod
 def test_ovn_check_version_pinning_version_pinning_config_True(model):
     machines = {"0": MagicMock(spec_set=Machine)}
     app = OvnPrincipal(
-        name="ovn-central",
+        name="ovn-dedicated-chassis",
         can_upgrade_to="",
-        charm="ovn-central",
+        charm="ovn-dedicated-chassis",
         channel="22.03/stable",
         config={"source": {"value": "distro"}, "enable-version-pinning": {"value": True}},
         machines=machines,
@@ -938,8 +939,8 @@ def test_ovn_check_version_pinning_version_pinning_config_True(model):
         series="focal",
         subordinate_to=[],
         units={
-            "ovn-central/0": Unit(
-                name="ovn-central/0",
+            "ovn-dedicated-chassis/0": Unit(
+                name="ovn-dedicated-chassis/0",
                 workload_version="22.03",
                 machine=machines["0"],
             )
@@ -954,7 +955,7 @@ def test_ovn_check_version_pinning_version_pinning_config_True(model):
 def test_ovn_principal_upgrade_plan(model):
     """Test generating plan for OvnPrincipal."""
     target = OpenStackRelease("victoria")
-    charm = "ovn-central"
+    charm = "ovn-dedicated-chassis"
     machines = {"0": MagicMock(spec_set=Machine)}
     app = OvnPrincipal(
         name=charm,

--- a/tests/unit/apps/test_auxiliary.py
+++ b/tests/unit/apps/test_auxiliary.py
@@ -21,7 +21,7 @@ from cou.apps.auxiliary import (
     CephMon,
     CephOsd,
     MysqlInnodbCluster,
-    OvnPrincipal,
+    OVNPrincipal,
     RabbitMQServer,
 )
 from cou.apps.core import NovaCompute
@@ -731,10 +731,10 @@ def test_ceph_mon_upgrade_plan_ussuri_to_victoria(model):
 
 
 def test_ovn_principal(model):
-    """Test the correctness of instantiating OvnPrincipal."""
+    """Test the correctness of instantiating OVNPrincipal."""
     charm = "ovn-central"
     machines = {"0": MagicMock(spec_set=Machine)}
-    app = OvnPrincipal(
+    app = OVNPrincipal(
         name=charm,
         can_upgrade_to="22.06/stable",
         charm=charm,
@@ -763,7 +763,7 @@ def test_ovn_principal(model):
 
 
 def test_ovn_workload_ver_lower_than_22_principal(model):
-    """Test the OvnPrincipal with lower version than 22."""
+    """Test the OVNPrincipal with lower version than 22."""
     target = OpenStackRelease("victoria")
     charm = "ovn-central"
     exp_msg = (
@@ -773,7 +773,7 @@ def test_ovn_workload_ver_lower_than_22_principal(model):
         "ovn-upgrade-2203.html"
     )
     machines = {"0": MagicMock(spec_set=Machine)}
-    app = OvnPrincipal(
+    app = OVNPrincipal(
         name=charm,
         can_upgrade_to="22.03/stable",
         charm=charm,
@@ -799,12 +799,12 @@ def test_ovn_workload_ver_lower_than_22_principal(model):
 
 
 def test_ovn_version_pinning_principal(model):
-    """Test the OvnPrincipal when enable-version-pinning is set to True."""
+    """Test the OVNPrincipal when enable-version-pinning is set to True."""
     target = OpenStackRelease("victoria")
     charm = "ovn-dedicated-chassis"
     exp_msg = f"Cannot upgrade '{charm}'. 'enable-version-pinning' must be set to 'false'."
     machines = {"0": MagicMock(spec_set=Machine)}
-    app = OvnPrincipal(
+    app = OVNPrincipal(
         name=charm,
         can_upgrade_to="22.03/stable",
         charm=charm,
@@ -831,7 +831,7 @@ def test_ovn_version_pinning_principal(model):
 
 @pytest.mark.parametrize("channel", ["55.7", "19.03"])
 def test_ovn_no_compatible_os_release(channel, model):
-    """Test the OvnPrincipal with not compatible os release."""
+    """Test the OVNPrincipal with not compatible os release."""
     charm = "ovn-central"
     machines = {"0": MagicMock(spec_set=Machine)}
     exp_msg = (
@@ -842,7 +842,7 @@ def test_ovn_no_compatible_os_release(channel, model):
     )
 
     with pytest.raises(ApplicationError, match=exp_msg):
-        OvnPrincipal(
+        OVNPrincipal(
             name=charm,
             can_upgrade_to="quincy/stable",
             charm=charm,
@@ -864,24 +864,33 @@ def test_ovn_no_compatible_os_release(channel, model):
         )
 
 
-@patch("cou.apps.auxiliary.logger")
-def test_ovn_check_version_pinning_no_version_pinning_config(mock_logger, model):
+@pytest.mark.parametrize(
+    "app, config",
+    [
+        (
+            "ovn-dedicated-chassis",
+            {"source": {"value": "distro"}, "enable-version-pinning": {"value": False}},
+        ),
+        # ovn-central doesn't have enable-version-pinning configuration
+        ("ovn-central", {"source": {"value": "distro"}}),
+    ],
+)
+def test_ovn_check_version_pinning_version_pinning_config_False(app, config, model):
     machines = {"0": MagicMock(spec_set=Machine)}
-    # Ovn-central doesn't have enable-version-pinning configuration
-    app = OvnPrincipal(
-        name="ovn-central",
+    app = OVNPrincipal(
+        name=app,
         can_upgrade_to="",
-        charm="ovn-central",
+        charm=app,
         channel="22.03/stable",
-        config={"source": {"value": "distro"}},
+        config=config,
         machines=machines,
         model=model,
         origin="ch",
         series="focal",
         subordinate_to=[],
         units={
-            "ovn-central/0": Unit(
-                name="ovn-central/0",
+            f"{app}/0": Unit(
+                name=f"{app}/0",
                 workload_version="22.03",
                 machine=machines["0"],
             )
@@ -889,39 +898,11 @@ def test_ovn_check_version_pinning_no_version_pinning_config(mock_logger, model)
         workload_version="22.03",
     )
     assert app._check_version_pinning() is None
-    mock_logger.debug.assert_called_once()
-
-
-@patch("cou.apps.auxiliary.logger")
-def test_ovn_check_version_pinning_version_pinning_config_False(mock_logger, model):
-    machines = {"0": MagicMock(spec_set=Machine)}
-    app = OvnPrincipal(
-        name="ovn-dedicated-chassis",
-        can_upgrade_to="",
-        charm="ovn-dedicated-chassis",
-        channel="22.03/stable",
-        config={"source": {"value": "distro"}, "enable-version-pinning": {"value": False}},
-        machines=machines,
-        model=model,
-        origin="ch",
-        series="focal",
-        subordinate_to=[],
-        units={
-            "ovn-dedicated-chassis/0": Unit(
-                name="ovn-dedicated-chassis/0",
-                workload_version="22.03",
-                machine=machines["0"],
-            )
-        },
-        workload_version="22.03",
-    )
-    assert app._check_version_pinning() is None
-    mock_logger.debug.assert_not_called()
 
 
 def test_ovn_check_version_pinning_version_pinning_config_True(model):
     machines = {"0": MagicMock(spec_set=Machine)}
-    app = OvnPrincipal(
+    app = OVNPrincipal(
         name="ovn-dedicated-chassis",
         can_upgrade_to="",
         charm="ovn-dedicated-chassis",
@@ -947,11 +928,11 @@ def test_ovn_check_version_pinning_version_pinning_config_True(model):
 
 
 def test_ovn_principal_upgrade_plan(model):
-    """Test generating plan for OvnPrincipal."""
+    """Test generating plan for OVNPrincipal."""
     target = OpenStackRelease("victoria")
     charm = "ovn-dedicated-chassis"
     machines = {"0": MagicMock(spec_set=Machine)}
-    app = OvnPrincipal(
+    app = OVNPrincipal(
         name=charm,
         can_upgrade_to="22.06/stable",
         charm=charm,

--- a/tests/unit/apps/test_auxiliary_subordinate.py
+++ b/tests/unit/apps/test_auxiliary_subordinate.py
@@ -19,7 +19,7 @@ import pytest
 
 from cou.apps.auxiliary_subordinate import (
     AuxiliarySubordinateApplication,
-    OvnSubordinate,
+    OVNSubordinate,
 )
 from cou.exceptions import ApplicationError, HaltUpgradePlanGeneration
 from cou.steps import ApplicationUpgradePlan, PreUpgradeStep, UpgradeStep
@@ -89,9 +89,9 @@ def test_auxiliary_subordinate_upgrade_plan_to_victoria(model):
 
 
 def test_ovn_subordinate(model):
-    """Test the correctness of instantiating OvnSubordinate."""
+    """Test the correctness of instantiating OVNSubordinate."""
     machines = {"0": MagicMock(spec_set=Machine)}
-    app = OvnSubordinate(
+    app = OVNSubordinate(
         name="ovn-chassis",
         can_upgrade_to="22.03/stable",
         charm="ovn-chassis",
@@ -115,7 +115,7 @@ def test_ovn_subordinate(model):
 
 
 def test_ovn_workload_ver_lower_than_22_subordinate(model):
-    """Test the OvnSubordinate with lower version than 22."""
+    """Test the OVNSubordinate with lower version than 22."""
     target = OpenStackRelease("victoria")
     machines = {"0": MagicMock(spec_set=Machine)}
     exp_msg = (
@@ -124,7 +124,7 @@ def test_ovn_workload_ver_lower_than_22_subordinate(model):
         "https://docs.openstack.org/charm-guide/latest/project/procedures/"
         "ovn-upgrade-2203.html"
     )
-    app = OvnSubordinate(
+    app = OVNSubordinate(
         name="ovn-chassis",
         can_upgrade_to="22.03/stable",
         charm="ovn-chassis",
@@ -144,12 +144,12 @@ def test_ovn_workload_ver_lower_than_22_subordinate(model):
 
 
 def test_ovn_version_pinning_subordinate(model):
-    """Test the OvnSubordinate when enable-version-pinning is set to True."""
+    """Test the OVNSubordinate when enable-version-pinning is set to True."""
     charm = "ovn-chassis"
     target = OpenStackRelease("victoria")
     machines = {"0": MagicMock(spec_set=Machine)}
     exp_msg = f"Cannot upgrade '{charm}'. 'enable-version-pinning' must be set to 'false'."
-    app = OvnSubordinate(
+    app = OVNSubordinate(
         name=charm,
         can_upgrade_to="22.03/stable",
         charm=charm,
@@ -165,14 +165,14 @@ def test_ovn_version_pinning_subordinate(model):
     )
 
     with pytest.raises(ApplicationError, match=exp_msg):
-        app.upgrade_plan_sanity_checks(target, [])
+        app.generate_upgrade_plan(target, False)
 
 
 def test_ovn_subordinate_upgrade_plan(model):
-    """Test generating plan for OvnSubordinate."""
+    """Test generating plan for OVNSubordinate."""
     target = OpenStackRelease("victoria")
     machines = {"0": MagicMock(spec_set=Machine)}
-    app = OvnSubordinate(
+    app = OVNSubordinate(
         name="ovn-chassis",
         can_upgrade_to="22.03/stable",
         charm="ovn-chassis",
@@ -205,7 +205,7 @@ def test_ovn_subordinate_upgrade_plan(model):
 
 
 def test_ovn_subordinate_upgrade_plan_cant_upgrade_charm(model):
-    """Test generating plan for OvnSubordinate failing.
+    """Test generating plan for OVNSubordinate failing.
 
     The ovn chassis 22.03 is considered yoga. If it's not necessary to upgrade the charm code,
     there is no steps to upgrade.
@@ -216,7 +216,7 @@ def test_ovn_subordinate_upgrade_plan_cant_upgrade_charm(model):
     )
     target = OpenStackRelease("victoria")
     machines = {"0": MagicMock(spec_set=Machine)}
-    app = OvnSubordinate(
+    app = OVNSubordinate(
         name="ovn-chassis",
         can_upgrade_to="",
         charm="ovn-chassis",

--- a/tests/unit/steps/test_plan.py
+++ b/tests/unit/steps/test_plan.py
@@ -16,7 +16,7 @@ from unittest.mock import MagicMock, PropertyMock, call, patch
 import pytest
 
 from cou.apps.auxiliary import CephMon, CephOsd
-from cou.apps.auxiliary_subordinate import OvnSubordinate
+from cou.apps.auxiliary_subordinate import OVNSubordinate
 from cou.apps.base import OpenStackApplication
 from cou.apps.core import Keystone, NovaCompute
 from cou.apps.subordinate import SubordinateApplication
@@ -279,7 +279,7 @@ nova-compute/0
         workload_version="15.2.0",
     )
 
-    ovn_chassis = OvnSubordinate(
+    ovn_chassis = OVNSubordinate(
         name="ovn-chassis",
         can_upgrade_to="22.03/stable",
         charm="ovn-chassis",
@@ -440,7 +440,7 @@ nova-compute/0
         workload_version="17.0.1",
     )
 
-    ovn_chassis = OvnSubordinate(
+    ovn_chassis = OVNSubordinate(
         name="ovn-chassis",
         can_upgrade_to="22.03/stable",
         charm="ovn-chassis",
@@ -1354,7 +1354,7 @@ def test_separate_hypervisors_apps(model):
     )
 
     # subordinates are considered as non-hypervisors
-    ovn_chassis = OvnSubordinate(
+    ovn_chassis = OVNSubordinate(
         name="ovn-chassis",
         can_upgrade_to="22.03/stable",
         charm="ovn-chassis",
@@ -1484,7 +1484,7 @@ def test_generate_data_plane_remaining_plan(mock_create_upgrade_group):
     ceph_osd = MagicMock(spec_set=CephOsd)()
     ceph_osd.is_subordinate = False
 
-    ovn_chassis = MagicMock(spec_set=OvnSubordinate)()
+    ovn_chassis = MagicMock(spec_set=OVNSubordinate)()
     ovn_chassis.is_subordinate = True
 
     cou_plan._generate_data_plane_remaining_plan(target, [ceph_osd, ovn_chassis], force)


### PR DESCRIPTION
- Not all ovn apps has this configuration and the current implementation it's not permesive on this.

Closes: #348