### PR TITLE
Workaround ceilometer-agent-compute not running

### DIFF
--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -36,6 +36,7 @@ def model() -> AsyncMock:
     model.scp_from_unit = AsyncMock()
     model.set_application_config = AsyncMock()
     model.get_application_config = AsyncMock()
+    model.update_status = AsyncMock()
 
     return model
 


### PR DESCRIPTION
This is a bug in nova-compute and/or ceilometer-agent
( https://bugs.launchpad.net/charm-ceilometer-agent/+bug/1947585 ),
where the nova-compute `resume` action can sometimes fail.
The workaround added here is to restart ceilometer-agent-compute
if it fails for this reason.



Fixes: #427