### PR TITLE
Update mapping for ceph on caracal

### DIFF
--- a/cou/utils/openstack_to_track_mapping.csv
+++ b/cou/utils/openstack_to_track_mapping.csv
@@ -7,7 +7,7 @@ ceph-mon,focal,yoga,quincy
 ceph-mon,jammy,yoga,quincy
 ceph-mon,jammy,zed,quincy
 ceph-mon,jammy,2023.1,quincy
-ceph-mon,jammy,2024.1,reef
+ceph-mon,jammy,2024.1,squid
 ceph-fs,focal,ussuri,octopus
 ceph-fs,focal,victoria,octopus
 ceph-fs,focal,wallaby,pacific
@@ -16,7 +16,7 @@ ceph-fs,focal,yoga,quincy
 ceph-fs,jammy,yoga,quincy
 ceph-fs,jammy,zed,quincy
 ceph-fs,jammy,2023.1,quincy
-ceph-fs,jammy,2024.1,reef
+ceph-fs,jammy,2024.1,squid
 ceph-radosgw,focal,ussuri,octopus
 ceph-radosgw,focal,victoria,octopus
 ceph-radosgw,focal,wallaby,pacific
@@ -25,7 +25,7 @@ ceph-radosgw,focal,yoga,quincy
 ceph-radosgw,jammy,yoga,quincy
 ceph-radosgw,jammy,zed,quincy
 ceph-radosgw,jammy,2023.1,quincy
-ceph-radosgw,jammy,2024.1,reef
+ceph-radosgw,jammy,2024.1,squid
 ceph-osd,focal,ussuri,octopus
 ceph-osd,focal,victoria,octopus
 ceph-osd,focal,wallaby,pacific
@@ -34,7 +34,7 @@ ceph-osd,focal,yoga,quincy
 ceph-osd,jammy,yoga,quincy
 ceph-osd,jammy,zed,quincy
 ceph-osd,jammy,2023.1,quincy
-ceph-osd,jammy,2024.1,reef
+ceph-osd,jammy,2024.1,squid
 ceph-dashboard,focal,ussuri,octopus
 ceph-dashboard,focal,victoria,octopus
 ceph-dashboard,focal,wallaby,pacific
@@ -43,7 +43,7 @@ ceph-dashboard,focal,yoga,quincy
 ceph-dashboard,jammy,yoga,quincy
 ceph-dashboard,jammy,zed,quincy
 ceph-dashboard,jammy,2023.1,quincy
-ceph-dashboard,jammy,2024.1,reef
+ceph-dashboard,jammy,2024.1,squid
 ovn-chassis,focal,ussuri,20.03
 ovn-chassis,focal,ussuri,22.03
 ovn-chassis,focal,victoria,20.03

--- a/tests/unit/utils/test_openstack.py
+++ b/tests/unit/utils/test_openstack.py
@@ -354,7 +354,7 @@ def test_determine_previous_openstack_release(o7k_release, previous_o7k_release)
         ("jammy", "ceph-mon", "yoga", ["quincy"]),
         ("jammy", "ceph-mon", "zed", ["quincy"]),
         ("jammy", "ceph-mon", "2023.1", ["quincy"]),
-        ("jammy", "ceph-mon", "2024.1", ["reef"]),
+        ("jammy", "ceph-mon", "2024.1", ["squid"]),
         ("focal", "ovn-central", "ussuri", ["20.03", "22.03"]),
         ("focal", "ovn-central", "victoria", ["20.03", "22.03"]),
         ("focal", "ovn-central", "wallaby", ["20.12", "22.03"]),


### PR DESCRIPTION
According to https://ubuntu.com/ceph/docs/supported-ceph-versions , Ceph Squid release must be used with OpenStack Caracal.

WARNING: at this time I'm not sure if ceph charms will support upgrading directly from quincy to squid, so this may require more work (we do a single step antelope -> caracal openstack upgrade, but ceph charms may require two steps: quincy -> reef -> squid).