### PR TITLE
Raise ApplicationError on auxiliary channel_codename on invalid channel

### DIFF
--- a/cou/apps/auxiliary.py
+++ b/cou/apps/auxiliary.py
@@ -128,6 +128,15 @@ class AuxiliaryApplication(OpenStackApplication):
 
         track: str = self._get_track_from_channel(self.channel)
         compatible_os_releases = TRACK_TO_OPENSTACK_MAPPING[(self.charm, self.series, track)]
+
+        if not compatible_os_releases:
+            raise ApplicationError(
+                f"Channel: {self.channel} for charm '{self.charm}' on series '{self.series}' is "
+                f"currently not supported in this tool. Please take a look at the documentation: "
+                "https://docs.openstack.org/charm-guide/latest/project/charm-delivery.html to see "
+                "if you are using the right track."
+            )
+
         return max(compatible_os_releases)
 
     def generate_upgrade_plan(

--- a/cou/apps/auxiliary.py
+++ b/cou/apps/auxiliary.py
@@ -132,7 +132,7 @@ class AuxiliaryApplication(OpenStackApplication):
         if not compatible_os_releases:
             raise ApplicationError(
                 f"Channel: {self.channel} for charm '{self.charm}' on series '{self.series}' is "
-                f"currently not supported in this tool. Please take a look at the documentation: "
+                f"not supported by COU. Please take a look at the documentation: "
                 "https://docs.openstack.org/charm-guide/latest/project/charm-delivery.html to see "
                 "if you are using the right track."
             )

--- a/cou/apps/base.py
+++ b/cou/apps/base.py
@@ -789,8 +789,7 @@ class OpenStackApplication(Application):
 
         raise ApplicationError(
             f"Channel: {self.channel} for charm '{self.charm}' on series "
-            f"'{self.series}' is currently not supported in this tool. Please take a look at the "
-            "documentation: "
+            f"'{self.series}' is not supported by COU. Please take a look at the documentation: "
             "https://docs.openstack.org/charm-guide/latest/project/charm-delivery.html to see if "
             "you are using the right track."
         )

--- a/tests/unit/apps/test_auxiliary.py
+++ b/tests/unit/apps/test_auxiliary.py
@@ -335,8 +335,8 @@ def test_auxiliary_upgrade_plan_unknown_track(model):
     """Test auxiliary upgrade plan with unknown track."""
     channel = "2.0/stable"
     exp_msg = (
-        f"Channel: {channel} for charm 'rabbitmq-server' on series 'focal' is currently "
-        "not supported in this tool. Please take a look at the documentation: "
+        f"Channel: {channel} for charm 'rabbitmq-server' on series 'focal' is not supported by "
+        "COU. Please take a look at the documentation: "
         "https://docs.openstack.org/charm-guide/latest/project/charm-delivery.html "
         "to see if you are using the right track."
     )
@@ -398,8 +398,8 @@ def test_auxiliary_raise_error_unknown_series(model):
     series = "foo"
     channel = "3.8/stable"
     exp_msg = (
-        f"Channel: {channel} for charm 'rabbitmq-server' on series '{series}' is currently "
-        "not supported in this tool. Please take a look at the documentation: "
+        f"Channel: {channel} for charm 'rabbitmq-server' on series '{series}' is not supported by "
+        "COU. Please take a look at the documentation: "
         "https://docs.openstack.org/charm-guide/latest/project/charm-delivery.html "
         "to see if you are using the right track."
     )
@@ -436,8 +436,8 @@ def test_auxiliary_raise_error_os_not_on_lookup(current_os_release, model):
     """
     current_os_release.return_value = OpenStackRelease("diablo")
     exp_error_msg = (
-        "Channel: 3.8/stable for charm 'rabbitmq-server' on series 'focal' is currently not "
-        "supported in this tool. Please take a look at the documentation: "
+        "Channel: 3.8/stable for charm 'rabbitmq-server' on series 'focal' is not supported by "
+        "COU. Please take a look at the documentation: "
         "https://docs.openstack.org/charm-guide/latest/project/charm-delivery.html to see if you "
         "are using the right track."
     )
@@ -895,8 +895,8 @@ def test_ovn_no_compatible_os_release(channel, model):
     charm = "ovn-central"
     machines = {"0": MagicMock(spec_set=Machine)}
     exp_msg = (
-        f"Channel: {channel} for charm '{charm}' on series 'focal' is currently "
-        "not supported in this tool. Please take a look at the documentation: "
+        f"Channel: {channel} for charm '{charm}' on series 'focal' is not supported by COU. "
+        "Please take a look at the documentation: "
         "https://docs.openstack.org/charm-guide/latest/project/charm-delivery.html "
         "to see if you are using the right track."
     )

--- a/tests/unit/apps/test_auxiliary_subordinate.py
+++ b/tests/unit/apps/test_auxiliary_subordinate.py
@@ -344,3 +344,33 @@ This may be a charm downgrade, which is generally not supported.
     )
     plan = app.generate_upgrade_plan(target, force=False)
     assert str(plan) == exp_plan
+
+
+def test_auxiliary_subordinate_channel_codename_raise(model):
+    app = AuxiliarySubordinateApplication(
+        name="ceph-dashboard",
+        can_upgrade_to="",
+        charm="ceph-dashboard",
+        channel="luminous/stable",
+        config={},
+        machines={"0": MagicMock(spec_set=Machine)},
+        model=model,
+        origin="ch",
+        series="focal",
+        subordinate_to=["nova-compute"],
+        units={},
+        workload_version="",
+    )
+
+    exp_msg = (
+        "Channel: luminous/stable for charm 'ceph-dashboard' on series 'focal' is currently "
+        "not supported in this tool. Please take a look at the documentation: "
+        "https://docs.openstack.org/charm-guide/latest/project/charm-delivery.html "
+        "to see if you are using the right track."
+    )
+
+    with pytest.raises(ApplicationError, match=exp_msg):
+        app.channel_codename
+
+    with pytest.raises(ApplicationError, match=exp_msg):
+        app.current_os_release

--- a/tests/unit/apps/test_auxiliary_subordinate.py
+++ b/tests/unit/apps/test_auxiliary_subordinate.py
@@ -363,8 +363,8 @@ def test_auxiliary_subordinate_channel_codename_raise(model):
     )
 
     exp_msg = (
-        "Channel: luminous/stable for charm 'ceph-dashboard' on series 'focal' is currently "
-        "not supported in this tool. Please take a look at the documentation: "
+        "Channel: luminous/stable for charm 'ceph-dashboard' on series 'focal' is not supported "
+        "by COU. Please take a look at the documentation: "
         "https://docs.openstack.org/charm-guide/latest/project/charm-delivery.html "
         "to see if you are using the right track."
     )

--- a/tests/unit/apps/test_base.py
+++ b/tests/unit/apps/test_base.py
@@ -315,8 +315,8 @@ def test_check_channel_error(_):
     channel = "stable"
     series = "focal"
     exp_error_msg = (
-        f"Channel: {channel} for charm '{name}' on series '{series}' is currently not supported "
-        "in this tool. Please take a look at the documentation: "
+        f"Channel: {channel} for charm '{name}' on series '{series}' is not supported by COU. "
+        "Please take a look at the documentation: "
         "https://docs.openstack.org/charm-guide/latest/project/charm-delivery.html to see if you "
         "are using the right track."
     )

--- a/tests/unit/apps/test_subordinate.py
+++ b/tests/unit/apps/test_subordinate.py
@@ -129,8 +129,8 @@ def test_channel_setter_invalid(model, channel):
     """Test unsuccessful validation of channel upgrade plan for SubordinateApplication."""
     machines = {"0": MagicMock(spec_set=Machine)}
     exp_error_msg = (
-        f"Channel: {channel} for charm 'keystone-ldap' on series 'focal' is currently not "
-        "supported in this tool. Please take a look at the documentation: "
+        f"Channel: {channel} for charm 'keystone-ldap' on series 'focal' is not supported by COU. "
+        "Please take a look at the documentation: "
         "https://docs.openstack.org/charm-guide/latest/project/charm-delivery.html to see if you "
         "are using the right track."
     )


### PR DESCRIPTION
- Auxiliary subordinates charms like ceph-dashboard uses the channel_codename to calculate the current OpenStack release. When the current channel is not expected, it can return an empty list that breaks the COU execution with a traceback that is hard to understand.

- This issue doesn't happen on charms that are not subornitate because it can rely on the workload_version to calculate current OpenStack release

- Closes #388