### PR TITLE
Tidy check workflow naming and graph

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -1,4 +1,4 @@
-name: Check workflow running linter, unit and functional tests
+name: Tests
 
 on:
   workflow_call:
@@ -16,8 +16,8 @@ concurrency:
       cancel-in-progress: true
 
 jobs:
-  lint-unit:
-    name: Lint checkers and Unit tests
+  lint:
+    name: Linters
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
@@ -33,12 +33,27 @@ jobs:
         python -m pip install tox
     - name: Run lint checkers
       run: tox -e lint
+
+  unit:
+    name: Unit tests
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        submodules: true
+    - name: Set up Python 3.10
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.10'
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install tox
     - name: Run unit tests
       run: tox -e unit
 
   mocked-plans:
-    name: Mocked plans tests
-    needs: lint-unit
+    name: Mocked plans
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
@@ -54,8 +69,11 @@ jobs:
       run: tox -e mocked-plans
 
   snap-build:
-    name: Build snap package
-    needs: lint-unit
+    name: Build snap
+    needs:
+      - lint
+      - unit
+      - mocked-plans
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:


### PR DESCRIPTION
Some usability improvements on the check workflow:
- shorter names so they aren't truncated by the github ui
- split unit and lint tests
- only build the snap if lint, unit, and mocked-plans succeed