### PR TITLE
use separate track for 3.x

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -2,7 +2,7 @@ name: Publish snap
 
 on:
   push:
-    branches: [ '*.x' ]
+    branches: [ '3.x' ]
   release:
     types: [ published ]
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -2,7 +2,7 @@ name: Publish snap
 
 on:
   push:
-    branches: [ main ]
+    branches: [ '*.x' ]
   release:
     types: [ published ]
 
@@ -29,4 +29,4 @@ jobs:
           SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.STORE_LOGIN }}
         with:
           snap: ${{ steps.build.outputs.snap }}
-          release: latest/edge
+          release: 3.x/edge


### PR DESCRIPTION
Change release workflow to release on push to 3.x branch and push it to the 3.x/edge instead of latest/edge.