### PR TITLE
Don't check for mismatched versions if colocated with nova-compute

### DIFF
--- a/cou/apps/base.py
+++ b/cou/apps/base.py
@@ -857,7 +857,10 @@ class OpenStackApplication(Application):
         :raises MismatchedOpenStackVersions: When the units of the app are running
                                              different OpenStack versions.
         """
-        if units:
+        # NOTE (gabrielcocenza) nova-compute is upgraded using paused-single-unit,
+        # so it's possible to have mismatched version in applications units that are
+        # nova-compute or colocated with it.
+        if any("nova-compute" in machine.apps for machine in self.machines.values()):
             return
 
         os_versions = self.os_release_units

--- a/cou/apps/base.py
+++ b/cou/apps/base.py
@@ -125,7 +125,7 @@ class OpenStackApplication(Application):
                 "machines": {
                     machine.machine_id: {
                         "id": machine.machine_id,
-                        "apps": machine.apps,
+                        "apps_charms": machine.apps_charms,
                         "az": machine.az,
                     }
                     for machine in self.machines.values()
@@ -860,7 +860,11 @@ class OpenStackApplication(Application):
         # NOTE (gabrielcocenza) nova-compute is upgraded using paused-single-unit,
         # so it's possible to have mismatched version in applications units that are
         # nova-compute or colocated with it.
-        if any("nova-compute" in machine.apps for machine in self.machines.values()):
+        if any(
+            "nova-compute" in app_charm
+            for machine in self.machines.values()
+            for app_charm in machine.apps_charms
+        ):
             return
 
         os_versions = self.os_release_units

--- a/tests/unit/apps/test_auxiliary.py
+++ b/tests/unit/apps/test_auxiliary.py
@@ -45,7 +45,7 @@ def test_auxiliary_app(model):
     The version 3.8 on rabbitmq can be from ussuri to yoga. In that case it will be
     set as yoga.
     """
