### PR TITLE
chores (backport from main): fix tox.ini

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -14,7 +14,6 @@ setenv =
     TEST_PYTHON_PACKAGE={envdir}
 
 [testenv:dev-environment]
-envdir = {toxinidir}/.venv
 deps =
     pre-commit
     {[testenv:lint]deps}
@@ -24,7 +23,6 @@ commands =
     pre-commit install
 
 [testenv:pre-commit]
-envdir = {[testenv:dev-environment]envdir}
 deps = {[testenv:dev-environment]deps}  # ensure that dev-environment is installed
 commands = pre-commit run --all-files
 
@@ -42,7 +40,6 @@ deps =
     {[testenv:func]deps}
 
 [testenv:reformat]
-envdir = {toxworkdir}/lint
 deps = {[testenv:lint]deps}
 commands =
     black .


### PR DESCRIPTION
The `envdir` is not suppose to use it that way, and it's no longer supported in tox > 4.