### PR TITLE
Add execution time of Applications and Hypervisors AZs

### DIFF
--- a/cou/steps/hypervisor.py
+++ b/cou/steps/hypervisor.py
@@ -16,6 +16,7 @@
 import logging
 from collections import defaultdict
 from dataclasses import dataclass
+from itertools import chain
 from typing import Any
 
 from cou.apps.base import OpenStackApplication
@@ -290,8 +291,9 @@ class HypervisorUpgradePlanner:
         """
         plan = UpgradePlan("Upgrading all applications deployed on machines with hypervisor.")
         for az, group in self.get_azs(target).items():
+            units = list(chain(*group.app_units.values()))
             hypervisor_plan = HypervisorUpgradePlan(
-                f"Upgrade plan for '{group.name}' to '{target}'"
+                f"Upgrade plan for {units} in '{group.name}' to '{target}'"
             )
 
             # sanity checks

--- a/tests/mocked_plans/sample_plans/018346c5-f95c-46df-a34e-9a78bdec0018.yaml
+++ b/tests/mocked_plans/sample_plans/018346c5-f95c-46df-a34e-9a78bdec0018.yaml
@@ -272,7 +272,7 @@ plan: |
             Upgrade plan for 'octavia-diskimage-retrofit' to 'victoria'
                 Upgrade 'octavia-diskimage-retrofit' to the new channel: 'victoria/stable'
         Upgrading all applications deployed on machines with hypervisor.
-            Upgrade plan for 'zone2' to 'victoria'
+            Upgrade plan for [cinder-volume/0, cinder-volume/2, cinder-volume/3, cinder-volume/9, nova-compute-kvm/0, nova-compute-kvm/2, nova-compute-kvm/3, nova-compute-kvm/9] in 'zone2' to 'victoria'
                 Upgrade software packages of 'cinder-volume' from the current APT repositories
                     Ψ Upgrade software packages on unit 'cinder-volume/0'
                     Ψ Upgrade software packages on unit 'cinder-volume/2'
@@ -339,7 +339,7 @@ plan: |
                 Enable nova-compute scheduler from unit: 'nova-compute-kvm/9'
                 Wait for up to 2400s for model '018346c5-f95c-46df-a34e-9a78bdec0018' to reach the idle state
                 Verify that the workload of 'nova-compute-kvm' has been upgraded on units: nova-compute-kvm/0, nova-compute-kvm/2, nova-compute-kvm/3, nova-compute-kvm/9
-            Upgrade plan for 'zone3' to 'victoria'
+            Upgrade plan for [cinder-volume/1, cinder-volume/10, cinder-volume/11, cinder-volume/5, nova-compute-kvm/1, nova-compute-kvm/10, nova-compute-kvm/11, nova-compute-kvm/5] in 'zone3' to 'victoria'
                 Upgrade software packages of 'cinder-volume' from the current APT repositories
                     Ψ Upgrade software packages on unit 'cinder-volume/1'
                     Ψ Upgrade software packages on unit 'cinder-volume/10'
@@ -406,7 +406,7 @@ plan: |
                 Enable nova-compute scheduler from unit: 'nova-compute-kvm/5'
                 Wait for up to 2400s for model '018346c5-f95c-46df-a34e-9a78bdec0018' to reach the idle state
                 Verify that the workload of 'nova-compute-kvm' has been upgraded on units: nova-compute-kvm/1, nova-compute-kvm/10, nova-compute-kvm/11, nova-compute-kvm/5
-            Upgrade plan for 'zone1' to 'victoria'
+            Upgrade plan for [cinder-volume/4, cinder-volume/6, cinder-volume/7, cinder-volume/8, nova-compute-kvm/4, nova-compute-kvm/6, nova-compute-kvm/7, nova-compute-kvm/8] in 'zone1' to 'victoria'
                 Upgrade software packages of 'cinder-volume' from the current APT repositories
                     Ψ Upgrade software packages on unit 'cinder-volume/4'
                     Ψ Upgrade software packages on unit 'cinder-volume/6'

--- a/tests/mocked_plans/sample_plans/9eb9af6a-b919-4cf9-8f2f-9df16a1556be.yaml
+++ b/tests/mocked_plans/sample_plans/9eb9af6a-b919-4cf9-8f2f-9df16a1556be.yaml
@@ -314,7 +314,7 @@ plan: |
                 WARNING: Changing 'octavia-ovn-chassis' channel from latest/stable to 22.03/stable. This may be a charm downgrade, which is generally not supported.
                 Upgrade 'octavia-ovn-chassis' to the new channel: '22.03/stable'
         Upgrading all applications deployed on machines with hypervisor.
-            Upgrade plan for 'az1' to 'victoria'
+            Upgrade plan for [nova-compute/0, nova-compute/2, nova-compute/3] in 'az1' to 'victoria'
                 Disable nova-compute scheduler from unit: 'nova-compute/0'
                 Disable nova-compute scheduler from unit: 'nova-compute/2'
                 Disable nova-compute scheduler from unit: 'nova-compute/3'
@@ -346,7 +346,7 @@ plan: |
                 Enable nova-compute scheduler from unit: 'nova-compute/3'
                 Wait for up to 2400s for model '9eb9af6a-b919-4cf9-8f2f-9df16a1556be' to reach the idle state
                 Verify that the workload of 'nova-compute' has been upgraded on units: nova-compute/0, nova-compute/2, nova-compute/3
-            Upgrade plan for 'az3' to 'victoria'
+            Upgrade plan for [nova-compute/1, nova-compute/6, nova-compute/8] in 'az3' to 'victoria'
                 Disable nova-compute scheduler from unit: 'nova-compute/1'
                 Disable nova-compute scheduler from unit: 'nova-compute/6'
                 Disable nova-compute scheduler from unit: 'nova-compute/8'
@@ -378,7 +378,7 @@ plan: |
                 Enable nova-compute scheduler from unit: 'nova-compute/8'
                 Wait for up to 2400s for model '9eb9af6a-b919-4cf9-8f2f-9df16a1556be' to reach the idle state
                 Verify that the workload of 'nova-compute' has been upgraded on units: nova-compute/1, nova-compute/6, nova-compute/8
-            Upgrade plan for 'az2' to 'victoria'
+            Upgrade plan for [nova-compute/4, nova-compute/5, nova-compute/7] in 'az2' to 'victoria'
                 Disable nova-compute scheduler from unit: 'nova-compute/4'
                 Disable nova-compute scheduler from unit: 'nova-compute/5'
                 Disable nova-compute scheduler from unit: 'nova-compute/7'

--- a/tests/mocked_plans/sample_plans/base.yaml
+++ b/tests/mocked_plans/sample_plans/base.yaml
@@ -17,7 +17,7 @@ plan: |
                 Refresh 'keystone-ldap' to the latest revision of 'ussuri/stable'
                 Upgrade 'keystone-ldap' to the new channel: 'victoria/stable'
         Upgrading all applications deployed on machines with hypervisor.
-            Upgrade plan for 'az-0' to 'victoria'
+            Upgrade plan for [nova-compute/0] in 'az-0' to 'victoria'
                 Disable nova-compute scheduler from unit: 'nova-compute/0'
                 Upgrade software packages of 'nova-compute' from the current APT repositories
                     Ψ Upgrade software packages on unit 'nova-compute/0'

--- a/tests/unit/steps/test_execute.py
+++ b/tests/unit/steps/test_execute.py
@@ -213,13 +213,16 @@ async def test_run_step_sequentially_application_upgrade_plan(
     upgrade_step = MagicMock(spec_set=ApplicationUpgradePlan("test-app upgrade plan"))
     upgrade_step.run = AsyncMock()
     upgrade_step.parallel = False
+    upgrade_step.description = "Upgrade plan for 'app' to 'victoria'"
 
     await _run_step(upgrade_step, False)
 
     mock_indicator.start.assert_not_called()
     upgrade_step.run.assert_awaited_once_with()
     mock_run_sub_steps_sequentially.assert_awaited_once_with(upgrade_step, False, True)
-    mock_indicator.succeed.assert_called_once_with(upgrade_step.description)
+    mock_indicator.succeed.assert_called_once_with(
+        "Upgrade plan for 'app' to 'victoria' executed in 0 seconds"
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/unit/steps/test_hypervisor.py
+++ b/tests/unit/steps/test_hypervisor.py
@@ -162,7 +162,7 @@ def test_generate_upgrade_plan(
     assert plan.description == "Upgrading all applications deployed on machines with hypervisor."
     assert len(plan.sub_steps) == 2
     assert isinstance(plan.sub_steps[0], HypervisorUpgradePlan)
-    assert plan.sub_steps[0].description == f"Upgrade plan for '{group1.name}' to '{target}'"
+    assert plan.sub_steps[0].description == f"Upgrade plan for [] in '{group1.name}' to '{target}'"
     assert (
         plan.sub_steps[0].sub_steps
         == pre_upgrade_steps.return_value
@@ -392,7 +392,7 @@ def test_hypervisor_upgrade_plan(model):
     exp_plan = dedent_plan(
         """\
     Upgrading all applications deployed on machines with hypervisor.