-    machines = {"0": MagicMock(spec_set=Machine)}
+    machines = {"0": generate_cou_machine("0", "az-0")}
     app = RabbitMQServer(
         name="rabbitmq-server",
         can_upgrade_to="",
@@ -77,7 +77,7 @@ def test_auxiliary_app(model):
 
 def test_auxiliary_app_cs(model):
     """Test auxiliary application from charm store."""
-    machines = {"0": MagicMock(spec_set=Machine)}
+    machines = {"0": generate_cou_machine("0", "az-0")}
     app = RabbitMQServer(
         name="rabbitmq-server",
         can_upgrade_to="",
@@ -110,7 +110,7 @@ def test_auxiliary_app_cs(model):
 def test_auxiliary_upgrade_plan_ussuri_to_victoria_change_channel(model):
     """Test auxiliary upgrade plan from Ussuri to Victoria with change of channel."""
     target = OpenStackRelease("victoria")
-    machines = {"0": MagicMock(spec_set=Machine)}
+    machines = {"0": generate_cou_machine("0", "az-0")}
     app = RabbitMQServer(
         name="rabbitmq-server",
         can_upgrade_to="3.9/stable",
@@ -188,7 +188,7 @@ def test_auxiliary_upgrade_plan_ussuri_to_victoria_change_channel(model):
 def test_auxiliary_upgrade_plan_ussuri_to_victoria(model):
     """Test auxiliary upgrade plan from Ussuri to Victoria."""
     target = OpenStackRelease("victoria")
-    machines = {"0": MagicMock(spec_set=Machine)}
+    machines = {"0": generate_cou_machine("0", "az-0")}
     app = RabbitMQServer(
         name="rabbitmq-server",
         can_upgrade_to="3.9/stable",
@@ -259,7 +259,7 @@ def test_auxiliary_upgrade_plan_ussuri_to_victoria(model):
 def test_auxiliary_upgrade_plan_ussuri_to_victoria_ch_migration(model):
     """Test auxiliary upgrade plan from Ussuri to Victoria with migration to charmhub."""
     target = OpenStackRelease("victoria")
-    machines = {"0": MagicMock(spec_set=Machine)}
+    machines = {"0": generate_cou_machine("0", "az-0")}
     app = RabbitMQServer(
         name="rabbitmq-server",
         can_upgrade_to="3.9/stable",
@@ -340,7 +340,7 @@ def test_auxiliary_upgrade_plan_unknown_track(model):
         "https://docs.openstack.org/charm-guide/latest/project/charm-delivery.html "
         "to see if you are using the right track."
     )
-    machines = {"0": MagicMock(spec_set=Machine)}
+    machines = {"0": generate_cou_machine("0", "az-0")}
     app = RabbitMQServer(
         name="rabbitmq-server",
         can_upgrade_to="3.9/stable",
@@ -372,7 +372,7 @@ def test_auxiliary_app_unknown_version_raise_ApplicationError(model):
     charm = "rabbitmq-server"
     exp_msg = f"'{charm}' with workload version {version} has no compatible OpenStack release."
 
-    machines = {"0": MagicMock(spec_set=Machine)}
+    machines = {"0": generate_cou_machine("0", "az-0")}
     unit = Unit(name=f"{charm}/0", workload_version=version, machine=machines["0"])
     app = RabbitMQServer(
         name=charm,
@@ -403,7 +403,7 @@ def test_auxiliary_raise_error_unknown_series(model):
         "https://docs.openstack.org/charm-guide/latest/project/charm-delivery.html "
         "to see if you are using the right track."
     )
-    machines = {"0": MagicMock(spec_set=Machine)}
+    machines = {"0": generate_cou_machine("0", "az-0")}
     app = RabbitMQServer(
         name="rabbitmq-server",
         can_upgrade_to="3.9/stable",
@@ -441,7 +441,7 @@ def test_auxiliary_raise_error_os_not_on_lookup(current_os_release, model):
         "https://docs.openstack.org/charm-guide/latest/project/charm-delivery.html to see if you "
         "are using the right track."
     )
-    machines = {"0": MagicMock(spec_set=Machine)}
+    machines = {"0": generate_cou_machine("0", "az-0")}
     app = RabbitMQServer(
         name="rabbitmq-server",
         can_upgrade_to="",
@@ -478,7 +478,7 @@ def test_auxiliary_raise_halt_upgrade(model):
         f"Application '{charm}' already configured for release equal to or greater than {target}. "
         "Ignoring."
     )
-    machines = {"0": MagicMock(spec_set=Machine)}
+    machines = {"0": generate_cou_machine("0", "az-0")}
     app = RabbitMQServer(
         name=charm,
         can_upgrade_to="",
@@ -569,7 +569,7 @@ def test_auxiliary_no_suitable_channel(model):
         "Please take a look at the documentation: "
         "https://docs.openstack.org/charm-guide/latest/project/charm-delivery.html"
     )
-    machines = {"0": MagicMock(spec_set=Machine)}
+    machines = {"0": generate_cou_machine("0", "az-0")}
     app = RabbitMQServer(
         name=charm,
         can_upgrade_to="",
@@ -598,7 +598,7 @@ def test_auxiliary_no_suitable_channel(model):
 def test_ceph_mon_app(model):
     """Test the correctness of instantiating CephMon."""
     charm = "ceph-mon"
-    machines = {"0": MagicMock(spec_set=Machine)}
+    machines = {"0": generate_cou_machine("0", "az-0")}
     app = CephMon(
         name=charm,
         can_upgrade_to="",
@@ -632,7 +632,7 @@ def test_ceph_mon_upgrade_plan_xena_to_yoga(model):
     """Test when ceph version changes between os releases."""
     target = OpenStackRelease("yoga")
     charm = "ceph-mon"
-    machines = {"0": MagicMock(spec_set=Machine)}
+    machines = {"0": generate_cou_machine("0", "az-0")}
     app = CephMon(
         name=charm,
         can_upgrade_to="quincy/stable",
@@ -716,7 +716,7 @@ def test_ceph_mon_upgrade_plan_ussuri_to_victoria(model):
     """Test when ceph version remains the same between os releases."""
     target = OpenStackRelease("victoria")
     charm = "ceph-mon"
-    machines = {"0": MagicMock(spec_set=Machine)}
+    machines = {"0": generate_cou_machine("0", "az-0")}
     app = CephMon(
         name=charm,
         can_upgrade_to="quincy/stable",
@@ -793,7 +793,7 @@ def test_ceph_mon_upgrade_plan_ussuri_to_victoria(model):
 def test_ovn_principal(model):
     """Test the correctness of instantiating OVNPrincipal."""
     charm = "ovn-central"
-    machines = {"0": MagicMock(spec_set=Machine)}
+    machines = {"0": generate_cou_machine("0", "az-0")}
     app = OVNPrincipal(
         name=charm,
         can_upgrade_to="22.06/stable",
@@ -832,7 +832,7 @@ def test_ovn_workload_ver_lower_than_22_principal(model):
         "https://docs.openstack.org/charm-guide/latest/project/procedures/"
         "ovn-upgrade-2203.html"
     )
-    machines = {"0": MagicMock(spec_set=Machine)}
+    machines = {"0": generate_cou_machine("0", "az-0")}
     app = OVNPrincipal(
         name=charm,
         can_upgrade_to="22.03/stable",
@@ -863,7 +863,7 @@ def test_ovn_version_pinning_principal(model):
     target = OpenStackRelease("victoria")
     charm = "ovn-dedicated-chassis"
     exp_msg = f"Cannot upgrade '{charm}'. 'enable-version-pinning' must be set to 'false'."
-    machines = {"0": MagicMock(spec_set=Machine)}
+    machines = {"0": generate_cou_machine("0", "az-0")}
     app = OVNPrincipal(
         name=charm,
         can_upgrade_to="22.03/stable",
@@ -893,7 +893,7 @@ def test_ovn_version_pinning_principal(model):
 def test_ovn_no_compatible_os_release(channel, model):
     """Test the OVNPrincipal with not compatible os release."""
     charm = "ovn-central"
-    machines = {"0": MagicMock(spec_set=Machine)}
+    machines = {"0": generate_cou_machine("0", "az-0")}
     exp_msg = (
         f"Channel: {channel} for charm '{charm}' on series 'focal' is not supported by COU. "
         "Please take a look at the documentation: "
@@ -937,7 +937,7 @@ def test_ovn_no_compatible_os_release(channel, model):
     ],
 )
 def test_ovn_check_version_pinning_version_pinning_config_False(app, config, model):
-    machines = {"0": MagicMock(spec_set=Machine)}
+    machines = {"0": generate_cou_machine("0", "az-0")}
     app = OVNPrincipal(
         name=app,
         can_upgrade_to="",
@@ -962,7 +962,7 @@ def test_ovn_check_version_pinning_version_pinning_config_False(app, config, mod
 
 
 def test_ovn_check_version_pinning_version_pinning_config_True(model):
-    machines = {"0": MagicMock(spec_set=Machine)}
+    machines = {"0": generate_cou_machine("0", "az-0")}
     app = OVNPrincipal(
         name="ovn-dedicated-chassis",
         can_upgrade_to="",
@@ -992,7 +992,7 @@ def test_ovn_principal_upgrade_plan(model):
     """Test generating plan for OVNPrincipal."""
     target = OpenStackRelease("victoria")
     charm = "ovn-dedicated-chassis"
-    machines = {"0": MagicMock(spec_set=Machine)}
+    machines = {"0": generate_cou_machine("0", "az-0")}
     app = OVNPrincipal(
         name=charm,
         can_upgrade_to="22.06/stable",
@@ -1068,7 +1068,7 @@ def test_mysql_innodb_cluster_upgrade(model):
     """Test generating plan for MysqlInnodbCluster."""
     target = OpenStackRelease("victoria")
     charm = "mysql-innodb-cluster"
-    machines = {"0": MagicMock(spec_set=Machine)}
+    machines = {"0": generate_cou_machine("0", "az-0")}
     app = MysqlInnodbCluster(
         name=charm,
         can_upgrade_to="9.0",

--- a/tests/unit/apps/test_auxiliary_subordinate.py
+++ b/tests/unit/apps/test_auxiliary_subordinate.py
@@ -13,8 +13,6 @@
 #  limitations under the License.
 """Tests of the Auxiliary Subordinate application class."""
 
-from unittest.mock import MagicMock
-
 import pytest
 
 from cou.apps.auxiliary_subordinate import (
@@ -23,14 +21,13 @@ from cou.apps.auxiliary_subordinate import (
 )
 from cou.exceptions import ApplicationError, HaltUpgradePlanGeneration
 from cou.steps import ApplicationUpgradePlan, PreUpgradeStep, UpgradeStep
-from cou.utils.juju_utils import Machine
 from cou.utils.openstack import OpenStackRelease
-from tests.unit.utils import assert_steps, dedent_plan
+from tests.unit.utils import assert_steps, dedent_plan, generate_cou_machine
 
 
 def test_auxiliary_subordinate(model):
     """Test auxiliary subordinate application."""
-    machines = {"0": MagicMock(spec_set=Machine)}
+    machines = {"0": generate_cou_machine("0", "az-0")}
     app = AuxiliarySubordinateApplication(
         name="keystone-mysql-router",
         can_upgrade_to="",
@@ -58,7 +55,7 @@ def test_auxiliary_subordinate(model):
 def test_auxiliary_subordinate_upgrade_plan_to_victoria(model):
     """Test auxiliary subordinate application upgrade plan to victoria."""
     target = OpenStackRelease("victoria")
-    machines = {"0": MagicMock(spec_set=Machine)}
+    machines = {"0": generate_cou_machine("0", "az-0")}
     app = AuxiliarySubordinateApplication(
         name="keystone-mysql-router",
         can_upgrade_to="8.0/stable",
@@ -90,7 +87,7 @@ def test_auxiliary_subordinate_upgrade_plan_to_victoria(model):
 
 def test_ovn_subordinate(model):
     """Test the correctness of instantiating OVNSubordinate."""
-    machines = {"0": MagicMock(spec_set=Machine)}
+    machines = {"0": generate_cou_machine("0", "az-0")}
     app = OVNSubordinate(
         name="ovn-chassis",
         can_upgrade_to="22.03/stable",
@@ -117,7 +114,7 @@ def test_ovn_subordinate(model):
 def test_ovn_workload_ver_lower_than_22_subordinate(model):
     """Test the OVNSubordinate with lower version than 22."""
     target = OpenStackRelease("victoria")
-    machines = {"0": MagicMock(spec_set=Machine)}
+    machines = {"0": generate_cou_machine("0", "az-0")}
     exp_msg = (
         "OVN versions lower than 22.03 are not supported. It's necessary to upgrade "
         "OVN to 22.03 before upgrading the cloud. Follow the instructions at: "
@@ -147,7 +144,7 @@ def test_ovn_version_pinning_subordinate(model):
     """Test the OVNSubordinate when enable-version-pinning is set to True."""
     charm = "ovn-chassis"
     target = OpenStackRelease("victoria")
-    machines = {"0": MagicMock(spec_set=Machine)}
+    machines = {"0": generate_cou_machine("0", "az-0")}
     exp_msg = f"Cannot upgrade '{charm}'. 'enable-version-pinning' must be set to 'false'."
     app = OVNSubordinate(
         name=charm,
@@ -171,7 +168,7 @@ def test_ovn_version_pinning_subordinate(model):
 def test_ovn_subordinate_upgrade_plan(model):
     """Test generating plan for OVNSubordinate."""
     target = OpenStackRelease("victoria")
-    machines = {"0": MagicMock(spec_set=Machine)}
+    machines = {"0": generate_cou_machine("0", "az-0")}
     app = OVNSubordinate(
         name="ovn-chassis",
         can_upgrade_to="22.03/stable",
@@ -215,7 +212,7 @@ def test_ovn_subordinate_upgrade_plan_cant_upgrade_charm(model):
         "victoria. Ignoring."
     )
     target = OpenStackRelease("victoria")
-    machines = {"0": MagicMock(spec_set=Machine)}
+    machines = {"0": generate_cou_machine("0", "az-0")}
     app = OVNSubordinate(
         name="ovn-chassis",
         can_upgrade_to="",
@@ -238,7 +235,7 @@ def test_ovn_subordinate_upgrade_plan_cant_upgrade_charm(model):
 def test_ceph_dashboard_upgrade_plan_ussuri_to_victoria(model):
     """Test when ceph version remains the same between os releases."""
     target = OpenStackRelease("victoria")
-    machines = {"0": MagicMock(spec_set=Machine)}
+    machines = {"0": generate_cou_machine("0", "az-0")}
     app = AuxiliarySubordinateApplication(
         name="ceph-dashboard",
         can_upgrade_to="octopus/stable",
@@ -275,7 +272,7 @@ def test_ceph_dashboard_upgrade_plan_ussuri_to_victoria(model):
 def test_ceph_dashboard_upgrade_plan_xena_to_yoga(model):
     """Test when ceph version changes between os releases."""
     target = OpenStackRelease("yoga")
-    machines = {"0": MagicMock(spec_set=Machine)}
+    machines = {"0": generate_cou_machine("0", "az-0")}
     app = AuxiliarySubordinateApplication(
         name="ceph-dashboard",
         can_upgrade_to="pacific/stable",
@@ -326,7 +323,7 @@ This may be a charm downgrade, which is generally not supported.
     """
     )
 
-    machines = {"0": MagicMock(spec_set=Machine)}
+    machines = {"0": generate_cou_machine("0", "az-0")}
 
     app = AuxiliarySubordinateApplication(
         name="keystone-hacluster",
@@ -353,7 +350,7 @@ def test_auxiliary_subordinate_channel_codename_raise(model):
         charm="ceph-dashboard",
         channel="luminous/stable",
         config={},
-        machines={"0": MagicMock(spec_set=Machine)},
+        machines={"0": generate_cou_machine("0", "az-0")},
         model=model,
         origin="ch",
         series="focal",

--- a/tests/unit/apps/test_base.py
+++ b/tests/unit/apps/test_base.py
@@ -462,7 +462,9 @@ def test_check_mismatched_versions_with_nova_compute(mock_os_release_units, mode
     """Not raise exception if workload version is different, but is colocated with nova-compute."""
     # Same test as above but this application is colocated with nova-compute
     machines = {
-        f"{i}": generate_cou_machine(f"{i}", f"az-{i}", ("my-app", "nova-compute"))
+        f"{i}": generate_cou_machine(
+            f"{i}", f"az-{i}", (("my-app", "app"), ("nova-compute-kvm-sriov", "nova-compute"))
+        )
         for i in range(3)
     }
     units = {

--- a/tests/unit/apps/test_channel_based.py
+++ b/tests/unit/apps/test_channel_based.py
@@ -10,8 +10,6 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-from unittest.mock import MagicMock
-
 import pytest
 
 from cou.apps.channel_based import ChannelBasedApplication
@@ -23,14 +21,14 @@ from cou.steps import (
     UpgradeStep,
 )
 from cou.utils import app_utils
-from cou.utils.juju_utils import Machine, Unit
+from cou.utils.juju_utils import Unit
 from cou.utils.openstack import OpenStackRelease
-from tests.unit.utils import assert_steps, dedent_plan
+from tests.unit.utils import assert_steps, dedent_plan, generate_cou_machine
 
 
 def test_application_versionless(model):
     """Test application without version."""
-    machines = {"0": MagicMock(spec_set=Machine)}
+    machines = {"0": generate_cou_machine("0", "az-0")}
     units = {
         "glance-simplestreams-sync/0": Unit(
             name="glance-simplestreams-sync/0",
@@ -77,7 +75,7 @@ This may be a charm downgrade, which is generally not supported.
     """  # noqa: E501 line too long
     )
 
-    machines = {"0": MagicMock(spec_set=Machine)}
+    machines = {"0": generate_cou_machine("0", "az-0")}
     units = {
         "glance-simplestreams-sync/0": Unit(
             name="glance-simplestreams-sync/0",
@@ -111,7 +109,7 @@ This may be a charm downgrade, which is generally not supported.
 
 def test_application_gnocchi_ussuri(model):
     """Test the Gnocchi ChannelBasedApplication with Ussuri."""
-    machines = {"0": MagicMock(spec_set=Machine)}
+    machines = {"0": generate_cou_machine("0", "az-0")}
     app = ChannelBasedApplication(
         name="gnocchi",
         can_upgrade_to="",
@@ -146,7 +144,7 @@ def test_application_gnocchi_xena(model):
     The workload version is the same for xena and yoga, but current_os_release is based on
     the channel.
     """
-    machines = {"0": MagicMock(spec_set=Machine)}
+    machines = {"0": generate_cou_machine("0", "az-0")}
     app = ChannelBasedApplication(
         name="gnocchi",
         can_upgrade_to="",
@@ -178,7 +176,7 @@ def test_application_designate_bind_ussuri(model):
     The workload version is the same from ussuri to yoga, but current_os_release is based on
     the channel.
     """
-    machines = {"0": MagicMock(spec_set=Machine)}
+    machines = {"0": generate_cou_machine("0", "az-0")}
     app = ChannelBasedApplication(
         name="designate-bind",
         can_upgrade_to="",
@@ -210,7 +208,7 @@ def test_application_designate_bind_ussuri(model):
 def test_application_versionless_upgrade_plan_ussuri_to_victoria(model):
     """Test generating plan for glance-simplestreams-sync (ChannelBasedApplication)."""
     target = OpenStackRelease("victoria")
-    machines = {"0": MagicMock(spec_set=Machine)}
+    machines = {"0": generate_cou_machine("0", "az-0")}
     app = ChannelBasedApplication(
         name="glance-simplestreams-sync",
         can_upgrade_to="ussuri/stable",
@@ -281,7 +279,7 @@ def test_application_gnocchi_upgrade_plan_ussuri_to_victoria(model):
     Updating Gnocchi from ussuri to victoria increases the workload version from 4.3.4 to 4.4.0.
     """
     target = OpenStackRelease("victoria")
-    machines = {"0": MagicMock(spec_set=Machine)}
+    machines = {"0": generate_cou_machine("0", "az-0")}
     app = ChannelBasedApplication(
         name="gnocchi",
         can_upgrade_to="ussuri/stable",
@@ -364,7 +362,7 @@ def test_application_gnocchi_upgrade_plan_ussuri_to_victoria(model):
 def test_application_designate_bind_upgrade_plan_ussuri_to_victoria(model):
     """Test generating plan for Designate-bind (ChannelBasedApplication)."""
     target = OpenStackRelease("victoria")
-    machines = {"0": MagicMock(spec_set=Machine)}
+    machines = {"0": generate_cou_machine("0", "az-0")}
     app = ChannelBasedApplication(
         name="designate-bind",
         can_upgrade_to="ussuri/stable",

--- a/tests/unit/apps/test_core.py
+++ b/tests/unit/apps/test_core.py
@@ -83,7 +83,7 @@ def test_application_different_wl(model):
 async def test_application_verify_workload_upgrade(model):
     """Test Kyestone application check successful upgrade."""
     target = OpenStackRelease("victoria")
-    machines = {"0": MagicMock(spec_set=Machine)}
+    machines = {"0": generate_cou_machine("0", "az-0")}
     app = Keystone(
         name="keystone",
         can_upgrade_to="ussuri/stable",
@@ -128,7 +128,7 @@ async def test_application_verify_workload_upgrade_fail(model):
         r"Unit\(s\) 'keystone/0' did not complete the upgrade to victoria. Some local processes "
         r"may still be executing; you may try re-running COU in a few minutes."
     )
-    machines = {"0": MagicMock(spec_set=Machine)}
+    machines = {"0": generate_cou_machine("0", "az-0")}
     app = Keystone(
         name="keystone",
         can_upgrade_to="ussuri/stable",
@@ -169,7 +169,7 @@ async def test_application_verify_workload_upgrade_fail(model):
 def test_upgrade_plan_ussuri_to_victoria(model):
     """Test generate plan to upgrade Keystone from Ussuri to Victoria."""
     target = OpenStackRelease("victoria")
-    machines = {"0": MagicMock(spec_set=Machine)}
+    machines = {"0": generate_cou_machine("0", "az-0")}
     app = Keystone(
         name="keystone",
         can_upgrade_to="ussuri/stable",
@@ -254,7 +254,7 @@ def test_upgrade_plan_ussuri_to_victoria(model):
 def test_upgrade_plan_ussuri_to_victoria_ch_migration(model):
     """Test generate plan to upgrade Keystone from Ussuri to Victoria with charmhub migration."""
     target = OpenStackRelease("victoria")
-    machines = {"0": MagicMock(spec_set=Machine)}
+    machines = {"0": generate_cou_machine("0", "az-0")}
     app = Keystone(
         name="keystone",
         can_upgrade_to="ussuri/stable",
@@ -342,7 +342,7 @@ def test_upgrade_plan_channel_on_next_os_release(model):
     The app channel it's already on next OpenStack release.
     """
     target = OpenStackRelease("victoria")
-    machines = {"0": MagicMock(spec_set=Machine)}
+    machines = {"0": generate_cou_machine("0", "az-0")}
     app = Keystone(
         name="keystone",
         can_upgrade_to="",
@@ -421,7 +421,7 @@ def test_upgrade_plan_origin_already_on_next_openstack_release(model):
     The app config option openstack-origin it's already on next OpenStack release.
     """
     target = OpenStackRelease("victoria")
-    machines = {"0": MagicMock(spec_set=Machine)}
+    machines = {"0": generate_cou_machine("0", "az-0")}
     app = Keystone(
         name="keystone",
         can_upgrade_to="ussuri/stable",
@@ -502,7 +502,7 @@ def test_upgrade_plan_application_already_upgraded(model):
         "than victoria. Ignoring."
     )
     target = OpenStackRelease("victoria")
-    machines = {"0": MagicMock(spec_set=Machine)}
+    machines = {"0": generate_cou_machine("0", "az-0")}
     app = Keystone(
         name="keystone",
         can_upgrade_to="",
@@ -536,7 +536,7 @@ def test_upgrade_plan_application_already_upgraded(model):
 def test_upgrade_plan_application_already_disable_action_managed(model):
     """Test generate plan to upgrade Keystone with managed upgrade disabled."""
     target = OpenStackRelease("victoria")
-    machines = {"0": MagicMock(spec_set=Machine)}
+    machines = {"0": generate_cou_machine("0", "az-0")}
     app = Keystone(
         name="keystone",
         can_upgrade_to="ussuri/stable",
@@ -1008,7 +1008,7 @@ def test_cinder_upgrade_plan_single_unit(model):
 def test_swift_application_not_supported(model):
     """Test Swift application raising ApplicationNotSupported error."""
     target = OpenStackRelease("victoria")
-    machines = {"0": MagicMock(spec_set=Machine)}
+    machines = {"0": generate_cou_machine("0", "az-0")}
     app = Swift(
         name="swift-proxy",
         can_upgrade_to="ussuri/stable",

--- a/tests/unit/apps/test_subordinate.py
+++ b/tests/unit/apps/test_subordinate.py
@@ -13,23 +13,21 @@
 #  limitations under the License.
 """Subordinate application class."""
 import logging
-from unittest.mock import MagicMock
 
 import pytest
 
 from cou.apps.subordinate import SubordinateApplication
 from cou.exceptions import ApplicationError
 from cou.steps import ApplicationUpgradePlan, PreUpgradeStep, UpgradeStep
-from cou.utils.juju_utils import Machine
 from cou.utils.openstack import OpenStackRelease
-from tests.unit.utils import assert_steps
+from tests.unit.utils import assert_steps, generate_cou_machine
 
 logger = logging.getLogger(__name__)
 
 
 def test_current_os_release(model):
     """Test current_os_release for SubordinateApplication."""
-    machines = {"0": MagicMock(spec_set=Machine)}
+    machines = {"0": generate_cou_machine("0", "az-0")}
     app = SubordinateApplication(
         name="keystone-ldap",
         can_upgrade_to="ussuri/stable",
@@ -51,7 +49,7 @@ def test_current_os_release(model):
 def test_generate_upgrade_plan(model):
     """Test generate upgrade plan for SubordinateApplication."""
     target = OpenStackRelease("victoria")
-    machines = {"0": MagicMock(spec_set=Machine)}
+    machines = {"0": generate_cou_machine("0", "az-0")}
     app = SubordinateApplication(
         name="keystone-ldap",
         can_upgrade_to="ussuri/stable",
@@ -98,7 +96,7 @@ def test_generate_upgrade_plan(model):
 )
 def test_channel_valid(model, channel):
     """Test successful validation of channel upgrade plan for SubordinateApplication."""
-    machines = {"0": MagicMock(spec_set=Machine)}
+    machines = {"0": generate_cou_machine("0", "az-0")}
     app = SubordinateApplication(
         name="keystone-ldap",
         can_upgrade_to=channel,
@@ -127,7 +125,7 @@ def test_channel_valid(model, channel):
 )
 def test_channel_setter_invalid(model, channel):
     """Test unsuccessful validation of channel upgrade plan for SubordinateApplication."""
-    machines = {"0": MagicMock(spec_set=Machine)}
+    machines = {"0": generate_cou_machine("0", "az-0")}
     exp_error_msg = (
         f"Channel: {channel} for charm 'keystone-ldap' on series 'focal' is not supported by COU. "
         "Please take a look at the documentation: "
@@ -164,7 +162,7 @@ def test_channel_setter_invalid(model, channel):
 def test_generate_plan_ch_migration(model, channel):
     """Test generate upgrade plan for SubordinateApplication with charmhub migration."""
     target = OpenStackRelease("wallaby")
-    machines = {"0": MagicMock(spec_set=Machine)}
+    machines = {"0": generate_cou_machine("0", "az-0")}
     app = SubordinateApplication(
         name="keystone-ldap",
         can_upgrade_to="wallaby/stable",
@@ -210,7 +208,7 @@ def test_generate_plan_ch_migration(model, channel):
 def test_generate_plan_from_to(model, from_os, to_os):
     """Test generate upgrade plan for SubordinateApplication from to version."""
     target = OpenStackRelease(to_os)
-    machines = {"0": MagicMock(spec_set=Machine)}
+    machines = {"0": generate_cou_machine("0", "az-0")}
     app = SubordinateApplication(
         name="keystone-ldap",
         can_upgrade_to=f"{to_os}/stable",
@@ -257,7 +255,7 @@ def test_generate_plan_from_to(model, from_os, to_os):
 def test_generate_plan_in_same_version(model, from_to):
     """Test generate upgrade plan for SubordinateApplication in same version."""
     target = OpenStackRelease(from_to)
-    machines = {"0": MagicMock(spec_set=Machine)}
+    machines = {"0": generate_cou_machine("0", "az-0")}
     app = SubordinateApplication(
         name="keystone-ldap",
         can_upgrade_to=f"{from_to}/stable",

--- a/tests/unit/steps/test_analyze.py
+++ b/tests/unit/steps/test_analyze.py
@@ -64,15 +64,15 @@ def test_analysis_dump(model):
           machines:
             '0':
               id: '0'
-              apps: !!python/tuple []
+              apps_charms: !!python/tuple []
               az: null
             '1':
               id: '1'
-              apps: !!python/tuple []
+              apps_charms: !!python/tuple []
               az: null
             '2':
               id: '2'
-              apps: !!python/tuple []
+              apps_charms: !!python/tuple []
               az: null
 
         cinder:
@@ -106,15 +106,15 @@ def test_analysis_dump(model):
           machines:
             '0':
               id: '0'
-              apps: !!python/tuple []
+              apps_charms: !!python/tuple []
               az: null
             '1':
               id: '1'
-              apps: !!python/tuple []
+              apps_charms: !!python/tuple []
               az: null
             '2':
               id: '2'
-              apps: !!python/tuple []
+              apps_charms: !!python/tuple []
               az: null
 
         rabbitmq-server:
@@ -138,7 +138,7 @@ def test_analysis_dump(model):
           machines:
             '0':
               id: '0'
-              apps: !!python/tuple []
+              apps_charms: !!python/tuple []
               az: null
         Data Plane:
 

--- a/tests/unit/steps/test_hypervisor.py
+++ b/tests/unit/steps/test_hypervisor.py
@@ -643,7 +643,10 @@ def test_hypervisor_upgrade_plan_some_units_upgraded(model):
             Verify that the workload of 'nova-compute' has been upgraded on units: nova-compute/2
     """
     )
-    machines = {f"{i}": generate_cou_machine(f"{i}", f"az-{i}") for i in range(3)}
+    machines = {
+        f"{i}": generate_cou_machine(f"{i}", f"az-{i}", ("nova-compute", "cinder"))
+        for i in range(3)
+    }
     # cinder/0 already upgraded
     cinder = OpenStackApplication(
         name="cinder",

--- a/tests/unit/utils.py
+++ b/tests/unit/utils.py
@@ -28,11 +28,13 @@ def assert_steps(step_1: BaseStep, step_2: BaseStep) -> None:
     assert step_1 == step_2, msg
 
 
-def generate_cou_machine(machine_id: str, az: str | None = None) -> MagicMock:
+def generate_cou_machine(
+    machine_id: str, az: str | None = None, apps: tuple = tuple()
+) -> MagicMock:
     machine = MagicMock(spec_set=Machine)()
     machine.machine_id = machine_id
     machine.az = az
-    machine.apps = tuple()
+    machine.apps = apps
     return machine
 
 

--- a/tests/unit/utils.py
+++ b/tests/unit/utils.py
@@ -29,12 +29,12 @@ def assert_steps(step_1: BaseStep, step_2: BaseStep) -> None:
 
 
 def generate_cou_machine(
-    machine_id: str, az: str | None = None, apps: tuple = tuple()
+    machine_id: str, az: str | None = None, apps_charms: tuple = tuple(tuple())
 ) -> MagicMock:
     machine = MagicMock(spec_set=Machine)()
     machine.machine_id = machine_id
     machine.az = az
-    machine.apps = apps
+    machine.apps_charms = apps_charms
     return machine
 
 

--- a/tests/unit/utils/test_juju_utils.py
+++ b/tests/unit/utils/test_juju_utils.py
@@ -561,27 +561,20 @@ async def test_coumodel_wait_for_active_idle_timeout(mock_get_supported_apps, mo
 async def test_get_machines(mocked_model):
     """Test Model getting machines from model."""
     expected_machines = {
-        "0": juju_utils.Machine(
-            "0",
-            (
-                "app1",
-                "app2",
-            ),
-            "zone-1",
-        ),
-        "1": juju_utils.Machine("1", ("app1",), "zone-2"),
-        "2": juju_utils.Machine("2", ("app1",), "zone-3"),
+        "0": juju_utils.Machine("0", (("my_app1", "app1"), ("my_app2", "app2")), "zone-1"),
+        "1": juju_utils.Machine("1", (("my_app1", "app1"),), "zone-2"),
+        "2": juju_utils.Machine("2", (("my_app1", "app1"),), "zone-3"),
     }
     mocked_model.machines = {f"{i}": _generate_juju_machine(f"{i}") for i in range(3)}
     mocked_model.units = {
-        "app1/0": _generate_juju_unit("app1", "0"),
-        "app1/1": _generate_juju_unit("app1", "1"),
-        "app1/2": _generate_juju_unit("app1", "2"),
-        "app2/0": _generate_juju_unit("app2", "0"),
+        "my_app1/0": _generate_juju_unit("my_app1", "0"),
+        "my_app1/1": _generate_juju_unit("my_app1", "1"),
+        "my_app1/2": _generate_juju_unit("my_app1", "2"),
+        "my_app2/0": _generate_juju_unit("my_app2", "0"),
     }
     mocked_model.applications = {
-        "app1": MagicMock(spec_set=Application)(),
-        "app2": MagicMock(spec_set=Application)(),
+        "my_app1": _generate_juju_app("app1"),
+        "my_app2": _generate_juju_app("app2"),
     }
 
     model = juju_utils.Model("test-model")
@@ -595,6 +588,12 @@ def _generate_juju_unit(app: str, machine_id: str) -> MagicMock:
     unit.application = app
     unit.machine.id = machine_id
     return unit
+
+
+def _generate_juju_app(charm: str) -> MagicMock:
+    app = MagicMock(spec_set=Application)()
+    app.charm_name = charm
+    return app
 
 
 def _generate_juju_machine(machine_id: str) -> MagicMock:


### PR DESCRIPTION
- nova-compute is expected to upgrade unit by unit. So it's expected to have different versions among nova-compute units or apps colocated with it.
- _check_mismatched_versions now check if a machine of an app is colocated with nova-compute.

Closes: #395