### PR TITLE
Fix --purge / --purge-before-date dependency issue

### DIFF
--- a/cou/commands.py
+++ b/cou/commands.py
@@ -542,9 +542,9 @@ def parse_args(args: Any) -> CLIargs:  # pylint: disable=inconsistent-return-sta
 
         # validate arguments
         validation_errors = []
-        if parsed_args.purge_before and not getattr(parsed_args, "purge", None):
+        if parsed_args.purge_before and not parsed_args.purge:
             validation_errors.append("--purge-before-date requires --purge")
-        if len(validation_errors) > 0:
+        if validation_errors:
             parser.error("\n" + "\n".join(validation_errors))
 
         return parsed_args

--- a/tests/unit/test_commands.py
+++ b/tests/unit/test_commands.py
@@ -935,31 +935,9 @@ def test_purge_before_arg(val, raise_err):
 
 
 @patch("cou.commands.setattr")
-def test_purge_before_argument_action(mock_setattr):
-    parser = ArgumentParser()
-    parser.add_argument("--purge", action="store_true", default=False)
-    parser.add_argument(
-        "--purge-before-date",
-        dest="purge_before",
-        type=str,
-        action=commands.PurgeBeforeArgumentAction,
-    )
-    parser.parse_args("--purge --purge-before-date 2000-01-02".split())
-    mock_setattr.assert_called()
-
-
-@patch("cou.commands.setattr")
-def test_purge_before_argument_action_failed(mock_setattr):
-    parser = ArgumentParser()
-    parser.add_argument("--purge", action="store_true", default=False)
-    parser.add_argument(
-        "--purge-before-date",
-        dest="purge_before",
-        type=str,
-        action=commands.PurgeBeforeArgumentAction,
-    )
+def test_purge_before_argument_missing_dependency(mock_setattr):
     with pytest.raises(SystemExit, match="2"):
-        parser.parse_args("--purge-before-date 2000-01-02".split())
+        commands.parse_args("plan --purge-before-date 2000-01-02".split())
 
 
 @patch("cou.commands.setattr")


### PR DESCRIPTION
Currently, the dependency check only works if `--purge` is specified first. If the `--purge` is after `--purge-before-date`, the dependency check action still report missing require args `--purge`. For example, `cou plan --purge-before-date 2000-1-1 --purge` will fail.

This PR fixed that issue, making the order of `--purge` and `--purge-before-date` unimportant