### PR TITLE
Add skip apps command line flag.

### DIFF
--- a/cou/cli.py
+++ b/cou/cli.py
@@ -123,7 +123,7 @@ async def analyze_and_plan(args: CLIargs) -> UpgradePlan:
     progress_indicator.succeed(f"Connected to '{model.name}'")
 
     progress_indicator.start("Analyzing cloud...")
-    analysis_result = await Analysis.create(model)
+    analysis_result = await Analysis.create(model, skip_apps=args.skip_apps)
     logger.info(analysis_result)
     progress_indicator.succeed()
 

--- a/cou/commands.py
+++ b/cou/commands.py
@@ -217,6 +217,9 @@ def get_subcommand_common_opts_parser() -> argparse.ArgumentParser:
         nargs="+",
         help=(
             "Skip upgrading the given applications."
+            "\nNote that skip upgrading applications is dangerous, and could leave"
+            "\nthe cloud in an unstable state. You should only use this option if"
+            "\nyou know the applications will not affect the cloud during an upgrade."
             "\nCurrently, it only supports skip upgrading vault."
         ),
         required=False,

--- a/cou/commands.py
+++ b/cou/commands.py
@@ -494,7 +494,7 @@ class CLIargs:
     availability_zones: Optional[set[str]] = None
     purge: bool = False
     purge_before: Optional[str] = None
-    skip_apps: Optional[list[str]] = field(default_factory=list)
+    skip_apps: list[str] = field(default_factory=list)
 
     @property
     def prompt(self) -> bool:

--- a/cou/commands.py
+++ b/cou/commands.py
@@ -145,6 +145,20 @@ class PurgeBeforeArgumentAction(argparse.Action):
         setattr(namespace, self.dest, values)
 
 
+class SkipAppsArgumentAction(argparse.Action):
+    """Custom action to make sure the arguments is unique."""
+
+    def __call__(
+        self,
+        parser: argparse.ArgumentParser,
+        namespace: argparse.Namespace,
+        values: Any,
+        option_string: Optional[str] = None,
+    ) -> None:
+        unique_values = set(values)
+        setattr(namespace, self.dest, unique_values)
+
+
 def get_subcommand_common_opts_parser() -> argparse.ArgumentParser:
     """Create a shared parser for options specific to subcommands.
 
@@ -207,6 +221,18 @@ def get_subcommand_common_opts_parser() -> argparse.ArgumentParser:
             "\nWithout --purge-before-date the purge step will delete all the data."
         ),
         type=purge_before_arg,
+        required=False,
+    )
+    subcommand_common_opts_parser.add_argument(
+        "--skip-apps",
+        dest="skip_apps",
+        choices=["vault"],
+        action=SkipAppsArgumentAction,
+        nargs="*",
+        help=(
+            "Skip upgrading the given applications."
+            "\nCurrently, it only supports skip upgrading vault."
+        ),
         required=False,
     )
     subcommand_common_opts_parser.add_argument(
@@ -479,6 +505,7 @@ class CLIargs:
     availability_zones: Optional[set[str]] = None
     purge: bool = False
     purge_before: Optional[str] = None
+    skip_apps: Optional[set[str]] = None
 
     @property
     def prompt(self) -> bool:

--- a/cou/commands.py
+++ b/cou/commands.py
@@ -15,7 +15,7 @@
 """Command line arguments parsing for 'charmed-openstack-upgrader'."""
 import argparse
 import logging
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import datetime
 from typing import Any, Iterable, Optional
 
@@ -145,20 +145,6 @@ class PurgeBeforeArgumentAction(argparse.Action):
         setattr(namespace, self.dest, values)
 
 
-class SkipAppsArgumentAction(argparse.Action):
-    """Custom action to make sure the arguments is unique."""
-
-    def __call__(
-        self,
-        parser: argparse.ArgumentParser,
-        namespace: argparse.Namespace,
-        values: Any,
-        option_string: Optional[str] = None,
-    ) -> None:
-        unique_values = set(values)
-        setattr(namespace, self.dest, unique_values)
-
-
 def get_subcommand_common_opts_parser() -> argparse.ArgumentParser:
     """Create a shared parser for options specific to subcommands.
 
