### PR TITLE
Add subordinate units information for Application.

### DIFF
--- a/cou/apps/base.py
+++ b/cou/apps/base.py
@@ -115,6 +115,7 @@ class OpenStackApplication(Application):
                 "origin": self.origin,
                 "series": self.series,
                 "subordinate_to": self.subordinate_to,
+                "subordinate_units": self.subordinate_units,
                 "workload_version": self.workload_version,
                 "units": {
                     unit.name: {

--- a/cou/apps/factory.py
+++ b/cou/apps/factory.py
@@ -57,6 +57,7 @@ class AppFactory:
                 series=app.series,
                 subordinate_to=app.subordinate_to,
                 units=app.units,
+                subordinate_units=app.subordinate_units,
                 workload_version=app.workload_version,
                 actions=app.actions,
             )

--- a/cou/utils/juju_utils.py
+++ b/cou/utils/juju_utils.py
@@ -175,7 +175,8 @@ class Application:
     origin: str
     series: str
     subordinate_to: list[str]
-    units: dict[str, Unit]
+    units: dict[str, Unit]  # subordainte apps does not have units, use subodinate_units instead
+    subordinate_units: list[SubordinateUnit]  # this is the units for subordinate apps
     workload_version: str
     actions: dict[str, str] = field(default_factory=lambda: {}, compare=False)
 
@@ -367,6 +368,10 @@ class Model:
         #                 information the status than from objects. e.g. workload_version for unit
         full_status = await self.get_status()
         machines = await self._get_machines()
+        subordinate_units = {
+            SubordinateUnit(name, model.applications[name.split("/")[0]].charm_name)
+            for name in model.subordinate_units
+        }
 
         return {
             app: Application(
@@ -398,6 +403,7 @@ class Model:
                     )
                     for name, unit in status.units.items()
                 },
+                subordinate_units=[su for su in subordinate_units if su.name.split("/")[0] == app],
                 workload_version=status.workload_version,
                 actions=await model.applications[app].get_actions(),
             )

--- a/tests/mocked_plans/sample_plans/018346c5-f95c-46df-a34e-9a78bdec0018.yaml
+++ b/tests/mocked_plans/sample_plans/018346c5-f95c-46df-a34e-9a78bdec0018.yaml
@@ -535,6 +535,7 @@ applications:
     origin: ch
     series: focal
     subordinate_to: []
+    subordinate_units: []
     workload_version: 10.0.0
     units:
       aodh/0:
@@ -635,6 +636,7 @@ applications:
         value: distro
     origin: ch
     series: focal
+    subordinate_units: []
     subordinate_to:
     - aodh
     workload_version: 8.0.32
@@ -749,6 +751,7 @@ applications:
     origin: ch
     series: focal
     subordinate_to: []
+    subordinate_units: []
     workload_version: 14.1.0
     units:
       ceilometer/0:
@@ -818,6 +821,7 @@ applications:
     config: {}
     origin: ch
     series: focal
+    subordinate_units: []
     subordinate_to:
     - nova-compute-kvm
     workload_version: 14.1.0
@@ -1156,6 +1160,7 @@ applications:
     config: {}
     origin: ch
     series: focal
+    subordinate_units: []
     subordinate_to:
     - ceph-mon
     workload_version: ''
@@ -1218,6 +1223,7 @@ applications:
     origin: ch
     series: focal
     subordinate_to: []
+    subordinate_units: []
     workload_version: 15.2.17
     units:
       ceph-mon/0:
@@ -1293,6 +1299,7 @@ applications:
     origin: ch
     series: focal
     subordinate_to: []
+    subordinate_units: []
     workload_version: 15.2.17
     units:
       ceph-osd/0:
@@ -1404,6 +1411,7 @@ applications:
     origin: ch
     series: focal
     subordinate_to: []
+    subordinate_units: []
     workload_version: 15.2.17
     units:
       ceph-radosgw/0:
@@ -1528,6 +1536,7 @@ applications:
     origin: ch
     series: focal
     subordinate_to: []
+    subordinate_units: []
     workload_version: 16.4.2
     units:
       cinder/0:
@@ -1606,6 +1615,7 @@ applications:
     config: {}
     origin: ch
     series: focal
+    subordinate_units: []
     subordinate_to:
     - cinder
     workload_version: 16.4.2
@@ -1671,6 +1681,7 @@ applications:
     config: {}
     origin: ch
     series: focal
+    subordinate_units: []
     subordinate_to:
     - cinder-volume
     workload_version: 16.4.2
@@ -2009,6 +2020,7 @@ applications:
     config: {}
     origin: ch
     series: focal
+    subordinate_units: []
     subordinate_to:
     - cinder-volume
     workload_version: 16.4.2
@@ -2347,6 +2359,7 @@ applications:
     config: {}
     origin: ch
     series: focal
+    subordinate_units: []
     subordinate_to:
     - cinder-volume
     workload_version: 16.4.2
@@ -2713,6 +2726,7 @@ applications:
         value: distro
     origin: ch
     series: focal
+    subordinate_units: []
     subordinate_to:
     - cinder
     workload_version: 8.0.32
@@ -2833,6 +2847,7 @@ applications:
     origin: ch
     series: focal
     subordinate_to: []
+    subordinate_units: []
     workload_version: 16.4.2
     units:
       cinder-volume/0:
@@ -3257,6 +3272,7 @@ applications:
         value: distro
     origin: ch
     series: focal
+    subordinate_units: []
     subordinate_to:
     - cinder-volume
     workload_version: 8.0.32
@@ -3627,6 +3643,7 @@ applications:
     origin: ch
     series: focal
     subordinate_to: []
+    subordinate_units: []
     workload_version: 10.0.2
     units:
       designate/1:
@@ -3703,6 +3720,7 @@ applications:
     origin: ch
     series: focal
     subordinate_to: []
+    subordinate_units: []
     workload_version: 9.16.48
     units:
       designate-bind/0:
@@ -3799,6 +3817,7 @@ applications:
         value: distro
     origin: ch
     series: focal
+    subordinate_units: []
     subordinate_to:
     - designate
     workload_version: 8.0.32
@@ -3916,6 +3935,7 @@ applications:
     origin: ch
     series: focal
     subordinate_to: []
+    subordinate_units: []
     workload_version: 20.2.0
     units:
       glance/0:
@@ -4019,6 +4039,7 @@ applications:
         value: distro
     origin: ch
     series: focal
+    subordinate_units: []
     subordinate_to:
     - glance
     workload_version: 8.0.32
@@ -4086,6 +4107,7 @@ applications:
     origin: ch
     series: focal
     subordinate_to: []
+    subordinate_units: []
     workload_version: ''
     units:
       glance-simplestreams-sync/0:
@@ -4149,6 +4171,7 @@ applications:
     origin: ch
     series: focal
     subordinate_to: []
+    subordinate_units: []
     workload_version: 4.3.4
     units:
       gnocchi/0:
@@ -4249,6 +4272,7 @@ applications:
         value: distro
     origin: ch
     series: focal
+    subordinate_units: []
     subordinate_to:
     - gnocchi
     workload_version: 8.0.32
@@ -4308,6 +4332,7 @@ applications:
     config: {}
     origin: ch
     series: focal
+    subordinate_units: []
     subordinate_to:
     - aodh
     - nrpe-container
@@ -4368,6 +4393,7 @@ applications:
     config: {}
     origin: ch
     series: focal
+    subordinate_units: []
     subordinate_to:
     - ceilometer
     - nrpe-container
@@ -4425,6 +4451,7 @@ applications:
     config: {}
     origin: ch
     series: focal
+    subordinate_units: []
     subordinate_to:
     - cinder
     - nrpe-container
@@ -4491,6 +4518,7 @@ applications:
     config: {}
     origin: ch
     series: focal
+    subordinate_units: []
     subordinate_to:
     - designate
     - nrpe-container
@@ -4554,6 +4582,7 @@ applications:
     config: {}
     origin: ch
     series: focal
+    subordinate_units: []
     subordinate_to:
     - glance
     - nrpe-container
@@ -4617,6 +4646,7 @@ applications:
     config: {}
     origin: ch
     series: focal
+    subordinate_units: []
     subordinate_to:
     - gnocchi
     - nrpe-container
@@ -4677,6 +4707,7 @@ applications:
     config: {}
     origin: ch
     series: focal
+    subordinate_units: []
     subordinate_to:
     - heat
     - nrpe-container
@@ -4740,6 +4771,7 @@ applications:
     config: {}
     origin: ch
     series: focal
+    subordinate_units: []
     subordinate_to:
     - nrpe-container
     - openstack-dashboard
@@ -4806,6 +4838,7 @@ applications:
     config: {}
     origin: ch
     series: focal
+    subordinate_units: []
     subordinate_to:
     - keystone
     - nrpe-container
@@ -4872,6 +4905,7 @@ applications:
     config: {}
     origin: ch
     series: focal
+    subordinate_units: []
     subordinate_to:
     - neutron-api
     - nrpe-container
@@ -4935,6 +4969,7 @@ applications:
     config: {}
     origin: ch
     series: focal
+    subordinate_units: []
     subordinate_to:
     - nova-cloud-controller
     - nrpe-container
@@ -4998,6 +5033,7 @@ applications:
     config: {}
     origin: ch
     series: focal
+    subordinate_units: []
     subordinate_to:
     - nrpe-container
     - octavia
@@ -5064,6 +5100,7 @@ applications:
     config: {}
     origin: ch
     series: focal
+    subordinate_units: []
     subordinate_to:
     - nrpe-container
     - placement
@@ -5124,6 +5161,7 @@ applications:
     config: {}
     origin: ch
     series: focal
+    subordinate_units: []
     subordinate_to:
     - ceph-radosgw
     - nrpe-container
@@ -5181,6 +5219,7 @@ applications:
     config: {}
     origin: ch
     series: focal
