### PR TITLE
fix: Temporary fix for python-libjuju application upgrade failed

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -27,7 +27,8 @@ python_requires = >=3.10
 packages = find:
 install_requires =
     oslo.config
-    juju>=3.0,<4.0
+    # A temporary workaround for bug: https://github.com/juju/python-libjuju/issues/1083
+    juju>=3.0,<3.5
     colorama
     packaging
     aioconsole


### PR DESCRIPTION
Downgrade juju version to 3.4 as a temperary
workaround for https://github.com/juju/python-libjuju/issues/1083