### PR TITLE
Check overall ceph versions

### DIFF
--- a/cou/apps/auxiliary.py
+++ b/cou/apps/auxiliary.py
@@ -204,22 +204,25 @@ class CephMon(AuxiliaryApplication):
         :rtype: list[PreUpgradeStep]
         """
         return super().pre_upgrade_steps(target, units) + [
-            self._get_change_require_osd_release_step()
+            self._get_change_require_osd_release_step(target)
         ]
 
-    def _get_change_require_osd_release_step(self) -> PreUpgradeStep:
+    def _get_change_require_osd_release_step(self, target: OpenStackRelease) -> PreUpgradeStep:
         """Get the step to set correct value for require-osd-release option on ceph-mon.
 
         This step is needed as a workaround for LP#1929254. Reference:
         https://docs.openstack.org/charm-guide/latest/project/issues/upgrade-issues.html#ceph-require-osd-release
 
+        :param target: OpenStack release as target to upgrade.
+        :type target: OpenStackRelease
         :return: Step to check and set correct value for require-osd-release
         :rtype: PreUpgradeStep
         """
         ceph_mon_unit, *_ = self.units.values()
+        track, *_ = self.target_channel(target).split("/")
         return PreUpgradeStep(
             "Ensure that the 'require-osd-release' option matches the 'ceph-osd' version",
-            coro=set_require_osd_release_option(ceph_mon_unit.name, self.model),
+            coro=set_require_osd_release_option(track, ceph_mon_unit.name, self.model),
         )
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -11,10 +11,8 @@ skip_missing_interpreters = True
 basepython = python3
 setenv =
     PYTHONPATH={toxinidir}
-    TEST_PYTHON_PACKAGE={envdir}
 
 [testenv:dev-environment]
-envdir = {toxinidir}/.venv
 deps =
     pre-commit
     {[testenv:lint]deps}
@@ -24,7 +22,6 @@ commands =
     pre-commit install
 
 [testenv:pre-commit]
-envdir = {[testenv:dev-environment]envdir}
 deps = {[testenv:dev-environment]deps}  # ensure that dev-environment is installed
 commands = pre-commit run --all-files
 
@@ -42,7 +39,6 @@ deps =
     {[testenv:func]deps}
 
 [testenv:reformat]
-envdir = {toxworkdir}/lint
 deps = {[testenv:lint]deps}
 commands =
     black .


### PR DESCRIPTION
Check if there is more than one ceph version in the overall field

- when more than one overall field shows, this probably means that is necessary to restart ceph services or manually upgrade a ceph charm

Closes #401