### PR TITLE
Add log with OS app string representation to Analysis._populate

### DIFF
--- a/cou/steps/analyze.py
+++ b/cou/steps/analyze.py
@@ -125,7 +125,7 @@ class Analysis:
         for name, app in juju_applications.items():
             if os_app := AppFactory.create(app):
                 apps.add(os_app)
-                logger.info("found %s application:\n%s", name, os_app)
+                logger.info("Found %s application:\n%s", name, os_app)
 
         # mypy complains that apps can have None, but we already removed.
         apps_to_upgrade_in_order = {

--- a/cou/steps/analyze.py
+++ b/cou/steps/analyze.py
@@ -125,7 +125,7 @@ class Analysis:
         for name, app in juju_applications.items():
             if os_app := AppFactory.create(app):
                 apps.add(os_app)
-                logger.info("found OpenStack application:\n%s", os_app)
+                logger.info("found %s application:\n%s", name, os_app)
 
         # mypy complains that apps can have None, but we already removed.
         apps_to_upgrade_in_order = {

--- a/cou/steps/analyze.py
+++ b/cou/steps/analyze.py
@@ -129,18 +129,18 @@ class Analysis:
 
         # mypy complains that apps can have None, but we already removed.
         apps_to_upgrade_in_order = {
-            app for app in apps if app.charm in UPGRADE_ORDER  # type: ignore
+            app for app in apps if app.charm in UPGRADE_ORDER
         }
         other_o7k_apps = apps - apps_to_upgrade_in_order
         sorted_apps_to_upgrade_in_order = sorted(
             apps_to_upgrade_in_order,
-            key=lambda app: UPGRADE_ORDER.index(app.charm),  # type: ignore
+            key=lambda app: UPGRADE_ORDER.index(app.charm),
         )
         # order by charm name to have a predictable upgrade sequence of others o7k charms.
         other_o7k_apps_sorted_by_name = sorted(
-            other_o7k_apps, key=lambda app: app.charm  # type: ignore
+            other_o7k_apps, key=lambda app: app.charm
         )
-        return sorted_apps_to_upgrade_in_order + other_o7k_apps_sorted_by_name  # type: ignore
+        return sorted_apps_to_upgrade_in_order + other_o7k_apps_sorted_by_name
 
     def __str__(self) -> str:
         """Dump as string.

--- a/cou/steps/analyze.py
+++ b/cou/steps/analyze.py
@@ -121,10 +121,12 @@ class Analysis:
         :rtype: List[OpenStackApplication]
         """
         juju_applications = await model.get_applications()
-        apps = {AppFactory.create(app) for app in juju_applications.values()}
+        apps = set()
+        for name, app in juju_applications.items():
+            if os_app := AppFactory.create(app):
+                apps.add(os_app)
+                logger.info("found OpenStack application:\n%s", os_app)
 
-        # remove non-supported charms that return None on AppFactory.create
-        apps.discard(None)
         # mypy complains that apps can have None, but we already removed.
         apps_to_upgrade_in_order = {
             app for app in apps if app.charm in UPGRADE_ORDER  # type: ignore


### PR DESCRIPTION
With this, we can collect info about application during Analysis._populate, like this the log will contain the app string representation before planning.

log message example:
```bash
found OpenStack application:
app-name:
  model_name: <model-name>
  ...
```