### PR TITLE
Fix `update-status` hook can be missing in some charms

### DIFF
--- a/cou/apps/base.py
+++ b/cou/apps/base.py
@@ -377,7 +377,7 @@ class OpenStackApplication(Application):
         """
         # NOTE (gabrielcocenza) force the update-status hook on units
         # to update the workload version
-        tasks = [self.model.run_on_unit(unit.name, "hooks/update-status") for unit in units]
+        tasks = [self.model.update_status(unit.name) for unit in units]
         await asyncio.gather(*tasks)
 
         status = await self.model.get_status()

--- a/cou/exceptions.py
+++ b/cou/exceptions.py
@@ -19,6 +19,14 @@ class COUException(Exception):
     """Default COU exception."""
 
 
+class HooksNotFound(COUException):
+    """Exception raised when a hook is not found in the unit."""
+
+
+class DispatchScriptNotFound(COUException):
+    """Exception raised when the dispatch script is not found in the unit."""
+
+
 class CommandRunFailed(COUException):
     """Exception raised when a command fails to run."""
 

--- a/cou/exceptions.py
+++ b/cou/exceptions.py
@@ -19,14 +19,6 @@ class COUException(Exception):
     """Default COU exception."""
 
 
-class HooksNotFound(COUException):
-    """Exception raised when a hook is not found in the unit."""
-
-
-class DispatchScriptNotFound(COUException):
-    """Exception raised when the dispatch script is not found in the unit."""
-
-
 class CommandRunFailed(COUException):
     """Exception raised when a command fails to run."""
 

--- a/cou/utils/juju_utils.py
+++ b/cou/utils/juju_utils.py
@@ -442,6 +442,21 @@ class Model:
         model = await self._get_model()
         return await model.get_status()
 
+    async def update_status(self, unit: str) -> None:
+        """Run the update_status hook on the given unit if the hook exists.
+
+        :param unit: Name of the unit to run update-status hook
+        :type unit: str
+        :raises CommandRunFailed: When update-status hook failed
+        """
+        update_status_hook = "hooks/update-status"
+        try:
+            await self.run_on_unit(unit, f"ls {update_status_hook}")
+        except CommandRunFailed:
+            logger.warning("Skipped running '%s': file does not exist", update_status_hook)
+        else:
+            await self.run_on_unit(unit, update_status_hook)
+
     # NOTE (rgildein): There is no need to add retry here, because we don't want to repeat
     # `unit.run_action(...)` and the rest of the function is covered by retry.
     async def run_action(

--- a/cou/utils/juju_utils.py
+++ b/cou/utils/juju_utils.py
@@ -454,9 +454,7 @@ class Model:
         :type unit_name: str
         :raises CommandRunFailed: When update-status hook failed
         """
-        await self.run_on_unit(  # pragma: no cover
-            unit_name, "JUJU_DISPATCH_PATH=hooks/update-status ./dispatch"
-        )
+        await self.run_on_unit(unit_name, "JUJU_DISPATCH_PATH=hooks/update-status ./dispatch")
 
     async def _run_update_status_hook(self, unit_name: str) -> None:
         """Run the update-status hook directly.
@@ -470,7 +468,7 @@ class Model:
         :type unit_name: str
         :raises CommandRunFailed: When update-status hook failed
         """
-        await self.run_on_unit(unit_name, "hooks/update-status")  # pragma: no cover
+        await self.run_on_unit(unit_name, "hooks/update-status")
 
     async def update_status(self, unit_name: str) -> None:
         """Run the update_status hook on the given unit.

--- a/cou/utils/juju_utils.py
+++ b/cou/utils/juju_utils.py
@@ -453,7 +453,7 @@ class Model:
         try:
             await self.run_on_unit(unit, f"ls {update_status_hook}")
         except CommandRunFailed:
-            logger.warning("Skipped running '%s': file does not exist", update_status_hook)
+            logger.debug("Skipped running '%s': file does not exist", update_status_hook)
         else:
             await self.run_on_unit(unit, update_status_hook)
 

--- a/cou/utils/juju_utils.py
+++ b/cou/utils/juju_utils.py
@@ -442,7 +442,7 @@ class Model:
         model = await self._get_model()
         return await model.get_status()
 
-    async def _dispatch_update_status_hook(self, unit_name: str) -> bool:
+    async def _dispatch_update_status_hook(self, unit_name: str) -> None:
         """Use dispatch to run the update-status hook.
 
         Legacy and reactive charm allows the operators to directly run hooks
@@ -452,19 +452,13 @@ class Model:
 
         :param unit_name: Name of the unit to run update-status hook
         :type unit_name: str
-        :return: True if command succeeded
-        :rtype: bool
         :raises CommandRunFailed: When update-status hook failed
         """
-        try:
-            await self.run_on_unit(unit_name, "JUJU_DISPATCH_PATH=hooks/update-status ./dispatch")
-        except CommandRunFailed as e:
-            if "No such file or directory" in str(e):
-                return False
-            raise e
-        return True
+        await self.run_on_unit(  # pragma: no cover
+            unit_name, "JUJU_DISPATCH_PATH=hooks/update-status ./dispatch"
+        )
 
-    async def _run_update_status_hook(self, unit_name: str) -> bool:
+    async def _run_update_status_hook(self, unit_name: str) -> None:
         """Run the update-status hook directly.
 
         Legacy and reactive charm allows the operators to directly run hooks
