### PR TITLE
Make `stable` as an alias to `latest/stable` channel

### DIFF
--- a/cou/apps/base.py
+++ b/cou/apps/base.py
@@ -52,7 +52,7 @@ STANDARD_IDLE_TIMEOUT: int = int(
 LONG_IDLE_TIMEOUT: int = int(os.environ.get("COU_LONG_IDLE_TIMEOUT", 40 * 60))  # default of 40 min
 ORIGIN_SETTINGS = ("openstack-origin", "source")
 REQUIRED_SETTINGS = ("enable-auto-restarts", "action-managed-upgrade", *ORIGIN_SETTINGS)
-LATEST_STABLE = "latest/stable"
+LATEST_STABLE = {"stable", "latest/stable"}
 
 
 @dataclass(frozen=True)
@@ -299,7 +299,7 @@ class OpenStackApplication(Application):
         :return: True if necessary, False otherwise
         :rtype: bool
         """
-        return self.is_from_charm_store or self.channel == LATEST_STABLE
+        return self.is_from_charm_store or self.channel in LATEST_STABLE
 
     def is_valid_track(self, charm_channel: str) -> bool:
         """Check if the channel track is valid.
@@ -580,7 +580,7 @@ class OpenStackApplication(Application):
         """
         if self.is_from_charm_store:
             return self._get_charmhub_migration_step(target)
-        if self.channel == LATEST_STABLE:
+        if self.channel in LATEST_STABLE:
             return self._get_change_channel_possible_downgrade_step(
                 target, self.expected_current_channel(target)
             )

--- a/tests/unit/apps/test_base.py
+++ b/tests/unit/apps/test_base.py
@@ -304,19 +304,19 @@ def test_get_reached_expected_target_step(mock_workload_upgrade, units, model):
 
 
 @pytest.mark.parametrize("origin", ["cs", "ch"])
-@patch("cou.apps.base.OpenStackApplication.is_valid_track", return_value=True)
-def test_check_channel(_, origin):
+def test_check_channel(origin):
     """Test function to verify validity of the charm channel."""
-    app_name = "app"
+    name = "app"
+    channel = "ussuri/stable"
+    series = "focal"
     app = OpenStackApplication(
-        app_name, "", app_name, "stable", {}, {}, MagicMock(), origin, "focal", [], {}, [], "1"
+        name, "", name, channel, {}, {}, MagicMock(), origin, series, [], {}, [], "1"
     )
 
     app._check_channel()
 
 
-@patch("cou.apps.base.OpenStackApplication.is_valid_track", return_value=False)
-def test_check_channel_error(_):
+def test_check_channel_error():
     """Test function to verify validity of the charm channel when it's not valid."""
     name = "app"
     channel = "stable"

--- a/tests/unit/apps/test_base.py
+++ b/tests/unit/apps/test_base.py
@@ -304,10 +304,11 @@ def test_get_reached_expected_target_step(mock_workload_upgrade, units, model):
 
 
 @pytest.mark.parametrize("origin", ["cs", "ch"])
-def test_check_channel(origin):
+@pytest.mark.parametrize("channel", ["stable", "latest/stable", "ussuri/stable"])
+def test_check_channel(channel, origin):
     """Test function to verify validity of the charm channel."""
     name = "app"
-    channel = "ussuri/stable"
+    channel = channel
     series = "focal"
     app = OpenStackApplication(
         name, "", name, channel, {}, {}, MagicMock(), origin, series, [], {}, [], "1"
@@ -319,7 +320,7 @@ def test_check_channel(origin):
 def test_check_channel_error():
     """Test function to verify validity of the charm channel when it's not valid."""
     name = "app"
-    channel = "stable"
+    channel = "unknown/stable"
     series = "focal"
     exp_error_msg = (
         f"Channel: {channel} for charm '{name}' on series '{series}' is not supported by COU. "

--- a/tests/unit/apps/test_base.py
+++ b/tests/unit/apps/test_base.py
@@ -591,9 +591,14 @@ def test_get_charmhub_migration_step(o7k_release, model):
     )
 
 
+@pytest.mark.parametrize("channel", ["stable", "latest/stable"])
 @patch("cou.apps.base.OpenStackApplication.o7k_release", new_callable=PropertyMock)
-def test_get_change_channel_possible_downgrade_step(o7k_release, model):
-    """Applications using latest/stable should be switched to a release-specific channel."""
+def test_get_change_channel_possible_downgrade_step(o7k_release, model, channel):
+    """Test possible downgrade scenario.
+
+    Applications using 'stable' or 'latest/stable' should be switched to a
+    release-specific channel.
+    """
     o7k_release.return_value = OpenStackRelease("ussuri")
     target = OpenStackRelease("victoria")
 
@@ -601,7 +606,7 @@ def test_get_change_channel_possible_downgrade_step(o7k_release, model):
         name="app",
         can_upgrade_to="",
         charm="app",
-        channel="latest/stable",
+        channel=channel,
         config={},
         machines={},
         model=model,
@@ -614,7 +619,7 @@ def test_get_change_channel_possible_downgrade_step(o7k_release, model):
     )
 
     description = (
-        f"WARNING: Changing '{app.name}' channel from latest/stable to "
+        f"WARNING: Changing '{app.name}' channel from {app.channel} to "
         "ussuri/stable. This may be a charm downgrade, which is generally not supported."
     )
 


### PR DESCRIPTION
Sometime (old) charm in `latest/stable` channel can showed up in COU as `stable` channel, which makes COU think that it's an unsupported channel. However, this is not correct, for `latest/channel`, COU can still support proposing a possible crossgrade channel. 

Close: #491 