### PR TITLE
Fetch all commits and tags in release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,6 +18,8 @@ jobs:
       snap: ${{ steps.build.outputs.snap }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # NOTE(rgildein): Fetch all tags as the latest tag is required for build.
       - uses: snapcore/action-build@v1
         id: build
       - uses: actions/upload-artifact@v4


### PR DESCRIPTION
In release the latest tag is needed to build proper version.