+    subordinate_units: []
     subordinate_to:
     - nrpe-host
     - vault
@@ -5293,6 +5332,7 @@ applications:
     origin: ch
     series: focal
     subordinate_to: []
+    subordinate_units: []
     workload_version: 14.2.0
     units:
       heat/0:
@@ -5396,6 +5436,7 @@ applications:
         value: distro
     origin: ch
     series: focal
+    subordinate_units: []
     subordinate_to:
     - heat
     workload_version: 8.0.32
@@ -5521,6 +5562,7 @@ applications:
     origin: ch
     series: focal
     subordinate_to: []
+    subordinate_units: []
     workload_version: 17.0.1
     units:
       keystone/0:
@@ -5599,6 +5641,7 @@ applications:
     config: {}
     origin: ch
     series: focal
+    subordinate_units: []
     subordinate_to:
     - keystone
     workload_version: 17.0.1
@@ -5692,6 +5735,7 @@ applications:
         value: distro
     origin: ch
     series: focal
+    subordinate_units: []
     subordinate_to:
     - keystone
     workload_version: 8.0.32
@@ -5777,6 +5821,7 @@ applications:
     origin: ch
     series: focal
     subordinate_to: []
+    subordinate_units: []
     workload_version: 3.8.2
     units:
       landscape-rabbitmq-server/0:
@@ -5872,6 +5917,7 @@ applications:
     origin: ch
     series: focal
     subordinate_to: []
+    subordinate_units: []
     workload_version: 8.0.32
     units:
       mysql-innodb-cluster/0:
@@ -5990,6 +6036,7 @@ applications:
     origin: ch
     series: focal
     subordinate_to: []
+    subordinate_units: []
     workload_version: 16.4.2
     units:
       neutron-api/0:
@@ -6093,6 +6140,7 @@ applications:
         value: distro
     origin: ch
     series: focal
+    subordinate_units: []
     subordinate_to:
     - neutron-api
     workload_version: 8.0.32
@@ -6166,6 +6214,7 @@ applications:
         value: false
     origin: ch
     series: focal
+    subordinate_units: []
     subordinate_to:
     - nova-compute-kvm
     workload_version: 16.4.2
@@ -6515,6 +6564,7 @@ applications:
         value: true
     origin: ch
     series: focal
+    subordinate_units: []
     subordinate_to:
     - octavia
     workload_version: 16.4.2
@@ -6635,6 +6685,7 @@ applications:
     origin: ch
     series: focal
     subordinate_to: []
+    subordinate_units: []
     workload_version: 21.2.4
     units:
       nova-cloud-controller/0:
@@ -6744,6 +6795,7 @@ applications:
     origin: ch
     series: focal
     subordinate_to: []
+    subordinate_units: []
     workload_version: 21.2.4
     units:
       nova-compute-kvm/0:
@@ -7215,6 +7267,7 @@ applications:
         value: distro
     origin: ch
     series: focal
+    subordinate_units: []
     subordinate_to:
     - nova-cloud-controller
     workload_version: 8.0.32
@@ -7309,6 +7362,7 @@ applications:
     origin: ch
     series: focal
     subordinate_to: []
+    subordinate_units: []
     workload_version: 6.2.2
     units:
       octavia/10:
@@ -7387,6 +7441,7 @@ applications:
     config: {}
     origin: ch
     series: focal
+    subordinate_units: []
     subordinate_to:
     - openstack-dashboard
     workload_version: 5.0.0
@@ -7452,6 +7507,7 @@ applications:
     config: {}
     origin: ch
     series: focal
+    subordinate_units: []
     subordinate_to:
     - glance-simplestreams-sync
     workload_version: 0.9.12
@@ -7508,6 +7564,7 @@ applications:
         value: distro
     origin: ch
     series: focal
+    subordinate_units: []
     subordinate_to:
     - octavia
     workload_version: 8.0.32
@@ -7628,6 +7685,7 @@ applications:
     origin: ch
     series: focal
     subordinate_to: []
+    subordinate_units: []
     workload_version: 18.3.5
     units:
       openstack-dashboard/0:
@@ -7734,6 +7792,7 @@ applications:
         value: distro
     origin: ch
     series: focal
+    subordinate_units: []
     subordinate_to:
     - openstack-dashboard
     workload_version: 8.0.32
@@ -7831,6 +7890,7 @@ applications:
     origin: ch
     series: focal
     subordinate_to: []
+    subordinate_units: []
     workload_version: 3.0.1
     units:
       placement/3:
@@ -7931,6 +7991,7 @@ applications:
         value: distro
     origin: ch
     series: focal
+    subordinate_units: []
     subordinate_to:
     - placement
     workload_version: 8.0.32
@@ -8011,6 +8072,7 @@ applications:
     origin: ch
     series: focal
     subordinate_to: []
+    subordinate_units: []
     workload_version: 3.8.2
     units:
       rabbitmq-server/0:
@@ -8102,6 +8164,7 @@ applications:
         value: distro
     origin: ch
     series: focal
+    subordinate_units: []
     subordinate_to:
     - vault
     workload_version: 8.0.32

--- a/tests/mocked_plans/sample_plans/9eb9af6a-b919-4cf9-8f2f-9df16a1556be.yaml
+++ b/tests/mocked_plans/sample_plans/9eb9af6a-b919-4cf9-8f2f-9df16a1556be.yaml
@@ -470,6 +470,7 @@ applications:
         value: distro
     origin: ch
     series: focal
+    subordinate_units: []
     subordinate_to: []
     workload_version: 3.8.2
     units:
@@ -540,6 +541,7 @@ applications:
         value: distro
     origin: ch
     series: focal
+    subordinate_units: []
     subordinate_to: []
     workload_version: 15.2.16
     units:
@@ -666,6 +668,7 @@ applications:
         value: distro
     origin: ch
     series: focal
+    subordinate_units: []
     subordinate_to: []
     workload_version: 17.0.1
     units:
@@ -770,6 +773,7 @@ applications:
         value: distro
     origin: ch
     series: focal
+    subordinate_units: []
     subordinate_to: []
     workload_version: 10.0.0
     units:
@@ -871,6 +875,7 @@ applications:
         value: distro
     origin: ch
     series: focal
+    subordinate_units: []
     subordinate_to: []
     workload_version: 10.1.0
     units:
@@ -998,6 +1003,7 @@ applications:
         value: distro
     origin: ch
     series: focal
+    subordinate_units: []
     subordinate_to: []
     workload_version: 14.1.0
     units:
@@ -1100,6 +1106,7 @@ applications:
         value: distro
     origin: ch
     series: focal
+    subordinate_units: []
     subordinate_to: []
     workload_version: 15.2.16
     units:
@@ -1221,6 +1228,7 @@ applications:
         value: distro
     origin: ch
     series: focal
+    subordinate_units: []
     subordinate_to: []
     workload_version: 16.4.2
     units:
@@ -1325,6 +1333,7 @@ applications:
         value: distro
     origin: ch
     series: focal
+    subordinate_units: []
     subordinate_to: []
     workload_version: 10.0.2
     units:
@@ -1395,6 +1404,7 @@ applications:
     config: {}
     origin: ch
     series: focal
+    subordinate_units: []
     subordinate_to: []
     workload_version: 9.16.1
     units:
@@ -1500,6 +1510,7 @@ applications:
         value: distro
     origin: ch
     series: focal
+    subordinate_units: []
     subordinate_to: []
     workload_version: 20.2.0
     units:
@@ -1601,6 +1612,7 @@ applications:
         value: distro
     origin: ch
     series: focal
+    subordinate_units: []
     subordinate_to: []
     workload_version: 4.3.4
     units:
@@ -1725,6 +1737,7 @@ applications:
         value: distro
     origin: ch
     series: focal
+    subordinate_units: []
     subordinate_to: []
     workload_version: 14.2.0
     units:
@@ -1849,6 +1862,7 @@ applications:
         value: distro
     origin: ch
     series: focal
+    subordinate_units: []
     subordinate_to: []
     workload_version: 16.4.2
     units:
@@ -1945,6 +1959,7 @@ applications:
         value: distro
     origin: ch
     series: focal
+    subordinate_units: []
     subordinate_to: []
     workload_version: 22.03.2
     units:
@@ -2037,6 +2052,7 @@ applications:
         value: distro
     origin: ch
     series: focal
+    subordinate_units: []
     subordinate_to: []
     workload_version: 3.0.1
     units:
@@ -2161,6 +2177,7 @@ applications:
         value: distro
     origin: ch
     series: focal
+    subordinate_units: []
     subordinate_to: []
     workload_version: 21.2.4
     units:
@@ -2285,6 +2302,7 @@ applications:
         value: distro
     origin: ch
     series: focal
+    subordinate_units: []
     subordinate_to: []
     workload_version: 18.3.5
     units:
@@ -2389,6 +2407,7 @@ applications:
         value: distro
     origin: ch
     series: focal
+    subordinate_units: []
     subordinate_to: []
     workload_version: 6.2.2
     units:
@@ -2462,6 +2481,7 @@ applications:
     config: {}
     origin: ch
     series: focal
+    subordinate_units: []
     subordinate_to:
     - barbican
     workload_version: 3.0.1
@@ -2521,6 +2541,7 @@ applications:
     config: {}
     origin: ch
     series: focal
+    subordinate_units: []
     subordinate_to:
     - ceph-mon
     workload_version: ''
@@ -2571,6 +2592,7 @@ applications:
     config: {}
     origin: ch
     series: focal
+    subordinate_units: []
     subordinate_to:
     - cinder
     workload_version: 16.4.2
@@ -2634,6 +2656,7 @@ applications:
         type: string
     origin: ch
     series: focal
+    subordinate_units: []
     subordinate_to: []
     workload_version: ''
     units:
