### PR TITLE
Run update-status hook before checking workload version upgrade

### DIFF
--- a/cou/apps/base.py
+++ b/cou/apps/base.py
@@ -369,8 +369,9 @@ class OpenStackApplication(Application):
 
         if units_not_upgraded:
             raise ApplicationError(
-                f"Cannot upgrade unit(s) '{', '.join(units_not_upgraded)}' to {target}. "
-                "Try again in some minutes to see if the unit(s) have been upgraded."
+                f"Unit(s) '{', '.join(units_not_upgraded)}' did not complete the upgrade to "
+                f"{target}. Some local processes may still be executing; you may try re-running "
+                "COU in a few minutes."
             )
 
     def upgrade_plan_sanity_checks(

--- a/tests/unit/apps/test_core.py
+++ b/tests/unit/apps/test_core.py
@@ -125,8 +125,8 @@ async def test_application_verify_workload_upgrade_fail(model):
     """Test Kyestone application check unsuccessful upgrade."""
     target = OpenStackRelease("victoria")
     exp_msg = (
-        r"Cannot upgrade unit\(s\) 'keystone/0' to victoria. Try again in some minutes "
-        r"to see if the unit\(s\) have been upgraded."
+        r"Unit\(s\) 'keystone/0' did not complete the upgrade to victoria. Some local processes "
+        r"may still be executing; you may try re-running COU in a few minutes."
     )
     machines = {"0": MagicMock(spec_set=Machine)}
     app = Keystone(

--- a/tests/unit/apps/test_core.py
+++ b/tests/unit/apps/test_core.py
@@ -124,7 +124,10 @@ async def test_application_verify_workload_upgrade(model):
 async def test_application_verify_workload_upgrade_fail(model):
     """Test Kyestone application check unsuccessful upgrade."""
     target = OpenStackRelease("victoria")
-    exp_msg = "Cannot upgrade units 'keystone/0' to victoria."
+    exp_msg = (
+        r"Cannot upgrade unit\(s\) 'keystone/0' to victoria. Try again in some minutes "
+        r"to see if the unit\(s\) have been upgraded."
+    )
     machines = {"0": MagicMock(spec_set=Machine)}
     app = Keystone(
         name="keystone",


### PR DESCRIPTION
- Sometimes the _get_reached_expected_target_step post upgrade step fails because the application turn into active/idle and might take an extra time to actually show the change on the workload version. Running the update-status hook before checking can help reducing false positives.
- Changed the error message to say to the user wait some minutes if the workload version change check fails.

Closes #384 