@@ -226,9 +212,9 @@ def get_subcommand_common_opts_parser() -> argparse.ArgumentParser:
     subcommand_common_opts_parser.add_argument(
         "--skip-apps",
         dest="skip_apps",
+        default=[],
         choices=["vault"],
-        action=SkipAppsArgumentAction,
-        nargs="*",
+        nargs="+",
         help=(
             "Skip upgrading the given applications."
             "\nCurrently, it only supports skip upgrading vault."
@@ -505,7 +491,7 @@ class CLIargs:
     availability_zones: Optional[set[str]] = None
     purge: bool = False
     purge_before: Optional[str] = None
-    skip_apps: Optional[set[str]] = None
+    skip_apps: Optional[list[str]] = field(default_factory=list)
 
     @property
     def prompt(self) -> bool:

--- a/cou/steps/analyze.py
+++ b/cou/steps/analyze.py
@@ -137,7 +137,7 @@ class Analysis:
 
     @classmethod
     async def create(
-        cls, model: juju_utils.Model, skip_apps: Optional[set[str]] = None
+        cls, model: juju_utils.Model, skip_apps: Optional[list[str]] = None
     ) -> Analysis:
         """Analyze the deployment before planning.
 
@@ -152,7 +152,7 @@ class Analysis:
         apps = await Analysis._populate(model)
 
         return Analysis(
-            model=model, apps=[app for app in apps if app.name not in (skip_apps or set())]
+            model=model, apps=[app for app in apps if app.name not in (skip_apps or [])]
         )
 
     @classmethod

--- a/cou/steps/analyze.py
+++ b/cou/steps/analyze.py
@@ -136,9 +136,7 @@ class Analysis:
         return control_plane, data_plane
 
     @classmethod
-    async def create(
-        cls, model: juju_utils.Model, skip_apps: Optional[list[str]] = None
-    ) -> Analysis:
+    async def create(cls, model: juju_utils.Model, skip_apps: list[str]) -> Analysis:
         """Analyze the deployment before planning.
 
         :param model: Model object
@@ -151,9 +149,7 @@ class Analysis:
         logger.info("Analyzing the OpenStack deployment...")
         apps = await Analysis._populate(model)
 
-        return Analysis(
-            model=model, apps=[app for app in apps if app.name not in (skip_apps or [])]
-        )
+        return Analysis(model=model, apps=[app for app in apps if app.name not in skip_apps])
 
     @classmethod
     async def _populate(cls, model: juju_utils.Model) -> list[OpenStackApplication]:

--- a/cou/steps/analyze.py
+++ b/cou/steps/analyze.py
@@ -136,18 +136,24 @@ class Analysis:
         return control_plane, data_plane
 
     @classmethod
-    async def create(cls, model: juju_utils.Model) -> Analysis:
+    async def create(
+        cls, model: juju_utils.Model, skip_apps: Optional[set[str]] = None
+    ) -> Analysis:
         """Analyze the deployment before planning.
 
         :param model: Model object
         :type model: Model
+        :param skip_apps: Application to skip upgrading
+        :type skip_apps: set of string
         :return: Analysis object populated with the model applications.
         :rtype: Analysis
         """
         logger.info("Analyzing the OpenStack deployment...")
         apps = await Analysis._populate(model)
 
-        return Analysis(model=model, apps=apps)
+        return Analysis(
+            model=model, apps=[app for app in apps if app.name not in (skip_apps or set())]
+        )
 
     @classmethod
     async def _populate(cls, model: juju_utils.Model) -> list[OpenStackApplication]:

--- a/tests/mocked_plans/test_sample_plans.py
+++ b/tests/mocked_plans/test_sample_plans.py
@@ -27,6 +27,6 @@ async def test_plans_with_empty_hypervisors(_, sample_plan):
     """Testing all the plans on sample_plans folder considering all hypervisors empty."""
     model, exp_plan = sample_plan
     args = CLIargs("plan", auto_approve=True)
-    analysis_results = await Analysis.create(model)
+    analysis_results = await Analysis.create(model, skip_apps=[])
     plan = await generate_plan(analysis_results, args)
     assert str(plan) == exp_plan

--- a/tests/unit/steps/test_analyze.py
+++ b/tests/unit/steps/test_analyze.py
@@ -334,7 +334,7 @@ async def test_analysis_create(mock_split_apps, mock_populate, model):
     mock_populate.return_value = exp_apps
     mock_split_apps.return_value = exp_apps, []
 
-    result = await Analysis.create(model=model)
+    result = await Analysis.create(model=model, skip_apps=[])
 
     assert result.model == model
     assert result.apps_control_plane == exp_apps

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -72,6 +72,7 @@ async def test_analyze_and_plan(mock_analyze, mock_generate_plan, cou_model, cli
     """Test analyze_and_plan function with different model_name arguments."""
     cli_args.model_name = None
     cli_args.backup = False
+    cli_args.skip_apps = None
 
     cou_model.return_value.connect.side_effect = AsyncMock()
     analysis_result = Analysis(model=cou_model, apps=[])
@@ -81,7 +82,7 @@ async def test_analyze_and_plan(mock_analyze, mock_generate_plan, cou_model, cli
     await cli.analyze_and_plan(cli_args)
 
     cou_model.assert_called_once_with(None)
-    mock_analyze.assert_awaited_once_with(cou_model.return_value)
+    mock_analyze.assert_awaited_once_with(cou_model.return_value, skip_apps=None)
     mock_generate_plan.assert_awaited_once_with(analysis_result, cli_args)
 
 

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -72,7 +72,7 @@ async def test_analyze_and_plan(mock_analyze, mock_generate_plan, cou_model, cli
     """Test analyze_and_plan function with different model_name arguments."""
     cli_args.model_name = None
     cli_args.backup = False
-    cli_args.skip_apps = None
+    cli_args.skip_apps = []
 
     cou_model.return_value.connect.side_effect = AsyncMock()
     analysis_result = Analysis(model=cou_model, apps=[])
@@ -82,7 +82,7 @@ async def test_analyze_and_plan(mock_analyze, mock_generate_plan, cou_model, cli
     await cli.analyze_and_plan(cli_args)
 
     cou_model.assert_called_once_with(None)
-    mock_analyze.assert_awaited_once_with(cou_model.return_value, skip_apps=None)
+    mock_analyze.assert_awaited_once_with(cou_model.return_value, skip_apps=[])
     mock_generate_plan.assert_awaited_once_with(analysis_result, cli_args)
 
 

--- a/tests/unit/test_commands.py
+++ b/tests/unit/test_commands.py
@@ -965,8 +965,7 @@ def test_purge_before_argument_action_failed(mock_setattr):
 @patch("cou.commands.setattr")
 def test_skip_apps(mock_setattr):
     args = commands.parse_args("upgrade --skip-apps vault vault vault".split())
-    args.skip_apps == {"vault"}
-    mock_setattr.assert_called()
+    args.skip_apps == ["vault", "vault", "vault"]
 
 
 @patch("cou.commands.setattr")

--- a/tests/unit/test_commands.py
+++ b/tests/unit/test_commands.py
@@ -847,6 +847,8 @@ def test_parse_args_hypervisors_exclusive_options(args):
         ["plan", "--purge_before", "2000-01-02"],
         ["plan", "--purge_before", "2000-01-02 03:04"],
         ["plan", "--purge_before", "2000-01-02 03:04:05"],
+        ["upgrade", "--skip-apps", "vault keystone"],
+        ["plan", "--skip_apps", "vault keystone"],
     ],
 )
 def test_parse_invalid_args(args):
@@ -958,3 +960,16 @@ def test_purge_before_argument_action_failed(mock_setattr):
     )
     with pytest.raises(SystemExit, match="2"):
         parser.parse_args("--purge-before-date 2000-01-02".split())
+
+
+@patch("cou.commands.setattr")
+def test_skip_apps(mock_setattr):
+    args = commands.parse_args("upgrade --skip-apps vault vault vault".split())
+    args.skip_apps == {"vault"}
+    mock_setattr.assert_called()
+
+
+@patch("cou.commands.setattr")
+def test_skip_apps_failed(mock_setattr):
+    with pytest.raises(SystemExit, match="2"):
+        commands.parse_args("upgrade --skip-apps vault keystone".split())


### PR DESCRIPTION
Add `--skip-apps` flag to allow COU to skip some applications, likely some auxiliary charms in charmed openstack deployment such as vault. And this feature currently only support vault.

The motivation behind this is that we observe some applications in a charmed openstack deployment can be deviated from the recommended setup and still working fine. Vault is an example: the vault version (1.10.x) is above the recommended version for current openstack version ([reference](https://docs.openstack.org/charm-guide/latest/project/charm-delivery.html)) but still working fine on production. The problem is worsen because users are not recommended to [downgrade vault](https://developer.hashicorp.com/vault/docs/v1.10.x/upgrading).  So we need a workaround for user to skip upgrading some applications that are known to be working and can't  afford to switch to recommend version.

Closes: #472 