@@ -2664,6 +2687,7 @@ applications:
     config: {}
     origin: ch
     series: focal
+    subordinate_units: []
     subordinate_to:
     - heat
     - nrpe
@@ -2721,6 +2745,7 @@ applications:
     config: {}
     origin: ch
     series: focal
+    subordinate_units: []
     subordinate_to:
     - nrpe
     - placement
@@ -2778,6 +2803,7 @@ applications:
     config: {}
     origin: ch
     series: focal
+    subordinate_units: []
     subordinate_to:
     - nrpe
     - openstack-dashboard
@@ -2838,6 +2864,7 @@ applications:
     config: {}
     origin: ch
     series: focal
+    subordinate_units: []
     subordinate_to:
     - ceilometer
     - nrpe
@@ -2892,6 +2919,7 @@ applications:
     config: {}
     origin: ch
     series: focal
+    subordinate_units: []
     subordinate_to:
     - barbican
     - nrpe
@@ -2952,6 +2980,7 @@ applications:
     config: {}
     origin: ch
     series: focal
+    subordinate_units: []
     subordinate_to:
     - openstack-loadbalancer
     workload_version: ''
@@ -2999,6 +3028,7 @@ applications:
     config: {}
     origin: ch
     series: focal
+    subordinate_units: []
     subordinate_to:
     - nrpe
     - octavia
@@ -3059,6 +3089,7 @@ applications:
     config: {}
     origin: ch
     series: focal
+    subordinate_units: []
     subordinate_to:
     - nrpe
     - vault
@@ -3119,6 +3150,7 @@ applications:
     config: {}
     origin: ch
     series: focal
+    subordinate_units: []
     subordinate_to:
     - nova-cloud-controller
     - nrpe
@@ -3176,6 +3208,7 @@ applications:
     config: {}
     origin: ch
     series: focal
+    subordinate_units: []
     subordinate_to:
     - designate
     - nrpe
@@ -3233,6 +3266,7 @@ applications:
     config: {}
     origin: ch
     series: focal
+    subordinate_units: []
     subordinate_to:
     - gnocchi
     - nrpe
@@ -3290,6 +3324,7 @@ applications:
     config: {}
     origin: ch
     series: focal
+    subordinate_units: []
     subordinate_to:
     - aodh
     - nrpe
@@ -3347,6 +3382,7 @@ applications:
     config: {}
     origin: ch
     series: focal
+    subordinate_units: []
     subordinate_to:
     - ceph-radosgw
     - nrpe
@@ -3401,6 +3437,7 @@ applications:
     config: {}
     origin: ch
     series: focal
+    subordinate_units: []
     subordinate_to:
     - keystone
     - nrpe
@@ -3461,6 +3498,7 @@ applications:
     config: {}
     origin: ch
     series: focal
+    subordinate_units: []
     subordinate_to:
     - glance
     - nrpe
@@ -3518,6 +3556,7 @@ applications:
     config: {}
     origin: ch
     series: focal
+    subordinate_units: []
     subordinate_to:
     - cinder
     - nrpe
@@ -3578,6 +3617,7 @@ applications:
     config: {}
     origin: ch
     series: focal
+    subordinate_units: []
     subordinate_to:
     - neutron-api
     - nrpe
@@ -3638,6 +3678,7 @@ applications:
     config: {}
     origin: ch
     series: focal
+    subordinate_units: []
     subordinate_to:
     - keystone
     workload_version: 17.0.1
@@ -3725,6 +3766,7 @@ applications:
         value: distro
     origin: ch
     series: focal
+    subordinate_units: []
     subordinate_to: []
     workload_version: 8.0.30
     units:
@@ -3817,6 +3859,7 @@ applications:
         value: distro
     origin: ch
     series: focal
+    subordinate_units: []
     subordinate_to:
     - nova-cloud-controller
     workload_version: 8.0.30
@@ -3901,6 +3944,7 @@ applications:
         value: distro
     origin: ch
     series: focal
+    subordinate_units: []
     subordinate_to:
     - heat
     workload_version: 8.0.30
@@ -3985,6 +4029,7 @@ applications:
         value: distro
     origin: ch
     series: focal
+    subordinate_units: []
     subordinate_to:
     - designate
     workload_version: 8.0.30
@@ -4069,6 +4114,7 @@ applications:
         value: distro
     origin: ch
     series: focal
+    subordinate_units: []
     subordinate_to:
     - placement
     workload_version: 8.0.30
@@ -4153,6 +4199,7 @@ applications:
         value: distro
     origin: ch
     series: focal
+    subordinate_units: []
     subordinate_to:
     - vault
     workload_version: 8.0.30
@@ -4240,6 +4287,7 @@ applications:
         value: distro
     origin: ch
     series: focal
+    subordinate_units: []
     subordinate_to:
     - openstack-dashboard
     workload_version: 8.0.31
@@ -4327,6 +4375,7 @@ applications:
         value: distro
     origin: ch
     series: focal
+    subordinate_units: []
     subordinate_to:
     - glance
     workload_version: 8.0.30
@@ -4411,6 +4460,7 @@ applications:
         value: distro
     origin: ch
     series: focal
+    subordinate_units: []
     subordinate_to:
     - keystone
     workload_version: 8.0.30
@@ -4498,6 +4548,7 @@ applications:
         value: distro
     origin: ch
     series: focal
+    subordinate_units: []
     subordinate_to:
     - neutron-api
     workload_version: 8.0.30
@@ -4585,6 +4636,7 @@ applications:
         value: distro
     origin: ch
     series: focal
+    subordinate_units: []
     subordinate_to:
     - aodh
     workload_version: 8.0.30
@@ -4669,6 +4721,7 @@ applications:
         value: distro
     origin: ch
     series: focal
+    subordinate_units: []
     subordinate_to:
     - cinder
     workload_version: 8.0.30
@@ -4756,6 +4809,7 @@ applications:
         value: distro
     origin: ch
     series: focal
+    subordinate_units: []
     subordinate_to:
     - gnocchi
     workload_version: 8.0.35
@@ -4840,6 +4894,7 @@ applications:
         value: distro
     origin: ch
     series: focal
+    subordinate_units: []
     subordinate_to:
     - octavia
     workload_version: 8.0.30
@@ -4927,6 +4982,7 @@ applications:
         value: distro
     origin: ch
     series: focal
+    subordinate_units: []
     subordinate_to:
     - barbican
     workload_version: 8.0.30
@@ -4986,6 +5042,7 @@ applications:
     config: {}
     origin: ch
     series: focal
+    subordinate_units: []
     subordinate_to:
     - neutron-api
     workload_version: 16.4.2
@@ -5045,6 +5102,7 @@ applications:
     config: {}
     origin: ch
     series: focal
+    subordinate_units: []
     subordinate_to:
     - openstack-dashboard
     workload_version: 5.0.0
@@ -5104,6 +5162,7 @@ applications:
     config: {}
     origin: ch
     series: focal
+    subordinate_units: []
     subordinate_to:
     - glance-simplestreams-sync
     workload_version: 0.9.12
@@ -5141,6 +5200,7 @@ applications:
         value: true
     origin: ch
     series: focal
+    subordinate_units: []
     subordinate_to:
     - octavia
     workload_version: 22.03.2
@@ -5200,6 +5260,7 @@ applications:
     config: {}
     origin: ch
     series: focal
+    subordinate_units: []
     subordinate_to: []
     workload_version: 1.7.9
     units:
@@ -5306,6 +5367,7 @@ applications:
         value: distro
     origin: ch
     series: focal
+    subordinate_units: []
     subordinate_to: []
     workload_version: 21.2.4
     units:
@@ -5624,6 +5686,7 @@ applications:
         value: distro
     origin: ch
     series: focal
+    subordinate_units: []
     subordinate_to: []
     workload_version: 15.2.16
     units:
@@ -5898,6 +5961,7 @@ applications:
     config: {}
     origin: ch
     series: focal
+    subordinate_units: []
     subordinate_to:
     - nova-compute
     workload_version: 14.1.0
@@ -6139,6 +6203,7 @@ applications:
         value: true
     origin: ch
     series: focal
+    subordinate_units: []
     subordinate_to:
     - nova-compute
     workload_version: 22.03.2

--- a/tests/mocked_plans/sample_plans/base.yaml
+++ b/tests/mocked_plans/sample_plans/base.yaml
@@ -62,6 +62,7 @@ applications:
     origin: ch
     series: focal
     subordinate_to: []
+    subordinate_units: []
     workload_version: 17.0.1
     units:
       keystone/0:
@@ -84,6 +85,7 @@ applications:
     series: focal
     subordinate_to:
     - keystone
+    subordinate_units: []
     workload_version: 17.0.1
     units: {}
     machines:
@@ -101,6 +103,7 @@ applications:
         value: distro
     origin: ch
     series: focal
+    subordinate_units: []
     subordinate_to: []
     workload_version: 15.2.0
     units:
@@ -127,6 +130,7 @@ applications:
     origin: ch
     series: focal
     subordinate_to: []
+    subordinate_units: []
     workload_version: 21.0.0
     units:
       nova-compute/0:
@@ -153,8 +157,10 @@ applications:
         value: false
     origin: ch
     series: focal
+    subordinate_units: []
     subordinate_to:
     - nova-compute
+    subordinate_units: []
     workload_version: '22.3'
     units: {}
     machines:

--- a/tests/mocked_plans/utils.py
+++ b/tests/mocked_plans/utils.py
@@ -63,6 +63,7 @@ def parse_sample_plan_file(source: Path) -> tuple[Model, str]:
             origin=app_data["origin"],
             series=app_data["series"],
             subordinate_to=app_data["subordinate_to"],