@@ -474,17 +468,9 @@ class Model:
 
         :param unit_name: Name of the unit to run update-status hook
         :type unit_name: str
-        :return: True if command succeeded
-        :rtype: bool
         :raises CommandRunFailed: When update-status hook failed
         """
-        try:
-            await self.run_on_unit(unit_name, "hooks/update-status")
-        except CommandRunFailed as e:
-            if "No such file or directory" in str(e):
-                return False
-            raise e
-        return True
+        await self.run_on_unit(unit_name, "hooks/update-status")  # pragma: no cover
 
     async def update_status(self, unit_name: str) -> None:
         """Run the update_status hook on the given unit.
@@ -494,11 +480,21 @@ class Model:
         :raises CommandRunFailed: When update-status hook failed
         """
         # For charm written in operator framework
-        if await self._dispatch_update_status_hook(unit_name):
+        try:
+            await self._dispatch_update_status_hook(unit_name)
+        except CommandRunFailed as e:
+            if "No such file or directory" not in str(e):
+                raise e
+        else:
             return
 
         # For charm written in legacy / reactive framework
-        if await self._run_update_status_hook(unit_name):
+        try:
+            await self._run_update_status_hook(unit_name)
+        except CommandRunFailed as e:
+            if "No such file or directory" not in str(e):
+                raise e
+        else:
             return
 
         logger.debug("Skipped updating status: file does not exist")

--- a/tests/unit/utils/test_juju_utils.py
+++ b/tests/unit/utils/test_juju_utils.py
@@ -445,6 +445,34 @@ async def test_coumodel_run_on_unit_failed_command(mocked_model):
 
 
 @pytest.mark.asyncio
+async def test_coumodel_update_status(mocked_model):
+    """Test Model update_status."""
+    expected_results = {"return-code": 0, "stderr": ""}
+    mocked_model.units.get.return_value = mocked_unit = AsyncMock(Unit)
+    mocked_unit.run.return_value = mocked_action = AsyncMock(Action)
+    mocked_action.results = expected_results
+    model = juju_utils.Model("test-model")
+    await model.update_status("test-unit/0")
+
+    mocked_unit.run.assert_any_await("ls hooks/update-status", timeout=None, block=True)
+    mocked_unit.run.assert_any_await("hooks/update-status", timeout=None, block=True)
+
+
+@pytest.mark.asyncio
+async def test_coumodel_update_status_skipped(mocked_model):
+    """Test skip Model update_status."""
+    expected_results = {"return-code": 2, "stderr": "No such file or directory"}
+    mocked_model.units.get.return_value = mocked_unit = AsyncMock(Unit)
+    mocked_unit.run.return_value = mocked_action = AsyncMock(Action)
+    mocked_action.results = expected_results
+    model = juju_utils.Model("test-model")
+    await model.update_status("test-unit/0")
+
+    mocked_unit.run.assert_awaited_once()
+    mocked_unit.run.assert_awaited_with("ls hooks/update-status", timeout=None, block=True)
+
+
+@pytest.mark.asyncio
 async def test_coumodel_set_application_configs(mocked_model):
     """Test Model set application configuration."""
     test_config = {"test-key": "test-value"}

--- a/tests/unit/utils/test_juju_utils.py
+++ b/tests/unit/utils/test_juju_utils.py
@@ -886,3 +886,27 @@ def test_unit_repr():
 def test_suborinate_unit_repr():
     unit = juju_utils.SubordinateUnit(name="foo/0", charm="foo")
     assert repr(unit) == "foo/0"
+
+
+@pytest.mark.asyncio
+async def test_run_update_status_hook(mocked_model):
+    """Test Model _run_update_status hook."""
+    mocked_model.units.get.return_value = mocked_unit = AsyncMock(Unit)
+    mocked_unit.run.return_value = mocked_action = AsyncMock(Action)
+    mocked_action.results = {"return-code": 0, "stderr": ""}
+    model = juju_utils.Model("test-model")
+    await model._run_update_status_hook(mocked_unit)
+    mocked_unit.run.assert_awaited_once_with("hooks/update-status", timeout=None, block=True)
+
+
+@pytest.mark.asyncio
+async def test_dispatch_update_status_hook(mocked_model):
+    """Test Model _dispatch_update_status hook."""
+    mocked_model.units.get.return_value = mocked_unit = AsyncMock(Unit)
+    mocked_unit.run.return_value = mocked_action = AsyncMock(Action)
+    mocked_action.results = {"return-code": 0, "stderr": ""}
+    model = juju_utils.Model("test-model")
+    await model._dispatch_update_status_hook(mocked_unit)
+    mocked_unit.run.assert_awaited_once_with(
+        "JUJU_DISPATCH_PATH=hooks/update-status ./dispatch", timeout=None, block=True
+    )


### PR DESCRIPTION
Make running `update-status` safer by checking if `hooks/update-status` exists or not before running it.

fixes: #465 