### PR TITLE
Ignore waiting for machine to create Applications class

### DIFF
--- a/cou/utils/juju_utils.py
+++ b/cou/utils/juju_utils.py
@@ -280,7 +280,7 @@ class Model:
                 apps=tuple(
                     unit.application
                     for unit in self._model.units.values()
-                    if unit.machine.id == machine.id
+                    if hasattr(unit.machine, "id") and unit.machine.id == machine.id
                 ),
                 az=machine.hardware_characteristics.get("availability-zone"),
             )
@@ -370,6 +370,7 @@ class Model:
                 workload_version=status.workload_version,
             )
             for app, status in full_status.applications.items()
+            if status.status.info != "waiting for machine"
         }
 
     @retry(no_retry_exceptions=(ApplicationNotFound,))


### PR DESCRIPTION
- if the model has an app waiting machine, the machine doesn't exist yet and COU fails with AttributeError

E.g:

```
ubuntu@fce:~$ juju status tempest
Model      Controller        Cloud/Region  Version  SLA          Timestamp
openstack  foundations-maas  maas_cloud    2.9.49   unsupported  21:20:04Z

App      Version  Status   Scale  Charm   Channel  Rev  Exposed  Message
tempest  22.04    waiting    1/2  ubuntu  stable    24  no       waiting for machine

Unit        Workload  Agent       Machine  Public address  Ports  Message
tempest/1   waiting   allocating                                  waiting for machine
tempest/3*  active    idle        7/lxd/1  10.17.2.198            

Machine  State    Address      Inst id              Series  AZ     Message
7        started  10.17.2.173  pc6a-rb3-n2          focal   zone2  Deployed
7/lxd/1  started  10.17.2.198  juju-e3e648-7-lxd-1  jammy   zone2  Container started
```

breaks with the message: `AttributeError: 'NoneType' object has no attribute 'id'`