### PR TITLE
fix linting issue with new flake8 version

### DIFF
--- a/tests/unit/steps/test_hypervisor.py
+++ b/tests/unit/steps/test_hypervisor.py
@@ -230,7 +230,7 @@ def test_hypervisor_azs_grouping():
     ```
     """
     target = OpenStackRelease("victoria")
-    machines = {f"{i}": Machine(f"{i}", (), f"az{i//2}") for i in range(6)}
+    machines = {f"{i}": Machine(f"{i}", (), f"az{i // 2}") for i in range(6)}
     units = {
         # app1
         "app1/0": Unit("app1/0", machines["0"], ""),
@@ -316,7 +316,7 @@ def test_hypervisor_azs_grouping_units_different_o7k_release():
     ```
     """
     target = OpenStackRelease("victoria")
-    machines = {f"{i}": Machine(f"{i}", (), f"az{i//2}") for i in range(6)}
+    machines = {f"{i}": Machine(f"{i}", (), f"az{i // 2}") for i in range(6)}
     units = {
         # app1
         "app1/0": Unit("app1/0", machines["0"], ""),


### PR DESCRIPTION
Running lint tests on Python 3.12.3 with `flake8==7.0.0` and `pyflakes==3.2.0` was failing.