-        Upgrade plan for 'az-0' to 'victoria'
+        Upgrade plan for [cinder/0, nova-compute/0] in 'az-0' to 'victoria'
             Upgrade software packages of 'cinder' from the current APT repositories
                 Ψ Upgrade software packages on unit 'cinder/0'
             Refresh 'cinder' to the latest revision of 'ussuri/stable'
@@ -422,7 +422,7 @@ def test_hypervisor_upgrade_plan(model):
             Enable nova-compute scheduler from unit: 'nova-compute/0'
             Wait for up to 2400s for model 'test_model' to reach the idle state
             Verify that the workload of 'nova-compute' has been upgraded on units: nova-compute/0
-        Upgrade plan for 'az-1' to 'victoria'
+        Upgrade plan for [nova-compute/1] in 'az-1' to 'victoria'
             Disable nova-compute scheduler from unit: 'nova-compute/1'
             Upgrade software packages of 'nova-compute' from the current APT repositories
                 Ψ Upgrade software packages on unit 'nova-compute/1'
@@ -439,7 +439,7 @@ def test_hypervisor_upgrade_plan(model):
             Enable nova-compute scheduler from unit: 'nova-compute/1'
             Wait for up to 2400s for model 'test_model' to reach the idle state
             Verify that the workload of 'nova-compute' has been upgraded on units: nova-compute/1
