### PR TITLE
Fix purge step

### DIFF
--- a/cou/steps/nova_cloud_controller.py
+++ b/cou/steps/nova_cloud_controller.py
@@ -86,7 +86,7 @@ async def purge(model: Model, before: Optional[str]) -> None:
         raise_on_failure=True,
         action_params=action_params,
     )
-    output = action.data["results"].get("output")
+    output = action.results.get("output")
     if output is None:
         raise COUException(
             "Expected to find output in action results. 'output', but it was not present."


### PR DESCRIPTION
Getting the action output was still using the juju2 api method.

Updating it must have been missed in #444 (add the purge step)
after it was updated with main after #451 (port to juju3) was merged.

Fixes: #488
