### PR TITLE
Fix archive step

### DIFF
--- a/cou/steps/plan.py
+++ b/cou/steps/plan.py
@@ -582,7 +582,7 @@ def _get_archive_data_steps(analysis_result: Analysis, args: CLIargs) -> list[Pr
                 description="Archive old database data on nova-cloud-controller",
                 coro=archive(
                     analysis_result.model,
-                    analysis_result.apps_data_plane,
+                    analysis_result.apps_control_plane,
                     batch_size=args.archive_batch_size,
                 ),
             )

--- a/tests/unit/steps/test_plan.py
+++ b/tests/unit/steps/test_plan.py
@@ -1111,7 +1111,9 @@ def test_get_archive_data_steps(cli_args, model):
         PreUpgradeStep(
             description="Archive old database data on nova-cloud-controller",
             coro=archive(
-                mock_analysis_result.model, mock_analysis_result.apps_control_plane, batch_size=2000
+                mock_analysis_result.model,
+                mock_analysis_result.apps_control_plane,
+                batch_size=2000,
             ),
         )
     ]

--- a/tests/unit/steps/test_plan.py
+++ b/tests/unit/steps/test_plan.py
@@ -1111,7 +1111,7 @@ def test_get_archive_data_steps(cli_args, model):
         PreUpgradeStep(
             description="Archive old database data on nova-cloud-controller",
             coro=archive(
-                mock_analysis_result.model, mock_analysis_result.apps_data_plane, batch_size=2000
+                mock_analysis_result.model, mock_analysis_result.apps_control_plane, batch_size=2000
             ),
         )
     ]


### PR DESCRIPTION
nova-cloud-controller is in the control plane group, not data plane. The wrong group was being passed,
so archive could not found the nova-cloud-controller units.

Fixes: #547