### PR TITLE
Fix ActionFailed creating error message

### DIFF
--- a/cou/exceptions.py
+++ b/cou/exceptions.py
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Module of exceptions that charmed-openstack-upgrader may raise."""
-from typing import Any, Optional, Union
-
 from juju.action import Action
 
 
@@ -79,15 +77,13 @@ class ActionFailed(COUException):
     """Exception raised when action fails."""
 
     # pylint: disable=consider-using-f-string
-    def __init__(self, action: Action, output: Optional[Union[Any, dict]] = None):
+    def __init__(self, action: Action):
         """Set information about action failure in message and raise.
 
         :param action: Action that failed.
         :type action: Action
-        :param output: Description of the failed action, defaults to None
-        :type output: Optional[str], optional
         """
-        params = {"output": output}
+        params = {"output": action.safe_data}
         for key in [
             "name",
             "parameters",
@@ -99,11 +95,11 @@ class ActionFailed(COUException):
             "started",
             "completed",
         ]:
-            params[key] = getattr(action, key, "<not-set>")
+            params[key] = action.safe_data.get(key, "<not-set>")
 
         message = (
-            'Run of action "{name}" with parameters "{parameters}" on '
-            '"{receiver}" failed with "{message}" (id={id} '
+            "Run of action '{name}' with parameters '{parameters}' on "
+            "'{receiver}' failed with '{message}' (id={id} "
             "status={status} enqueued={enqueued} started={started} "
             "completed={completed} output={output})".format(**params)
         )

--- a/cou/utils/juju_utils.py
+++ b/cou/utils/juju_utils.py
@@ -254,7 +254,8 @@ class Model:
         """
         action_obj = await action.wait()
         if raise_on_failure and action_obj.status != "completed":
-            raise ActionFailed(action, output=action_obj.data)
+            logger.error("action %s failed", action_obj)
+            raise ActionFailed(action)
 
         return action_obj
 

--- a/tests/unit/test_exceptions.py
+++ b/tests/unit/test_exceptions.py
@@ -20,22 +20,25 @@ from cou.exceptions import ActionFailed
 
 def test_action_failed():
     """Test error message composition for ActionFailed."""
-    mocked_action = mock.Mock(spec=Action)
-    action = mocked_action()
-    action.name = "test-action"
-    action.parameters = "test=1"
-    action.receiver = "test-receiver"
-    action.message = "test-message"
-    action.id = "test-id"
-    action.status = "test-status"
-    action.enqueued = "test-enqueued"
-    action.started = "test-started"
-    action.completed = "test-completed"
+    action = mock.Mock(spec_set=Action)()
+    action.safe_data = {
+        "model-uuid": "12885f47-4dfa-4457-8ed1-1f08c1b278dd",
+        "id": "4",
+        "receiver": "my-charm/0",
+        "name": "test-action",
+        "status": "failed",
+        "message": "error message",
+        "enqueued": "2024-05-29T14:50:08Z",
+        "started": "2024-05-29T14:50:11Z",
+        "completed": "2024-05-29T14:50:11Z",
+    }
 
-    error = ActionFailed(action=action, output="test output")
+    error = ActionFailed(action=action)
     assert str(error) == (
-        'Run of action "test-action" with parameters "test=1" on '
-        '"test-receiver" failed with "test-message" (id=test-id '
-        "status=test-status enqueued=test-enqueued started=test-started "
-        "completed=test-completed output=test output)"
+        "Run of action 'test-action' with parameters '<not-set>' on 'my-charm/0' failed with "
+        "'error message' (id=4 status=failed enqueued=2024-05-29T14:50:08Z started=2024-05-29T14:"
+        "50:11Z completed=2024-05-29T14:50:11Z output={'model-uuid': '12885f47-4dfa-4457-8ed1-1f0"
+        "8c1b278dd', 'id': '4', 'receiver': 'my-charm/0', 'name': 'test-action', 'status': "
+        "'failed', 'message': 'error message', 'enqueued': '2024-05-29T14:50:08Z', 'started': "
+        "'2024-05-29T14:50:11Z', 'completed': '2024-05-29T14:50:11Z'})"
     )


### PR DESCRIPTION
The ActionFailed was failing to create error message when `parameters` was not present in action object. We used getattr, but this in action object is overwritten to do self.safe_data[key], so if key does not exists it raise KeyError.

fixes: #423