-        Upgrade plan for 'az-2' to 'victoria'
+        Upgrade plan for [nova-compute/2] in 'az-2' to 'victoria'
             Disable nova-compute scheduler from unit: 'nova-compute/2'
             Upgrade software packages of 'nova-compute' from the current APT repositories
                 Ψ Upgrade software packages on unit 'nova-compute/2'
@@ -519,7 +519,7 @@ def test_hypervisor_upgrade_plan_single_machine(model):
     exp_plan = dedent_plan(
         """\
     Upgrading all applications deployed on machines with hypervisor.
-        Upgrade plan for 'az-0' to 'victoria'
+        Upgrade plan for [cinder/0, nova-compute/0] in 'az-0' to 'victoria'
             Upgrade software packages of 'cinder' from the current APT repositories
                 Ψ Upgrade software packages on unit 'cinder/0'
             Refresh 'cinder' to the latest revision of 'ussuri/stable'
@@ -609,7 +609,7 @@ def test_hypervisor_upgrade_plan_some_units_upgraded(model):
     exp_plan = dedent_plan(
         """\
     Upgrading all applications deployed on machines with hypervisor.
-        Upgrade plan for 'az-1' to 'victoria'
+        Upgrade plan for [cinder/1] in 'az-1' to 'victoria'
             Upgrade software packages of 'cinder' from the current APT repositories
                 Ψ Upgrade software packages on unit 'cinder/1'
             Upgrade plan for units: cinder/1
@@ -619,7 +619,7 @@ def test_hypervisor_upgrade_plan_some_units_upgraded(model):
                     Resume the unit: 'cinder/1'
             Wait for up to 300s for app 'cinder' to reach the idle state
             Verify that the workload of 'cinder' has been upgraded on units: cinder/1
-        Upgrade plan for 'az-2' to 'victoria'
+        Upgrade plan for [cinder/2, nova-compute/2] in 'az-2' to 'victoria'
             Upgrade software packages of 'cinder' from the current APT repositories
                 Ψ Upgrade software packages on unit 'cinder/2'
             Disable nova-compute scheduler from unit: 'nova-compute/2'

--- a/tests/unit/steps/test_plan.py
+++ b/tests/unit/steps/test_plan.py
@@ -162,7 +162,7 @@ async def test_generate_plan(mock_filter_hypervisors, model, cli_args):
                 Refresh 'keystone-ldap' to the latest revision of 'ussuri/stable'
                 Upgrade 'keystone-ldap' to the new channel: 'victoria/stable'
         Upgrading all applications deployed on machines with hypervisor.
-            Upgrade plan for 'az-1' to 'victoria'
+            Upgrade plan for [nova-compute/0] in 'az-1' to 'victoria'
                 Disable nova-compute scheduler from unit: 'nova-compute/0'
                 Upgrade software packages of 'nova-compute' from the current APT repositories
                     Ψ Upgrade software packages on unit 'nova-compute/0'
@@ -318,7 +318,7 @@ async def test_generate_plan_with_warning_messages(mock_filter_hypervisors, mode
                 Refresh 'keystone-ldap' to the latest revision of 'ussuri/stable'
                 Upgrade 'keystone-ldap' to the new channel: 'victoria/stable'
         Upgrading all applications deployed on machines with hypervisor.
-            Upgrade plan for 'az-1' to 'victoria'
+            Upgrade plan for [nova-compute/0] in 'az-1' to 'victoria'
                 Disable nova-compute scheduler from unit: 'nova-compute/0'
                 Upgrade software packages of 'nova-compute' from the current APT repositories
                     Ψ Upgrade software packages on unit 'nova-compute/0'


### PR DESCRIPTION
With this change it will be possible to show to the users how long COU took to execute an upgrade. This will make easier to calculate the expected time to upgrade control-plane and data-plane.

With this change the user will see the result of applications upgrades like this:

```shell
Running cloud upgrade...
Verify that all OpenStack applications are in idle state ✔
Upgrade plan for 'ceilometer' to 'victoria' executed in 169 seconds ✔
Upgrade plan for 'ceph-radosgw' to 'victoria' executed in 118 seconds ✔
Upgrade plan for 'cinder' to 'victoria' executed in 150 seconds ✔
....
Upgrade plan for [cinder-volume/0, nova-compute-kvm/0] in 'AZ3' to 'victoria' executed in 453 seconds ✔
```