+            subordinate_units=app_data["subordinate_units"],
             units={
                 name: Unit(
                     name,

--- a/tests/unit/apps/test_auxiliary.py
+++ b/tests/unit/apps/test_auxiliary.py
@@ -57,6 +57,7 @@ def test_auxiliary_app(model):
         origin="ch",
         series="focal",
         subordinate_to=[],
+        subordinate_units=[],
         units={
             "rabbitmq-server/0": Unit(
                 name="rabbitmq-server/0",
@@ -93,6 +94,7 @@ def test_auxiliary_app_cs(model):
         origin="cs",
         series="focal",
         subordinate_to=[],
+        subordinate_units=[],
         units={
             "rabbitmq-server/0": Unit(
                 name="rabbitmq-server/0",
@@ -132,6 +134,7 @@ def test_auxiliary_upgrade_plan_ussuri_to_victoria_change_channel(model):
         origin="ch",
         series="focal",
         subordinate_to=[],
+        subordinate_units=[],
         units={
             "rabbitmq-server/0": Unit(
                 name="rabbitmq-server/0",
@@ -213,6 +216,7 @@ def test_auxiliary_upgrade_plan_ussuri_to_victoria(model):
         origin="ch",
         series="focal",
         subordinate_to=[],
+        subordinate_units=[],
         units={
             "rabbitmq-server/0": Unit(
                 name="rabbitmq-server/0",
@@ -287,6 +291,7 @@ def test_auxiliary_upgrade_plan_ussuri_to_victoria_ch_migration(model):
         origin="cs",
         series="focal",
         subordinate_to=[],
+        subordinate_units=[],
         units={
             "rabbitmq-server/0": Unit(
                 name="rabbitmq-server/0",
@@ -360,6 +365,7 @@ def test_rabbitmq_server_upgrade_plan_ussuri_to_victoria_auto_restart_False(mode
         origin="ch",
         series="focal",
         subordinate_to=[],
+        subordinate_units=[],
         units={
             "rabbitmq-server/0": Unit(
                 name="rabbitmq-server/0",
@@ -467,6 +473,7 @@ def test_auxiliary_upgrade_plan_unknown_track(model):
         origin="ch",
         series="focal",
         subordinate_to=[],
+        subordinate_units=[],
         units={
             "rabbitmq-server/0": Unit(
                 name="rabbitmq-server/0",
@@ -500,6 +507,7 @@ def test_auxiliary_app_unknown_version_raise_ApplicationError(model):
         origin="ch",
         series="focal",
         subordinate_to=[],
+        subordinate_units=[],
         units={unit.name: unit},
         workload_version=version,
     )
@@ -525,6 +533,7 @@ def test_auxiliary_raise_error_unknown_series(model):
         origin="ch",
         series=series,
         subordinate_to=[],
+        subordinate_units=[],
         units={
             "rabbitmq-server/0": Unit(
                 name="rabbitmq-server/0",
@@ -563,6 +572,7 @@ def test_auxiliary_raise_error_o7k_not_on_lookup(o7k_release, model):
         origin="ch",
         series="focal",
         subordinate_to=[],
+        subordinate_units=[],
         units={
             "rabbitmq-server/0": Unit(
                 name="rabbitmq-server/0",
@@ -600,6 +610,7 @@ def test_auxiliary_raise_halt_upgrade(model):
         origin="ch",
         series="focal",
         subordinate_to=[],
+        subordinate_units=[],
         units={
             f"{charm}/0": Unit(
                 name=f"{charm}/0",
@@ -636,6 +647,7 @@ def test_auxiliary_no_origin_setting_raise_halt_upgrade(model):
         origin="ch",
         series="focal",
         subordinate_to=[],
+        subordinate_units=[],
         units={
             f"{charm}/0": Unit(
                 name=f"{charm}/0",
@@ -687,6 +699,7 @@ def test_auxiliary_no_suitable_channel(model):
         origin="ch",
         series="focal",
         subordinate_to=[],
+        subordinate_units=[],
         units={
             f"{charm}/0": Unit(
                 name=f"{charm}/0",
@@ -716,6 +729,7 @@ def test_ceph_mon_app(model):
         origin="ch",
         series="focal",
         subordinate_to=[],
+        subordinate_units=[],
         units={
             f"{charm}/0": Unit(
                 name=f"{charm}/0",
@@ -750,6 +764,7 @@ def test_ceph_mon_upgrade_plan_xena_to_yoga(model):
         origin="ch",
         series="focal",
         subordinate_to=[],
+        subordinate_units=[],
         units={
             f"{charm}/0": Unit(
                 name=f"{charm}/0",
@@ -835,6 +850,7 @@ def test_ceph_mon_upgrade_plan_ussuri_to_victoria(model):
         origin="ch",
         series="focal",
         subordinate_to=[],
+        subordinate_units=[],
         units={
             f"{charm}/0": Unit(
                 name=f"{charm}/0",
@@ -912,6 +928,7 @@ def test_ovn_principal(model):
         origin="ch",
         series="focal",
         subordinate_to=[],
+        subordinate_units=[],
         units={
             f"{charm}/0": Unit(
                 name=f"{charm}/0",
@@ -951,6 +968,7 @@ def test_ovn_workload_ver_lower_than_22_principal(model):
         origin="ch",
         series="focal",
         subordinate_to=[],
+        subordinate_units=[],
         units={
             f"{charm}/0": Unit(
                 name=f"{charm}/0",
@@ -982,6 +1000,7 @@ def test_ovn_version_pinning_principal(model):
         origin="ch",
         series="focal",
         subordinate_to=[],
+        subordinate_units=[],
         units={
             f"{charm}/0": Unit(
                 name=f"{charm}/0",
@@ -1020,6 +1039,7 @@ def test_ovn_no_compatible_o7k_release(channel, model):
             origin="ch",
             series="focal",
             subordinate_to=[],
+            subordinate_units=[],
             units={
                 f"{charm}/0": Unit(
                     name=f"{charm}/0",
@@ -1056,6 +1076,7 @@ def test_ovn_check_version_pinning_version_pinning_config_False(app, config, mod
         origin="ch",
         series="focal",
         subordinate_to=[],
+        subordinate_units=[],
         units={
             f"{app}/0": Unit(
                 name=f"{app}/0",
@@ -1081,6 +1102,7 @@ def test_ovn_check_version_pinning_version_pinning_config_True(model):
         origin="ch",
         series="focal",
         subordinate_to=[],
+        subordinate_units=[],
         units={
             "ovn-dedicated-chassis/0": Unit(
                 name="ovn-dedicated-chassis/0",
@@ -1111,6 +1133,7 @@ def test_ovn_principal_upgrade_plan(model):
         origin="ch",
         series="focal",
         subordinate_to=[],
+        subordinate_units=[],
         units={
             f"{charm}/0": Unit(
                 name=f"{charm}/0",
@@ -1187,6 +1210,7 @@ def test_mysql_innodb_cluster_upgrade(model):
         origin="ch",
         series="focal",
         subordinate_to=[],
+        subordinate_units=[],
         units={
             f"{charm}/0": Unit(
                 name=f"{charm}/0",
@@ -1261,6 +1285,7 @@ def test_ceph_osd_pre_upgrade_steps(mock_pre_upgrade_steps, target, model):
         origin="ch",
         series="focal",
         subordinate_to=[],
+        subordinate_units=[],
         units={
             f"ceph-osd/{i}": Unit(
                 name=f"ceph-osd/{i}",
@@ -1299,6 +1324,7 @@ async def test_ceph_osd_verify_nova_compute_no_app(model):
         origin="ch",
         series="focal",
         subordinate_to=[],
+        subordinate_units=[],
         units={
             f"ceph-osd/{i}": Unit(
                 name=f"ceph-osd/{i}",
@@ -1333,6 +1359,7 @@ def test_auxiliary_upgrade_by_unit(mock_super, model):
         origin="ch",
         series="focal",
         subordinate_to=[],
+        subordinate_units=[],
         units={
             f"{charm}/0": Unit(
                 name=f"{charm}/0",
@@ -1381,6 +1408,7 @@ async def test_ceph_osd_verify_nova_compute_pass(mock_lookup, model):
         origin="ch",
         series="focal",
         subordinate_to=[],
+        subordinate_units=[],
         units={
             f"ceph-osd/{i}": Unit(
                 name=f"ceph-osd/{i}",
@@ -1420,6 +1448,7 @@ async def test_ceph_osd_verify_nova_compute_fail(mock_lookup, model):
         origin="ch",
         series="focal",
         subordinate_to=[],
+        subordinate_units=[],
         units={
             f"ceph-osd/{i}": Unit(
                 name=f"ceph-osd/{i}",
@@ -1465,6 +1494,7 @@ def test_ceph_osd_upgrade_plan(model):
         origin="ch",
         series="focal",
         subordinate_to=[],
+        subordinate_units=[],
         units={
             f"ceph-osd/{i}": Unit(
                 name=f"ceph-osd/{i}",
@@ -1515,7 +1545,19 @@ def test_need_current_channel_refresh_auxiliary(
     target = OpenStackRelease("victoria")
     app_name = "app"
     app = AuxiliaryApplication(
-        app_name, can_upgrade_to, app_name, "3.9/stable", {}, {}, model, "ch", "focal", [], {}, "1"
+        app_name,
+        can_upgrade_to,
+        app_name,
+        "3.9/stable",
+        {},
+        {},
+        model,
+        "ch",
+        "focal",
+        [],
+        {},
+        [],
+        "1",
     )
     assert app._need_current_channel_refresh(target) is exp_result
 
@@ -1545,6 +1587,7 @@ def test_expected_current_channel_auxiliary(mock_o7k_release, model, channel, or
         origin=origin,
         series="focal",
         subordinate_to=[],
+        subordinate_units=[],
         units={},
         workload_version="15.2.0",
     )
@@ -1568,6 +1611,7 @@ def test_auxiliary_wrong_channel(model):
         origin="ch",
         series="focal",
         subordinate_to=[],
+        subordinate_units=[],
         units={
             f"{charm}/0": Unit(
                 name=f"{charm}/0",

--- a/tests/unit/apps/test_auxiliary_subordinate.py
+++ b/tests/unit/apps/test_auxiliary_subordinate.py
@@ -22,6 +22,7 @@ from cou.apps.auxiliary_subordinate import (
 )
 from cou.exceptions import ApplicationError, HaltUpgradePlanGeneration
 from cou.steps import ApplicationUpgradePlan, PreUpgradeStep, UpgradeStep
+from cou.utils.juju_utils import SubordinateUnit
 from cou.utils.openstack import OpenStackRelease
 from tests.unit.utils import assert_steps, dedent_plan, generate_cou_machine
 
@@ -40,6 +41,7 @@ def test_auxiliary_subordinate(model):
         origin="ch",
         series="focal",
         subordinate_to=["keystone"],
+        subordinate_units=[SubordinateUnit("keystone-mysql-router/0", "mysql-router")],
         units={},
         workload_version="8.0",
     )
@@ -69,6 +71,7 @@ def test_auxiliary_subordinate_upgrade_plan_to_victoria(model):
         origin="ch",
         series="focal",
         subordinate_to=["keystone"],
+        subordinate_units=[SubordinateUnit("keystone-mysql-router/0", "mysql-router")],
         units={},
         workload_version="8.0",
     )
@@ -101,6 +104,7 @@ def test_ovn_subordinate(model):
         origin="ch",
         series="focal",
         subordinate_to=["nova-compute"],
+        subordinate_units=[SubordinateUnit("ovn-chassis/0", "ovn-chassis")],
         units={},
         workload_version="22.3",
     )
@@ -135,6 +139,7 @@ def test_ovn_workload_ver_lower_than_22_subordinate(model):
         origin="ch",
         series="focal",
         subordinate_to=["nova-compute"],
+        subordinate_units=[SubordinateUnit("ovn-chassisr/0", "ovn-chassis")],
         units={},
         workload_version="20.3",
     )
@@ -160,6 +165,7 @@ def test_ovn_version_pinning_subordinate(model):
         origin="ch",
         series="focal",
         subordinate_to=["nova-compute"],
+        subordinate_units=[SubordinateUnit("ovn-chassisr/0", "ovn-chassis")],
         units={},
         workload_version="22.3",
     )
@@ -183,6 +189,7 @@ def test_ovn_subordinate_upgrade_plan(model):
         origin="ch",
         series="focal",
         subordinate_to=["nova-compute"],
+        subordinate_units=[SubordinateUnit("ovn-chassisr/0", "ovn-chassis")],
         units={},
         workload_version="22.3",
     )
@@ -227,6 +234,7 @@ def test_ovn_subordinate_upgrade_plan_cant_upgrade_charm(model):
         origin="ch",
         series="focal",
         subordinate_to=["nova-compute"],
+        subordinate_units=[SubordinateUnit("ovn-chassisr/0", "ovn-chassis")],
         units={},
         workload_version="22.3",
     )
@@ -250,6 +258,7 @@ def test_ceph_dashboard_upgrade_plan_ussuri_to_victoria(model):
         origin="ch",
         series="focal",
         subordinate_to=["nova-compute"],
+        subordinate_units=[SubordinateUnit("ovn-chassisr/0", "ovn-chassis")],
         units={},
         workload_version="15.2.0",
     )
@@ -287,6 +296,7 @@ def test_ceph_dashboard_upgrade_plan_xena_to_yoga(model):
         origin="ch",
         series="focal",
         subordinate_to=["nova-compute"],
+        subordinate_units=[SubordinateUnit("ovn-chassisr/0", "ovn-chassis")],
         units={},
         workload_version="16.2.0",
     )
@@ -339,6 +349,7 @@ This may be a charm downgrade, which is generally not supported.
         origin="ch",
         series="focal",
         subordinate_to=["nova-compute"],
+        subordinate_units=[SubordinateUnit("ovn-chassisr/0", "ovn-chassis")],
         units={},
         workload_version="",
     )
@@ -358,6 +369,7 @@ def test_auxiliary_subordinate_channel_o7k_release_raise(model):
         origin="ch",
         series="focal",
         subordinate_to=["nova-compute"],
+        subordinate_units=[SubordinateUnit("ovn-chassisr/0", "ovn-chassis")],
         units={},
         workload_version="",
     )
@@ -390,6 +402,7 @@ def test_hacluster_change_channel(model):
         origin="ch",
         series="focal",
         subordinate_to=["keystone"],
+        subordinate_units=[SubordinateUnit("keystone-hacluster/0", "hacluster")],
         units={},
         workload_version="2.0.3",
     )

--- a/tests/unit/apps/test_base.py
+++ b/tests/unit/apps/test_base.py
@@ -41,6 +41,7 @@ def test_openstack_application_magic_functions(model):
         origin="ch",
         series="focal",
         subordinate_to=[],
+        subordinate_units=[],
         units={},
         workload_version="1",
     )
@@ -77,6 +78,7 @@ def test_application_get_latest_o7k_version_failed(mock_find_compatible_versions
         origin="ch",
         series="focal",
         subordinate_to=[],
+        subordinate_units=[],
         units={f"{app_name}/0": unit},
         workload_version=unit.workload_version,
     )
@@ -130,6 +132,7 @@ def test_set_action_managed_upgrade(charm_config, enable, exp_description, model
         origin="ch",
         series="focal",
         subordinate_to=[],
+        subordinate_units=[],
         units={},
         workload_version="1",
     )
@@ -163,6 +166,7 @@ def test_get_pause_unit_step(model):
         origin="ch",
         series="focal",
         subordinate_to=[],
+        subordinate_units=[],
         units={f"{unit.name}": unit},
         workload_version="1",
     )
@@ -196,6 +200,7 @@ def test_get_resume_unit_step(model):
         origin="ch",
         series="focal",
         subordinate_to=[],
+        subordinate_units=[],
         units={f"{app_name}/0": unit},
         workload_version="1",
     )
@@ -229,6 +234,7 @@ def test_get_openstack_upgrade_step(model):
         origin="ch",
         series="focal",
         subordinate_to=[],
+        subordinate_units=[],
         units={f"{app_name}/0": unit},
         workload_version="1",
     )
@@ -256,7 +262,7 @@ def test_get_upgrade_current_release_packages_step(mock_upgrade_packages, units,
     }
 
     app = OpenStackApplication(
-        app_name, "", charm, channel, {}, {}, model, "ch", "focal", [], app_units, "21.0.1"
+        app_name, "", charm, channel, {}, {}, model, "ch", "focal", [], app_units, [], "21.0.1"
     )
 
     expected_calls = (
@@ -288,7 +294,7 @@ def test_get_reached_expected_target_step(mock_workload_upgrade, units, model):
     app_units = {f"my_app/{unit}": Unit(f"my_app/{unit}", mock, mock) for unit in range(3)}
 
     app = OpenStackApplication(
-        app_name, "", charm, channel, {}, {}, model, "ch", "focal", [], app_units, "21.0.1"
+        app_name, "", charm, channel, {}, {}, model, "ch", "focal", [], app_units, [], "21.0.1"
     )
 
     expected_calls = [call(target, units)] if units else [call(target, list(app.units.values()))]
@@ -303,7 +309,7 @@ def test_check_channel(_, origin):
     """Test function to verify validity of the charm channel."""
     app_name = "app"
     app = OpenStackApplication(
-        app_name, "", app_name, "stable", {}, {}, MagicMock(), origin, "focal", [], {}, "1"
+        app_name, "", app_name, "stable", {}, {}, MagicMock(), origin, "focal", [], {}, [], "1"
     )
 
     app._check_channel()
@@ -322,7 +328,7 @@ def test_check_channel_error(_):
         "are using the right track."
     )
     app = OpenStackApplication(
-        name, "", name, channel, {}, {}, MagicMock(), "ch", series, [], {}, "1"
+        name, "", name, channel, {}, {}, MagicMock(), "ch", series, [], {}, [], "1"
     )
 
     with pytest.raises(ApplicationError, match=exp_error_msg):
@@ -334,7 +340,7 @@ def test_check_auto_restarts(config):
     """Test function to verify that enable-auto-restarts is disabled."""
     app_name = "app"
     app = OpenStackApplication(
-        app_name, "", app_name, "stable", config, {}, MagicMock(), "ch", "focal", [], {}, "1"
+        app_name, "", app_name, "stable", config, {}, MagicMock(), "ch", "focal", [], {}, [], "1"
     )
 
     app._check_auto_restarts()
@@ -350,7 +356,7 @@ def test_check_auto_restarts_error():
     )
     config = {"enable-auto-restarts": {"value": False}}
     app = OpenStackApplication(
-        app_name, "", app_name, "stable", config, {}, MagicMock(), "ch", "focal", [], {}, "1"
+        app_name, "", app_name, "stable", config, {}, MagicMock(), "ch", "focal", [], {}, [], "1"
     )
 
     with pytest.raises(ApplicationError, match=exp_error_msg):
@@ -365,7 +371,7 @@ def test_check_application_target(o7k_release, apt_source_codename):
     release = OpenStackRelease("ussuri")
     app_name = "app"
     app = OpenStackApplication(
-        app_name, "", app_name, "stable", {}, {}, MagicMock(), "ch", "focal", [], {}, "1"
+        app_name, "", app_name, "stable", {}, {}, MagicMock(), "ch", "focal", [], {}, [], "1"
     )
     o7k_release.return_value = apt_source_codename.return_value = release
 
@@ -380,7 +386,7 @@ def test_check_application_target_can_upgrade(o7k_release, apt_source_codename):
     release = OpenStackRelease("ussuri")
     app_name = "app"
     app = OpenStackApplication(
-        app_name, "stable", app_name, "stable", {}, {}, MagicMock(), "ch", "focal", [], {}, "1"
+        app_name, "stable", app_name, "stable", {}, {}, MagicMock(), "ch", "focal", [], {}, [], "1"
     )
     o7k_release.return_value = apt_source_codename.return_value = release
 
@@ -398,7 +404,7 @@ def test_check_application_target_error(o7k_release, apt_source_codename):
         f"{target}. Ignoring."
     )
     app = OpenStackApplication(
-        app_name, "", app_name, "stable", {}, {}, MagicMock(), "ch", "focal", [], {}, "1"
+        app_name, "", app_name, "stable", {}, {}, MagicMock(), "ch", "focal", [], {}, [], "1"
     )
     o7k_release.return_value = apt_source_codename.return_value = target
 
@@ -450,6 +456,7 @@ def test_check_mismatched_versions_exception(mock_o7k_release_units, model):
         origin="ch",
         series="focal",
         subordinate_to=[],
+        subordinate_units=[],
         units=units,
         workload_version="18.1.0",
     )
@@ -501,6 +508,7 @@ def test_check_mismatched_versions_with_nova_compute(mock_o7k_release_units, mod
         origin="ch",
         series="focal",
         subordinate_to=[],
+        subordinate_units=[],
         units=units,
         workload_version="18.1.0",
     )
@@ -545,6 +553,7 @@ def test_check_mismatched_versions(mock_o7k_release_units, model):
         origin="ch",
         series="focal",
         subordinate_to=[],
+        subordinate_units=[],
         units=units,
         workload_version="17.0.1",
     )
@@ -569,6 +578,7 @@ def test_get_charmhub_migration_step(o7k_release, model):
         origin="cs",
         series="focal",
         subordinate_to=[],
+        subordinate_units=[],
         units={},
         workload_version="1",
     )
@@ -597,6 +607,7 @@ def test_get_change_channel_possible_downgrade_step(o7k_release, model):
         origin="ch",
         series="focal",
         subordinate_to=[],
+        subordinate_units=[],
         units={},
         workload_version="1",
     )
@@ -627,6 +638,7 @@ def test_get_refresh_current_channel_step(model):
         origin="ch",
         series="focal",
         subordinate_to=[],
+        subordinate_units=[],
         units={},
         workload_version="1",
     )
@@ -658,6 +670,7 @@ def test_get_refresh_charm_step_skip(
         origin="ch",
         series="focal",
         subordinate_to=[],
+        subordinate_units=[],
         units={},
         workload_version="1",
     )
@@ -689,6 +702,7 @@ def test_get_refresh_charm_step_refresh_current_channel(
         origin="ch",
         series="focal",
         subordinate_to=[],
+        subordinate_units=[],
         units={},
         workload_version="1",
     )
@@ -731,6 +745,7 @@ def test_get_refresh_charm_step_change_to_openstack_channels(
         origin="ch",
         series="focal",
         subordinate_to=[],
+        subordinate_units=[],
         units={},
         workload_version="1",
     )
@@ -778,6 +793,7 @@ def test_get_refresh_charm_step_charmhub_migration(
         origin="cs",
         series="focal",
         subordinate_to=[],
+        subordinate_units=[],
         units={},
         workload_version="1",
     )
@@ -815,6 +831,7 @@ def test_extract_from_uca_source(model, config, exp_result):
         origin="ch",
         series="focal",
         subordinate_to=[],
+        subordinate_units=[],
         units={},
         workload_version="1",
     )
@@ -835,6 +852,7 @@ def test_extract_from_uca_source_raise(wrong_uca, model):
         origin="ch",
         series="focal",
         subordinate_to=[],
+        subordinate_units=[],
         units={},
         workload_version="1",
     )
@@ -866,6 +884,7 @@ def test_apt_source_codename(config, exp_result, model):
         origin="ch",
         series="focal",
         subordinate_to=[],
+        subordinate_units=[],
         units={
             "app/0": Unit(
                 name="app/0",
@@ -905,6 +924,7 @@ def test_apt_source_codename_empty_or_without_origin_setting(mock_o7k_release, c
         origin="ch",
         series="focal",
         subordinate_to=[],
+        subordinate_units=[],
         units={
             "app/0": Unit(
                 name="app/0",
@@ -937,6 +957,7 @@ def test_apt_source_codename_unknown_source(source_value, model):
         origin="ch",
         series="focal",
         subordinate_to=[],
+        subordinate_units=[],
         units={
             "app/0": Unit(
                 name="app/0",
@@ -974,6 +995,7 @@ def test_need_crossgrade(model, channel, origin, exp_result):
         origin=origin,
         series="focal",
         subordinate_to=[],
+        subordinate_units=[],
         units={},
         workload_version="1",
     )
@@ -1001,6 +1023,7 @@ def test_expected_current_channel(mock_o7k_release, model, channel, origin):
         origin=origin,
         series="focal",
         subordinate_to=[],
+        subordinate_units=[],
         units={},
         workload_version="1",
     )

--- a/tests/unit/apps/test_channel_based.py
+++ b/tests/unit/apps/test_channel_based.py
@@ -50,6 +50,7 @@ def test_application_versionless(model):
         origin="ch",
         series="focal",
         subordinate_to=[],
+        subordinate_units=[],
         units=units,
         workload_version="",
     )
@@ -98,6 +99,7 @@ This may be a charm downgrade, which is generally not supported.
         origin="ch",
         series="focal",
         subordinate_to=[],
+        subordinate_units=[],
         units=units,
         workload_version="",
     )
@@ -126,6 +128,7 @@ def test_application_gnocchi_ussuri(model):
         origin="ch",
         series="focal",
         subordinate_to=[],
+        subordinate_units=[],
         units={
             "gnocchi/0": Unit(
                 name="gnocchi/0",
@@ -158,6 +161,7 @@ def test_application_gnocchi_xena(model):
         origin="ch",
         series="focal",
         subordinate_to=[],
+        subordinate_units=[],
         units={
             "gnocchi/0": Unit(
                 name="gnocchi/0",
@@ -193,6 +197,7 @@ def test_application_designate_bind_ussuri(model):
         origin="ch",
         series="focal",
         subordinate_to=[],
+        subordinate_units=[],
         units={
             "designate-bind/0": Unit(
                 name="designate-bind/0",
@@ -222,6 +227,7 @@ def test_application_versionless_upgrade_plan_ussuri_to_victoria(model):
         origin="ch",
         series="focal",
         subordinate_to=[],
+        subordinate_units=[],
         units={
             "glance-simplestreams-sync/0": Unit(
                 name="glance-simplestreams-sync/0",
@@ -297,6 +303,7 @@ def test_application_gnocchi_upgrade_plan_ussuri_to_victoria(model):
         origin="ch",
         series="focal",
         subordinate_to=[],
+        subordinate_units=[],
         units={
             "gnocchi/0": Unit(
                 name="gnocchi/0",
@@ -381,6 +388,7 @@ def test_application_designate_bind_upgrade_plan_ussuri_to_victoria(model):
         origin="ch",
         series="focal",
         subordinate_to=[],
+        subordinate_units=[],
         units={
             "designate-bind/0": Unit(
                 name="designate-bind/0",
@@ -482,6 +490,7 @@ def test_expected_current_channel_channel_based(
         origin=origin,
         series="focal",
         subordinate_to=[],
+        subordinate_units=[],
         units={},
         workload_version="1",
     )

--- a/tests/unit/apps/test_core.py
+++ b/tests/unit/apps/test_core.py
@@ -68,6 +68,7 @@ def test_application_different_wl(model):
         origin="ch",
         series="focal",
         subordinate_to=[],
+        subordinate_units=[],
         units=units,
         workload_version="18.1.0",
     )
@@ -94,6 +95,7 @@ async def test_application_verify_workload_upgrade(model):
         origin="ch",
         series="focal",
         subordinate_to=[],
+        subordinate_units=[],
         units={
             "keystone/0": Unit(
                 name="keystone/0",
@@ -139,6 +141,7 @@ async def test_application_verify_workload_upgrade_fail(model):
         origin="ch",
         series="focal",
         subordinate_to=[],
+        subordinate_units=[],
         units={
             "keystone/0": Unit(
                 name="keystone/0",
@@ -180,6 +183,7 @@ def test_upgrade_plan_ussuri_to_victoria(model):
         origin="ch",
         series="focal",
         subordinate_to=[],
+        subordinate_units=[],
         units={
             f"keystone/{unit}": Unit(
                 name=f"keystone/{unit}",
@@ -266,6 +270,7 @@ def test_upgrade_plan_ussuri_to_victoria_ch_migration(model):
         origin="cs",
         series="focal",
         subordinate_to=[],
+        subordinate_units=[],
         units={
             f"keystone/{unit}": Unit(
                 name=f"keystone/{unit}",
@@ -355,6 +360,7 @@ def test_upgrade_plan_channel_on_next_o7k_release(model):
         origin="ch",
         series="focal",
         subordinate_to=[],
+        subordinate_units=[],
         units={
             f"keystone/{unit}": Unit(
                 name=f"keystone/{unit}",
@@ -434,6 +440,7 @@ def test_upgrade_plan_origin_already_on_next_openstack_release(model):
         origin="ch",
         series="focal",
         subordinate_to=[],
+        subordinate_units=[],
         units={
             f"keystone/{unit}": Unit(
                 name=f"keystone/{unit}",
@@ -516,6 +523,7 @@ def test_upgrade_plan_application_already_upgraded(model):
         origin="ch",
         series="focal",
         subordinate_to=[],
+        subordinate_units=[],
         units={
             f"keystone/{unit}": Unit(
                 name=f"keystone/{unit}",
@@ -550,6 +558,7 @@ def test_upgrade_plan_application_already_disable_action_managed(model):
         origin="ch",
         series="focal",
         subordinate_to=[],
+        subordinate_units=[],
         units={
             f"keystone/{unit}": Unit(
                 name=f"keystone/{unit}",
@@ -816,7 +825,7 @@ def _generate_nova_compute_app(model):
         for unit_num in range(3)
     }
     app = NovaCompute(
-        app_name, "", charm, channel, {}, {}, model, "cs", "focal", [], units, "21.0.1"
+        app_name, "", charm, channel, {}, {}, model, "cs", "focal", [], units, [], "21.0.1"
     )
 
     return app
@@ -888,6 +897,7 @@ def test_nova_compute_upgrade_plan(model):
         origin="ch",
         series="focal",
         subordinate_to=[],
+        subordinate_units=[],
         units=units,
         workload_version="21.0.0",
     )
@@ -944,6 +954,7 @@ def test_nova_compute_upgrade_plan_single_unit(model):
         origin="ch",
         series="focal",
         subordinate_to=[],
+        subordinate_units=[],
         units=units,
         workload_version="21.0.0",
     )
@@ -994,6 +1005,7 @@ cinder/0, cinder/1, cinder/2
         origin="ch",
         series="focal",
         subordinate_to=[],
+        subordinate_units=[],
         units=units,
         workload_version="16.4.2",
     )
@@ -1047,6 +1059,7 @@ def test_cinder_upgrade_plan_single_unit(model):
         origin="ch",
         series="focal",
         subordinate_to=[],
+        subordinate_units=[],
         units=units,
         workload_version="16.4.2",
     )
@@ -1071,6 +1084,7 @@ def test_swift_application_not_supported(model):
         origin="ch",
         series="focal",
         subordinate_to=[],
+        subordinate_units=[],
         units={
             "swift-proxy/0": Unit(
                 name="swift-proxy/0",
@@ -1108,6 +1122,7 @@ def test_core_wrong_channel(model):
         origin="ch",
         series="focal",
         subordinate_to=[],
+        subordinate_units=[],
         units={
             "keystone/0": Unit(
                 name="keystone/0",

--- a/tests/unit/apps/test_subordinate.py
+++ b/tests/unit/apps/test_subordinate.py
@@ -19,6 +19,7 @@ import pytest
 from cou.apps.subordinate import SubordinateApplication
 from cou.exceptions import ApplicationError
 from cou.steps import ApplicationUpgradePlan, PreUpgradeStep, UpgradeStep
+from cou.utils.juju_utils import SubordinateUnit
 from cou.utils.openstack import OpenStackRelease
 from tests.unit.utils import assert_steps, generate_cou_machine
 
@@ -39,6 +40,7 @@ def test_o7k_release(model):
         origin="ch",
         series="focal",
         subordinate_to=["nova-compute"],
+        subordinate_units=[SubordinateUnit("keystone-ldap/0", "keystone-ldap")],
         units={},
         workload_version="18.1.0",
     )
@@ -61,6 +63,7 @@ def test_generate_upgrade_plan(model):
         origin="ch",
         series="focal",
         subordinate_to=["nova-compute"],
+        subordinate_units=[SubordinateUnit("keystone-ldap/0", "keystone-ldap")],
         units={},
         workload_version="18.1.0",
     )
@@ -109,6 +112,7 @@ def test_channel_valid(model, channel):
         origin="ch",
         series="focal",
         subordinate_to=["nova-compute"],
+        subordinate_units=[SubordinateUnit("keystone-ldap/0", "keystone-ldap")],
         units={},
         workload_version="18.1.0",
     )
@@ -144,6 +148,7 @@ def test_channel_setter_invalid(model, channel):
         origin="ch",
         series="focal",
         subordinate_to=["nova-compute"],
+        subordinate_units=[SubordinateUnit("keystone-ldap/0", "keystone-ldap")],
         units={},
         workload_version="18.1.0",
     )
@@ -175,6 +180,7 @@ def test_generate_plan_ch_migration(model, channel):
         origin="cs",
         series="focal",
         subordinate_to=["nova-compute"],
+        subordinate_units=[SubordinateUnit("keystone-ldap/0", "keystone-ldap")],
         units={},
         workload_version="",
     )
@@ -222,6 +228,7 @@ def test_generate_plan_from_to(model, from_os, to_os):
         origin="ch",
         series="focal",
         subordinate_to=["nova-compute"],
+        subordinate_units=[SubordinateUnit("keystone-ldap/0", "keystone-ldap")],
         units={},
         workload_version="18.1.0",
     )
@@ -270,6 +277,7 @@ def test_generate_plan_in_same_version(model, from_to):
         origin="ch",
         series="focal",
         subordinate_to=["nova-compute"],
+        subordinate_units=[SubordinateUnit("keystone-ldap/0", "keystone-ldap")],
         units={},
         workload_version="18.1.0",
     )
@@ -322,6 +330,7 @@ def test_expected_current_channel_subordinate(
         origin=origin,
         series="focal",
         subordinate_to=["keystone"],
+        subordinate_units=[SubordinateUnit("keystone-ldap/0", "keystone-ldap")],
         units={},
         workload_version="1",
     )

--- a/tests/unit/steps/test_analyze.py
+++ b/tests/unit/steps/test_analyze.py
@@ -28,6 +28,7 @@ from cou.utils.openstack import OpenStackRelease
 from tests.unit.utils import generate_cou_machine
 
 
+@pytest.mark.asyncio
 def test_analysis_dump(model):
     """Test analysis dump."""
     expected_result = dedent(
@@ -44,6 +45,7 @@ def test_analysis_dump(model):
           origin: ch
           series: focal
           subordinate_to: []
+          subordinate_units: []
           workload_version: 17.0.1
           units:
             keystone/0:
@@ -89,6 +91,7 @@ def test_analysis_dump(model):
           origin: ch
           series: focal
           subordinate_to: []
+          subordinate_units: []
           workload_version: 16.4.2
           units:
             cinder/0:
@@ -134,6 +137,7 @@ def test_analysis_dump(model):
           origin: ch
           series: focal
           subordinate_to: []
+          subordinate_units: []
           workload_version: '3.8'
           units:
             rabbitmq-server/0:
@@ -166,6 +170,7 @@ def test_analysis_dump(model):
         origin="ch",
         series="focal",
         subordinate_to=[],
+        subordinate_units=[],
         units={
             f"keystone/{unit}": Unit(
                 name=f"keystone/{unit}", workload_version="17.0.1", machine=machines[f"{unit}"]
@@ -185,6 +190,7 @@ def test_analysis_dump(model):
         origin="ch",
         series="focal",
         subordinate_to=[],
+        subordinate_units=[],
         units={
             "rabbitmq-server/0": Unit(
                 name="rabbitmq-server/0",
@@ -205,6 +211,7 @@ def test_analysis_dump(model):
         origin="ch",
         series="focal",
         subordinate_to=[],
+        subordinate_units=[],
         units={
             f"cinder/{unit}": Unit(
                 name=f"cinder/{unit}",
@@ -272,6 +279,7 @@ async def test_analysis_create(mock_split_apps, mock_populate, model):
         origin="ch",
         series="focal",
         subordinate_to=[],
+        subordinate_units=[],
         units={
             "keystone/0": Unit(
                 name="keystone/0",
@@ -292,6 +300,7 @@ async def test_analysis_create(mock_split_apps, mock_populate, model):
         origin="ch",
         series="focal",
         subordinate_to=[],
+        subordinate_units=[],
         units={
             "rabbitmq-server/0": Unit(
                 name="rabbitmq-server/0",
@@ -312,6 +321,7 @@ async def test_analysis_create(mock_split_apps, mock_populate, model):
         origin="ch",
         series="focal",
         subordinate_to=[],
+        subordinate_units=[],
         units={
             "cinder/0": Unit(
                 name="cinder/0",
@@ -350,6 +360,7 @@ async def test_analysis_detect_current_cloud_o7k_release_different_releases(mode
         origin="ch",
         series="focal",
         subordinate_to=[],
+        subordinate_units=[],
         units={
             "keystone/0": Unit(
                 name="keystone/0",
@@ -370,6 +381,7 @@ async def test_analysis_detect_current_cloud_o7k_release_different_releases(mode
         origin="ch",
         series="focal",
         subordinate_to=[],
+        subordinate_units=[],
         units={
             "rabbitmq-server/0": Unit(
                 name="rabbitmq-server/0",
@@ -390,6 +402,7 @@ async def test_analysis_detect_current_cloud_o7k_release_different_releases(mode
         origin="ch",
         series="focal",
         subordinate_to=[],
+        subordinate_units=[],
         units={
             "cinder/0": Unit(
                 name="cinder/0",
@@ -424,6 +437,7 @@ async def test_analysis_detect_current_cloud_series_different_series(model):
         origin="ch",
         series="focal",
         subordinate_to=[],
+        subordinate_units=[],
         units={
             "keystone/0": Unit(
                 name="keystone/0",
@@ -444,6 +458,7 @@ async def test_analysis_detect_current_cloud_series_different_series(model):
         origin="ch",
         series="focal",
         subordinate_to=[],
+        subordinate_units=[],
         units={
             "rabbitmq-server/0": Unit(
                 name="rabbitmq-server/0",
@@ -464,6 +479,7 @@ async def test_analysis_detect_current_cloud_series_different_series(model):
         origin="ch",
         series="bionic",  # change cinder to Bionic series
         subordinate_to=[],
+        subordinate_units=[],
         units={
             "cinder/0": Unit(
                 name="cinder/0",
@@ -573,6 +589,7 @@ def test_min_o7k_release_apps(model, channel_keystone, channel_gnocchi, origin, 
         origin=origin,
         series="focal",
         subordinate_to=[],
+        subordinate_units=[],
         units={
             "keystone/0": Unit(
                 name="keystone/0",
@@ -594,6 +611,7 @@ def test_min_o7k_release_apps(model, channel_keystone, channel_gnocchi, origin, 
         origin=origin,
         series="focal",
         subordinate_to=[],
+        subordinate_units=[],
         units={
             "gnocchi": Unit(
                 name="gnocchi/0",

--- a/tests/unit/steps/test_hypervisor.py
+++ b/tests/unit/steps/test_hypervisor.py
@@ -476,6 +476,7 @@ def test_hypervisor_upgrade_plan(model):
         origin="ch",
         series="focal",
         subordinate_to=[],
+        subordinate_units=[],
         units={
             "cinder/0": Unit(
                 name="cinder/0",
@@ -496,6 +497,7 @@ def test_hypervisor_upgrade_plan(model):
         origin="ch",
         series="focal",
         subordinate_to=[],
+        subordinate_units=[],
         units={
             f"nova-compute/{unit}": Unit(
                 name=f"nova-compute/{unit}",
@@ -573,6 +575,7 @@ def test_hypervisor_upgrade_plan_single_machine(model):
         origin="ch",
         series="focal",
         subordinate_to=[],
+        subordinate_units=[],
         units={
             "cinder/0": Unit(
                 name="cinder/0",
@@ -593,6 +596,7 @@ def test_hypervisor_upgrade_plan_single_machine(model):
         origin="ch",
         series="focal",
         subordinate_to=[],
+        subordinate_units=[],
         units={
             f"nova-compute/{unit}": Unit(
                 name=f"nova-compute/{unit}",
@@ -673,6 +677,7 @@ def test_hypervisor_upgrade_plan_some_units_upgraded(model):
         origin="ch",
         series="focal",
         subordinate_to=[],
+        subordinate_units=[],
         units={
             "cinder/0": Unit(
                 name="cinder/0",
@@ -707,6 +712,7 @@ def test_hypervisor_upgrade_plan_some_units_upgraded(model):
         origin="ch",
         series="focal",
         subordinate_to=[],
+        subordinate_units=[],
         units={
             "nova-compute/0": Unit(
                 name="nova-compute/0",

--- a/tests/unit/steps/test_plan.py
+++ b/tests/unit/steps/test_plan.py
@@ -46,7 +46,7 @@ from cou.steps.backup import backup
 from cou.steps.hypervisor import HypervisorGroup, HypervisorUpgradePlanner
 from cou.steps.nova_cloud_controller import archive, purge
 from cou.utils import app_utils
-from cou.utils.juju_utils import Machine, Unit
+from cou.utils.juju_utils import Machine, SubordinateUnit, Unit
 from cou.utils.openstack import OpenStackRelease
 from tests.unit.utils import dedent_plan, generate_cou_machine
 
@@ -223,6 +223,7 @@ nova-compute/0
         origin="ch",
         series="focal",
         subordinate_to=[],
+        subordinate_units=[],
         units={
             "keystone/0": Unit(
                 name="keystone/0",
@@ -243,6 +244,7 @@ nova-compute/0
         origin="ch",
         series="focal",
         subordinate_to=["keystone"],
+        subordinate_units=[SubordinateUnit("keystone-ldap/0", "keystone-ldap")],
         units={},
         workload_version="17.0.1",
     )
@@ -258,6 +260,7 @@ nova-compute/0
         origin="ch",
         series="focal",
         subordinate_to=[],
+        subordinate_units=[],
         units={
             "nova-compute/0": Unit(
                 name="nova-compute/0",
@@ -279,6 +282,7 @@ nova-compute/0
         origin="ch",
         series="focal",
         subordinate_to=[],
+        subordinate_units=[],
         units={
             "ceph-osd/0": Unit(
                 name="ceph-osd/0",
@@ -300,6 +304,7 @@ nova-compute/0
         origin="ch",
         series="focal",
         subordinate_to=["nova-compute"],
+        subordinate_units=[SubordinateUnit("ovn-chassis/0", "ovn-chassis")],
         units={},
         workload_version="22.3",
     )
@@ -380,6 +385,7 @@ nova-compute/0
         origin="ch",
         series="focal",
         subordinate_to=[],
+        subordinate_units=[],
         units={
             "keystone/0": Unit(
                 name="keystone/0",
@@ -405,6 +411,7 @@ nova-compute/0
         origin="ch",
         series="focal",
         subordinate_to=["keystone"],
+        subordinate_units=[SubordinateUnit("keystone-ldap/0", "keystone-ldap")],
         units={},
         workload_version="17.0.1",
     )
@@ -420,6 +427,7 @@ nova-compute/0
         origin="ch",
         series="focal",
         subordinate_to=[],
+        subordinate_units=[],
         units={
             "nova-compute/0": Unit(
                 name="nova-compute/0",
@@ -441,6 +449,7 @@ nova-compute/0
         origin="ch",
         series="focal",
         subordinate_to=[],
+        subordinate_units=[],
         units={
             "ceph-osd/0": Unit(
                 name="ceph-osd/0",
@@ -462,6 +471,7 @@ nova-compute/0
         origin="ch",
         series="focal",
         subordinate_to=["nova-compute"],
+        subordinate_units=[SubordinateUnit("ovn-chassis/0", "ovn-chassis")],
         units={},
         workload_version="22.3",
     )
@@ -1252,6 +1262,7 @@ def test_get_ceph_mon_post_upgrade_steps_multiple(model):
         origin="ch",
         series="focal",
         subordinate_to=[],
+        subordinate_units=[],
         units=units,
         workload_version="17.0.1",
     )
@@ -1473,6 +1484,7 @@ def test_separate_hypervisors_apps(model):
         origin="ch",
         series="focal",
         subordinate_to=[],
+        subordinate_units=[],
         units={
             "nova-compute/0": Unit(
                 name="nova-compute/0",
@@ -1498,6 +1510,7 @@ def test_separate_hypervisors_apps(model):
         origin="ch",
         series="focal",
         subordinate_to=[],
+        subordinate_units=[],
         units={
             "cinder/0": Unit(
                 name="cinder/0",
@@ -1520,6 +1533,7 @@ def test_separate_hypervisors_apps(model):
         origin="ch",
         series="focal",
         subordinate_to=["nova-compute"],
+        subordinate_units=[SubordinateUnit("ovn-chassis/0", "ovn-chassis")],
         units={},
         workload_version="22.3",
     )
@@ -1536,6 +1550,7 @@ def test_separate_hypervisors_apps(model):
         origin="ch",
         series="focal",
         subordinate_to=[],
+        subordinate_units=[],
         units={
             "ceph-osd/0": Unit(
                 name="ceph-osd/0",
@@ -1558,6 +1573,7 @@ def test_separate_hypervisors_apps(model):
         origin="ch",
         series="focal",
         subordinate_to=[],
+        subordinate_units=[],
         units={
             "ceph-osd/0": Unit(
                 name="ceph-osd/0",

--- a/tests/unit/utils/test_juju_utils.py
+++ b/tests/unit/utils/test_juju_utils.py
@@ -782,6 +782,8 @@ async def test_get_applications(mock_get_machines, mock_get_status, mocked_model
     app1/2    active    idle   2        10.147.4.3
     app2/0*   active    idle   0        10.147.4.1
       app4/0* active    idle            10.147.4.1
+      app4/1* active    idle            10.147.4.1
+      app4/2* active    idle            10.147.4.1
     app3/0*   active    idle   1        10.147.4.2
 
     Machine  State    Address     Inst id        Base          AZ  Message
@@ -811,6 +813,7 @@ async def test_get_applications(mock_get_machines, mock_get_status, mocked_model
     }
 
     mocked_model.applications = {app: MagicMock(spec_set=Application)() for app in exp_apps}
+    mocked_model.subordinate_units = {f"app4/{i}" for i in range(3)}
 
     for app in exp_apps:
         mocked_model.applications[app].get_actions = AsyncMock()
@@ -821,6 +824,10 @@ async def test_get_applications(mock_get_machines, mock_get_status, mocked_model
     full_status_apps = {app: _generate_app_status(exp_units_from_status[app]) for app in exp_apps}
     mock_get_status.return_value.applications = full_status_apps
     mock_get_machines.return_value = exp_machines
+    mock_subordinate_units = {
+        juju_utils.SubordinateUnit(name, mocked_model.applications[name.split("/")[0]].charm_name)
+        for name in mocked_model.subordinate_units
+    }
 
     model = juju_utils.Model("test-model")
     exp_apps = {
@@ -850,6 +857,9 @@ async def test_get_applications(mock_get_machines, mock_get_status, mocked_model
                 )
                 for name, unit in exp_units_from_status[app].items()
             },
+            subordinate_units=[
+                su for su in mock_subordinate_units if su.name.split("/")[0] == app
+            ],
             workload_version=status.workload_version,
         )
         for app, status in full_status_apps.items()


### PR DESCRIPTION
This augmented the `Application` class with `subordinate_units` information so that you can get subordinate units easily for an application.

For example, If the model contains the following:

```
App
nova-compute
ovn-chassis

Unit
nova-compute/0
    ovn-chassis/0
nova-compute/1
    ovn-chassis/2
```

**Before the PR:**

```python
Application.units = {"nova-compute/0": Unit(...), nova-compute/1": Unit(...)}  # for nova-compute
Application.units = {}` for `ovn-chassis  # for ovn-chassis
```

**After the PR:**

```python
Application.units = {"nova-compute/0": Unit(...), nova-compute/1": Unit(...)}  # for nova-compute
Application.subordinate_units = []  # for nova-compute
Application.units = {}` for `ovn-chassis 
Application.subordinate_units = [SubordinateUnit("ovn-chassis/0"), SubordinateUnit("ovn-chassis/1")] # for ovn-chassis
```

see `tests/unit/utils/test_juju_utils.py` for updated test case
