### PR TITLE
feat: Add purge data step

### DIFF
--- a/cou/apps/factory.py
+++ b/cou/apps/factory.py
@@ -58,6 +58,7 @@ class AppFactory:
                 subordinate_to=app.subordinate_to,
                 units=app.units,
                 workload_version=app.workload_version,
+                actions=app.actions,
             )
 
         logger.debug(

--- a/cou/commands.py
+++ b/cou/commands.py
@@ -204,7 +204,7 @@ def get_subcommand_common_opts_parser() -> argparse.ArgumentParser:
             "Providing this argument will delete data from all shadow tables"
             "\nthat is older than the date provided."
             "\nDate string format should be YYYY-MM-DD[HH:mm][:ss]."
-            "\nWithout --purge-before the purge step will delete all the data."
+            "\nWithout --purge-before-date the purge step will delete all the data."
         ),
         type=purge_before_arg,
         required=False,

--- a/cou/commands.py
+++ b/cou/commands.py
@@ -17,7 +17,6 @@ import argparse
 import logging
 from dataclasses import dataclass
 from datetime import datetime
-from os import linesep
 from typing import Any, Iterable, Optional
 
 import pkg_resources
@@ -119,15 +118,14 @@ def purge_before_arg(value: str) -> str:
     :rtype: str
     :raises argparse.ArgumentTypeError: if string format is invalid
     """
-    valid = False
     formats = ["%Y-%m-%d %H:%M:%S", "%Y-%m-%d %H:%M", "%Y-%m-%d"]
     for fmt in formats:
         try:
             datetime.strptime(value, fmt)
-            valid = True
+            break
         except ValueError:
-            continue
-    if not valid:
+            pass
+    else:  # only run this if didn't `break` above
         raise argparse.ArgumentTypeError("purge before format must be YYYY-MM-DD[HH:mm][:ss]")
     return value
 
@@ -205,10 +203,10 @@ def get_subcommand_common_opts_parser() -> argparse.ArgumentParser:
         dest="purge_before",
         action=PurgeBeforeArgumentAction,
         help=(
-            "Specifying –before will delete data from all shadow tables"
-            f"{linesep}that is older than the date provided."
-            f"{linesep}Date string format should be YYYY-MM-DD[HH:mm][:ss]."
-            f"{linesep}Without before the step will delete all the data."
+            "Providing this argument will delete data from all shadow tables"
+            "\nthat is older than the date provided."
+            "\nDate string format should be YYYY-MM-DD[HH:mm][:ss]."
+            "\nWithout --purge-before the purge step will delete all the data."
         ),
         type=purge_before_arg,
         required=False,

--- a/cou/commands.py
+++ b/cou/commands.py
@@ -154,6 +154,22 @@ def get_subcommand_common_opts_parser() -> argparse.ArgumentParser:
         default=1000,
     )
     subcommand_common_opts_parser.add_argument(
+        "--purge",
+        help="Delete data from shadow tables. before cloud upgrade.\n"
+        "Default to disable purge.",
+        action=argparse.BooleanOptionalAction,
+        default=False,
+    )
+    subcommand_common_opts_parser.add_argument(
+        "--purge-before",
+        dest="purge_before",
+        help="Specifying –before will delete data from all shadow tables "
+        "that is older than the date provided. "
+        "Date strings may be fuzzy, such as 'Oct 21 2015'. "
+        "Without before the step will delete all the data.",
+        type=str,
+    )
+    subcommand_common_opts_parser.add_argument(
         "--force",
         action="store_true",
         dest="force",
@@ -421,6 +437,8 @@ class CLIargs:
     subcommand: Optional[str] = None  # for help option
     machines: Optional[set[str]] = None
     availability_zones: Optional[set[str]] = None
+    purge: bool = False
+    purge_before: str = ""
 
     @property
     def prompt(self) -> bool:

--- a/cou/commands.py
+++ b/cou/commands.py
@@ -16,6 +16,7 @@
 import argparse
 import logging
 from dataclasses import dataclass
+from datetime import datetime
 from typing import Any, Iterable, Optional
 
 import pkg_resources
@@ -108,6 +109,28 @@ def batch_size_arg(value: str) -> int:
     return batch_size
 
 
+def purge_before_arg(value: str) -> str:
+    """Verify the datetime string is acceptable.
+
+    :param value: input arg value to validate
+    :type value: str
+    :return: same as input string
+    :rtype: str
+    :raises argparse.ArgumentTypeError: if string format is invalid
+    """
+    valid = False
+    formats = ["%Y-%m-%d %H:%M:%S", "%Y-%m-%d %H:%M", "%Y-%m-%d"]
+    for fmt in formats:
+        try:
+            datetime.strptime(value, fmt)
+            valid = True
+        except ValueError:
+            continue
+    if not valid:
+        raise argparse.ArgumentTypeError("purge before format must be YYYY-MM-DD[HH:mm][:ss]")
+    return value
+
+
 def get_subcommand_common_opts_parser() -> argparse.ArgumentParser:
     """Create a shared parser for options specific to subcommands.
 
@@ -155,9 +178,8 @@ def get_subcommand_common_opts_parser() -> argparse.ArgumentParser:
     )
     subcommand_common_opts_parser.add_argument(
         "--purge",
-        help="Delete data from shadow tables. before cloud upgrade.\n"
-        "Default to disable purge.",
-        action=argparse.BooleanOptionalAction,
+        help="Delete data from shadow tables. before cloud upgrade.\n" "Default to disable purge.",
+        action="store_true",
         default=False,
     )
     subcommand_common_opts_parser.add_argument(
@@ -167,7 +189,7 @@ def get_subcommand_common_opts_parser() -> argparse.ArgumentParser:
         "that is older than the date provided. "
         "Date strings may be fuzzy, such as 'Oct 21 2015'. "
         "Without before the step will delete all the data.",
-        type=str,
+        type=purge_before_arg,
     )
     subcommand_common_opts_parser.add_argument(
         "--force",

--- a/cou/commands.py
+++ b/cou/commands.py
@@ -17,6 +17,7 @@ import argparse
 import logging
 from dataclasses import dataclass
 from datetime import datetime
+from os import linesep
 from typing import Any, Iterable, Optional
 
 import pkg_resources
@@ -203,10 +204,12 @@ def get_subcommand_common_opts_parser() -> argparse.ArgumentParser:
         "--purge-before",
         dest="purge_before",
         action=PurgeBeforeArgumentAction,
-        help="Specifying –before will delete data from all shadow tables "
-        "that is older than the date provided. "
-        "Date string format should be YYYY-MM-DD[HH:mm][:ss]"
-        "Without before the step will delete all the data.",
+        help=(
+            "Specifying –before will delete data from all shadow tables"
+            f"{linesep}that is older than the date provided."
+            f"{linesep}Date string format should be YYYY-MM-DD[HH:mm][:ss]."
+            f"{linesep}Without before the step will delete all the data."
+        ),
         type=purge_before_arg,
         required=False,
     )

--- a/cou/commands.py
+++ b/cou/commands.py
@@ -122,12 +122,10 @@ def purge_before_arg(value: str) -> str:
     for fmt in formats:
         try:
             datetime.strptime(value, fmt)
-            break
+            return value
         except ValueError:
             pass
-    else:  # only run this if didn't `break` above
-        raise argparse.ArgumentTypeError("purge before format must be YYYY-MM-DD[HH:mm][:ss]")
-    return value
+    raise argparse.ArgumentTypeError("purge before format must be YYYY-MM-DD[HH:mm][:ss]")
 
 
 class PurgeBeforeArgumentAction(argparse.Action):
@@ -199,7 +197,7 @@ def get_subcommand_common_opts_parser() -> argparse.ArgumentParser:
         default=False,
     )
     subcommand_common_opts_parser.add_argument(
-        "--purge-before",
+        "--purge-before-date",
         dest="purge_before",
         action=PurgeBeforeArgumentAction,
         help=(

--- a/cou/steps/nova_cloud_controller.py
+++ b/cou/steps/nova_cloud_controller.py
@@ -93,13 +93,13 @@ async def purge(model: Model, before: Optional[str]) -> None:
         )
     if "Purging stale soft-deleted rows failed" in output:
         raise COUException(
-            f"Purge data action failed in {unit_name}, please check unit's debug log"
+            f"purge-data action failed on {unit_name}, please check unit's debug log"
             " for more details."
         )
     if "Purging stale soft-deleted rows and no data was deleted" in output:
-        logger.info("Run purge-data action in %s and no data was deleted", unit_name)
+        logger.info("purge-data action succeeded on %s (no data was deleted)", unit_name)
     else:
-        logger.info("Purge data action success in %s", unit_name)
+        logger.info("purge-data action succeeded on %s", unit_name)
 
 
 async def _get_nova_cloud_controller_unit_name(model: Model) -> str:

--- a/cou/steps/nova_cloud_controller.py
+++ b/cou/steps/nova_cloud_controller.py
@@ -70,8 +70,9 @@ async def purge(model: Model, before: Optional[str]) -> None:
     The purge-data action delete rows from shadow tables.
     :param model: juju model to work with
     :type model: Model
-    :param before: specifying before will delete data from all shadow tables that is older than the data provided.
-         Date strings may be fuzzy, such as Oct 21 2015
+    :param before: specifying before will delete data from all shadow tables
+        that is older than the data provided.
+        Date string format should be YYYY-MM-DD[HH:mm][:ss]
     :raises COUException: if action returned unexpected output or failed
     """
     action_params = {}
@@ -88,8 +89,7 @@ async def purge(model: Model, before: Optional[str]) -> None:
     output = action.data["results"].get("output")
     if output is None:
         raise COUException(
-            "Expected to find output in action results. 'output',"
-            "but it was not present."
+            "Expected to find output in action results. 'output', but it was not present."
         )
     if "Purging stale soft-deleted rows failed" in output:
         raise COUException(
@@ -97,9 +97,7 @@ async def purge(model: Model, before: Optional[str]) -> None:
             "for more details."
         )
     if "Purging stale soft-deleted rows and no data was deleted" in output:
-        logger.info(
-            f"Run purge-data action in ${unit_name} and no data was deleted"
-        )
+        logger.info("Run purge-data action in %s and no data was deleted", unit_name)
     else:
         logger.info("Purge data action success in ${unit_name}")
 

--- a/cou/steps/nova_cloud_controller.py
+++ b/cou/steps/nova_cloud_controller.py
@@ -93,13 +93,13 @@ async def purge(model: Model, before: Optional[str]) -> None:
         )
     if "Purging stale soft-deleted rows failed" in output:
         raise COUException(
-            f"Purge data action failed in ${unit_name}, please check unit's debug log"
-            "for more details."
+            f"Purge data action failed in {unit_name}, please check unit's debug log"
+            " for more details."
         )
     if "Purging stale soft-deleted rows and no data was deleted" in output:
         logger.info("Run purge-data action in %s and no data was deleted", unit_name)
     else:
-        logger.info("Purge data action success in ${unit_name}")
+        logger.info(f"Purge data action success in {unit_name}")
 
 
 async def _get_nova_cloud_controller_unit_name(model: Model) -> str:

--- a/cou/steps/nova_cloud_controller.py
+++ b/cou/steps/nova_cloud_controller.py
@@ -99,7 +99,7 @@ async def purge(model: Model, before: Optional[str]) -> None:
     if "Purging stale soft-deleted rows and no data was deleted" in output:
         logger.info("Run purge-data action in %s and no data was deleted", unit_name)
     else:
-        logger.info(f"Purge data action success in {unit_name}")
+        logger.info("Purge data action success in %s", unit_name)
 
 
 async def _get_nova_cloud_controller_unit_name(model: Model) -> str:

--- a/cou/steps/nova_cloud_controller.py
+++ b/cou/steps/nova_cloud_controller.py
@@ -14,6 +14,7 @@
 
 """Functions for prereq steps relating to nova."""
 import logging
+from typing import Optional
 
 from cou.exceptions import ApplicationNotFound, COUException, UnitNotFound
 from cou.utils.juju_utils import Model
@@ -61,6 +62,46 @@ async def archive(model: Model, *, batch_size: int) -> None:
             logger.debug("Archiving complete.")
             break
         logger.debug("Potentially more data to archive...")
+
+
+async def purge(model: Model, before: Optional[str]) -> None:
+    """Purge data on a nova-cloud-controller unit.
+
+    The purge-data action delete rows from shadow tables.
+    :param model: juju model to work with
+    :type model: Model
+    :param before: specifying before will delete data from all shadow tables that is older than the data provided.
+         Date strings may be fuzzy, such as Oct 21 2015
+    :raises COUException: if action returned unexpected output or failed
+    """
+    action_params = {}
+    if before is not None:
+        action_params = {"before": before}
+
+    unit_name: str = await _get_nova_cloud_controller_unit_name(model)
+    action = await model.run_action(
+        unit_name=unit_name,
+        action_name="purge-data",
+        raise_on_failure=True,
+        action_params=action_params,
+    )
+    output = action.data["results"].get("output")
+    if output is None:
+        raise COUException(
+            "Expected to find output in action results. 'output',"
+            "but it was not present."
+        )
+    if "Purging stale soft-deleted rows failed" in output:
+        raise COUException(
+            f"Purge data action failed in ${unit_name}, please check unit's debug log"
+            "for more details."
+        )
+    if "Purging stale soft-deleted rows and no data was deleted" in output:
+        logger.info(
+            f"Run purge-data action in ${unit_name} and no data was deleted"
+        )
+    else:
+        logger.info("Purge data action success in ${unit_name}")
 
 
 async def _get_nova_cloud_controller_unit_name(model: Model) -> str:

--- a/cou/steps/plan.py
+++ b/cou/steps/plan.py
@@ -387,8 +387,7 @@ def _get_pre_upgrade_steps(analysis_result: Analysis, args: CLIargs) -> list[Pre
             )
         )
 
-    pre_clean_data_steps = _get_pre_clean_data_steps(analysis_result, args)
-    steps = steps + pre_clean_data_steps
+    steps.extend(_get_pre_clean_data_steps(analysis_result, args))
     return steps
 
 
@@ -406,12 +405,12 @@ def _get_pre_clean_data_steps(analysis_result: Analysis, args: CLIargs) -> list[
     # Add a pre-upgrade step to archive old database data.
     # This is a performance optimisation.
     if args.archive:
-        steps = steps + _get_archive_data_steps(analysis_result, args)
+        steps.extend(_get_archive_data_steps(analysis_result, args))
 
     # Add a pre-upgrade step to purge old database data.
     # This is a performance optimisation.
     if args.purge:
-        steps = steps + _get_purge_data_steps(analysis_result, args)
+        steps.extend(_get_purge_data_steps(analysis_result, args))
     return steps
 
 

--- a/cou/steps/plan.py
+++ b/cou/steps/plan.py
@@ -383,17 +383,30 @@ def _get_pre_upgrade_steps(analysis_result: Analysis, args: CLIargs) -> list[Pre
             ),
         )
     ]
+    steps.extend(_get_backup_steps(analysis_result, args))
+    steps.extend(_get_archive_data_steps(analysis_result, args))
+    steps.extend(_get_purge_data_steps(analysis_result, args))
+    return steps
+
+
+def _get_backup_steps(analysis_result: Analysis, args: CLIargs) -> list[PreUpgradeStep]:
+    """Get back up MySQL databases step.
+
+    :param analysis_result: Analysis result
+    :type analysis_result: Analysis
+    :param args: CLI arguments
+    :type args: CLIargs
+    :return: List of post-upgrade steps.
+    :rtype: list[PreUpgradeStep]
+    """
     if args.backup:
-        steps.append(
+        return [
             PreUpgradeStep(
                 description="Back up MySQL databases",
                 coro=backup(analysis_result.model),
             )
-        )
-
-    steps.extend(_get_archive_data_steps(analysis_result, args))
-    steps.extend(_get_purge_data_steps(analysis_result, args))
-    return steps
+        ]
+    return []
 
 
 def _get_purge_data_steps(analysis_result: Analysis, args: CLIargs) -> list[PreUpgradeStep]:

--- a/cou/utils/juju_utils.py
+++ b/cou/utils/juju_utils.py
@@ -194,7 +194,7 @@ class Application:
     subordinate_to: list[str]
     units: dict[str, Unit]
     workload_version: str
-    actions: dict[str, str]
+    actions: dict[str, str] = field(default_factory=lambda: {}, compare=False)
 
     @property
     def is_subordinate(self) -> bool:

--- a/cou/utils/juju_utils.py
+++ b/cou/utils/juju_utils.py
@@ -177,6 +177,7 @@ class Application:
     subordinate_to: list[str]
     units: dict[str, Unit]
     workload_version: str
+    actions: dict[str, str]
 
     @property
     def is_subordinate(self) -> bool:
@@ -387,6 +388,7 @@ class Model:
                     for name, unit in status.units.items()
                 },
                 workload_version=status.workload_version,
+                actions=await model.applications[app].get_actions(),
             )
             for app, status in full_status.applications.items()
         }

--- a/tests/unit/steps/test_nova_cloud_controller.py
+++ b/tests/unit/steps/test_nova_cloud_controller.py
@@ -110,19 +110,19 @@ async def test_archive_handles_multiple_batches(model):
             "Purge all",
             None,
             AsyncMock(),
-            ["Purge data action success in %s", "nova-cloud-controller/0"],
+            ["purge-data action succeeded on %s", "nova-cloud-controller/0"],
         ),
         (
             "Purge before",
             "2000-01-02",
             AsyncMock(),
-            ["Purge data action success in %s", "nova-cloud-controller/0"],
+            ["purge-data action succeeded on %s", "nova-cloud-controller/0"],
         ),
         (
             "No data deleted",
             None,
             {"results": {"output": "Purging stale soft-deleted rows and no data was deleted"}},
-            ["Run purge-data action in %s and no data was deleted", "nova-cloud-controller/0"],
+            ["purge-data action succeeded on %s (no data was deleted)", "nova-cloud-controller/0"],
         ),
     ],
 )
@@ -167,7 +167,7 @@ async def test_purge(mock_logger, case, before, action_output, log_msg, model):
             None,
             {"results": {"output": "Purging stale soft-deleted rows failed"}},
             (
-                "Purge data action failed in nova-cloud-controller/0,"
+                "purge-data action failed on nova-cloud-controller/0,"
                 " please check unit's debug log"
                 " for more details."
             ),

--- a/tests/unit/steps/test_nova_cloud_controller.py
+++ b/tests/unit/steps/test_nova_cloud_controller.py
@@ -110,13 +110,13 @@ async def test_archive_handles_multiple_batches(model):
             "Purge all",
             None,
             AsyncMock(),
-            ["Purge data action success in nova-cloud-controller/0"],
+            ["Purge data action success in %s", "nova-cloud-controller/0"],
         ),
         (
             "Purge before",
             "2000-01-02",
             AsyncMock(),
-            ["Purge data action success in nova-cloud-controller/0"],
+            ["Purge data action success in %s", "nova-cloud-controller/0"],
         ),
         (
             "No data deleted",
@@ -154,13 +154,13 @@ async def test_purge(mock_logger, case, before, action_output, log_msg, model):
             "Output not found",
             None,
             {"results": {}},
-            "Expected to find output in action results. 'output', but it was not present."
+            "Expected to find output in action results. 'output', but it was not present.",
         ),
         (
             "Output not found, before",
             "2000-01-02",
             {"results": {}},
-            "Expected to find output in action results. 'output', but it was not present."
+            "Expected to find output in action results. 'output', but it was not present.",
         ),
         (
             "Action failed",
@@ -170,7 +170,7 @@ async def test_purge(mock_logger, case, before, action_output, log_msg, model):
                 "Purge data action failed in nova-cloud-controller/0,"
                 " please check unit's debug log"
                 " for more details."
-            )
+            ),
         ),
     ],
 )

--- a/tests/unit/test_commands.py
+++ b/tests/unit/test_commands.py
@@ -170,7 +170,7 @@ def test_parse_args_quiet_verbose_exclusive(args):
             ),
         ),
         (
-            ["plan", "--purge", "--purge-before", "2000-01-02"],
+            ["plan", "--purge", "--purge-before-date", "2000-01-02"],
             CLIargs(
                 command="plan",
                 model_name=None,
@@ -184,7 +184,7 @@ def test_parse_args_quiet_verbose_exclusive(args):
             ),
         ),
         (
-            ["plan", "--purge", "--purge-before", "2000-01-02 03:04"],
+            ["plan", "--purge", "--purge-before-date", "2000-01-02 03:04"],
             CLIargs(
                 command="plan",
                 model_name=None,
@@ -198,7 +198,7 @@ def test_parse_args_quiet_verbose_exclusive(args):
             ),
         ),
         (
-            ["plan", "--purge", "--purge-before", "2000-01-02 03:04:05"],
+            ["plan", "--purge", "--purge-before-date", "2000-01-02 03:04:05"],
             CLIargs(
                 command="plan",
                 model_name=None,
@@ -544,7 +544,7 @@ def test_parse_args_plan(args, expected_CLIargs):
             ),
         ),
         (
-            ["upgrade", "--purge", "--purge-before", "2000-01-02 03:04:05"],
+            ["upgrade", "--purge", "--purge-before-date", "2000-01-02 03:04:05"],
             CLIargs(
                 command="upgrade",
                 model_name=None,
@@ -932,23 +932,29 @@ def test_purge_before_arg(val, raise_err):
             commands.purge_before_arg(val)
 
 
-@pytest.mark.parametrize(
-    "case,args,expected_err",
-    [
-        ("without purge", "--purge-before 2000-01-02", True),
-        ("with purge", "--purge --purge-before 2000-01-02", False),
-    ],
-)
 @patch("cou.commands.setattr")
-def test_purge_before_argument_action(mock_setattr, case, args, expected_err):
+def test_purge_before_argument_action(mock_setattr):
     parser = ArgumentParser()
     parser.add_argument("--purge", action="store_true", default=False)
     parser.add_argument(
-        "--purge-before", dest="purge_before", type=str, action=commands.PurgeBeforeArgumentAction
+        "--purge-before-date",
+        dest="purge_before",
+        type=str,
+        action=commands.PurgeBeforeArgumentAction,
     )
-    if expected_err:
-        with pytest.raises(SystemExit, match="2"):
-            parser.parse_args(args.split())
-    else:
-        parser.parse_args(args.split())
-        mock_setattr.assert_called()
+    parser.parse_args("--purge --purge-before-date 2000-01-02".split())
+    mock_setattr.assert_called()
+
+
+@patch("cou.commands.setattr")
+def test_purge_before_argument_action_failed(mock_setattr):
+    parser = ArgumentParser()
+    parser.add_argument("--purge", action="store_true", default=False)
+    parser.add_argument(
+        "--purge-before-date",
+        dest="purge_before",
+        type=str,
+        action=commands.PurgeBeforeArgumentAction,
+    )
+    with pytest.raises(SystemExit, match="2"):
+        parser.parse_args("--purge-before-date 2000-01-02".split())

--- a/tests/unit/test_commands.py
+++ b/tests/unit/test_commands.py
@@ -935,8 +935,8 @@ def test_purge_before_arg(val, raise_err):
 @pytest.mark.parametrize(
     "case,args,expected_err",
     [
-        ("with purge", "--purge-before 2000-01-02", True),
-        ("without purge", "--purge --purge-before 2000-01-02", False),
+        ("without purge", "--purge-before 2000-01-02", True),
+        ("with purge", "--purge --purge-before 2000-01-02", False),
     ],
 )
 @patch("cou.commands.setattr")

--- a/tests/unit/test_commands.py
+++ b/tests/unit/test_commands.py
@@ -530,6 +530,35 @@ def test_parse_args_plan(args, expected_CLIargs):
             ),
         ),
         (
+            ["upgrade", "--purge"],
+            CLIargs(
+                command="upgrade",
+                model_name=None,
+                verbosity=0,
+                quiet=False,
+                auto_approve=False,
+                backup=True,
+                force=False,
+                purge=True,
+                **{"upgrade_group": None}
+            ),
+        ),
+        (
+            ["upgrade", "--purge", "--purge-before", "2000-01-02 03:04:05"],
+            CLIargs(
+                command="upgrade",
+                model_name=None,
+                verbosity=0,
+                quiet=False,
+                auto_approve=False,
+                backup=True,
+                force=False,
+                purge=True,
+                purge_before="2000-01-02 03:04:05",
+                **{"upgrade_group": None}
+            ),
+        ),
+        (
             ["upgrade", "--model=model_name"],
             CLIargs(
                 command="upgrade",

--- a/tests/unit/utils/test_juju_utils.py
+++ b/tests/unit/utils/test_juju_utils.py
@@ -702,6 +702,7 @@ async def test_get_applications(mock_get_machines, mock_get_status, mocked_model
     mocked_model.applications = {app: MagicMock(spec_set=Application)() for app in exp_apps}
 
     for app in exp_apps:
+        mocked_model.applications[app].get_actions = AsyncMock()
         mocked_model.applications[app].get_config = AsyncMock()
         mocked_model.applications[app].units = exp_units[app]
         mocked_model.applications[app].charm_name = app


### PR DESCRIPTION
- Add `--purge` argument, which will run the purge-data action on the nova-cloud-controller as a pre-upgrade step.
- Add `--purge-before-date` argument, which is a argument mapping to `nova-manage db purge --before`. This argument is depends on `--purge` and the datetime format should be *YYYY-MM-DD[HH:mm][:ss]*. 