### PR TITLE
Improve error message for enable version pinning

### DIFF
--- a/cou/apps/auxiliary.py
+++ b/cou/apps/auxiliary.py
@@ -411,7 +411,16 @@ class OVN(AuxiliaryApplication):
             return
         if self.config["enable-version-pinning"].get("value"):
             raise ApplicationError(
-                f"Cannot upgrade '{self.name}'. 'enable-version-pinning' must be set to 'false'."
+                (
+                    f"Cannot upgrade '{self.name}'. "
+                    "'enable-version-pinning' must be set to 'false' because "
+                    "from OVN LTS version 22.03 and onwards, rolling chassis upgrades are "
+                    "supported when upgrading to minor versions as well as to any version within"
+                    "the next major OVN LTS version."
+                    "For move information, please refer to the charm guide at: "
+                    "https://docs.openstack.org/charm-guide/latest/project/procedures/"
+                    "ovn-upgrade-2203.html#disable-version-pinning"
+                )
             )
 
     def upgrade_plan_sanity_checks(

--- a/tests/unit/apps/test_auxiliary.py
+++ b/tests/unit/apps/test_auxiliary.py
@@ -1031,6 +1031,7 @@ def test_ovn_version_pinning_principal(model):
     target = OpenStackRelease("victoria")
     charm = "ovn-dedicated-chassis"
     machines = {"0": generate_cou_machine("0", "az-0")}
+    exp_regex_msg = ".*enable-version-pinning.*"
     app = OVNPrincipal(
         name=charm,
         can_upgrade_to="22.03/stable",
@@ -1052,7 +1053,7 @@ def test_ovn_version_pinning_principal(model):
         workload_version="22.03.2",
     )
 
-    with pytest.raises(ApplicationError):
+    with pytest.raises(ApplicationError, match=exp_regex_msg):
         app.upgrade_plan_sanity_checks(target, list(app.units.values()))
 
 
@@ -1130,6 +1131,7 @@ def test_ovn_check_version_pinning_version_pinning_config_False(app, config, mod
 
 def test_ovn_check_version_pinning_version_pinning_config_True(model):
     machines = {"0": generate_cou_machine("0", "az-0")}
+    exp_regex_msg = ".*enable-version-pinning.*"
     app = OVNPrincipal(
         name="ovn-dedicated-chassis",
         can_upgrade_to="",
@@ -1150,7 +1152,7 @@ def test_ovn_check_version_pinning_version_pinning_config_True(model):
         },
         workload_version="22.03",
     )
-    with pytest.raises(ApplicationError):
+    with pytest.raises(ApplicationError, match=exp_regex_msg):
         app._check_version_pinning()
 
 

--- a/tests/unit/apps/test_auxiliary.py
+++ b/tests/unit/apps/test_auxiliary.py
@@ -1030,7 +1030,16 @@ def test_ovn_version_pinning_principal(model):
     """Test the OVNPrincipal when enable-version-pinning is set to True."""
     target = OpenStackRelease("victoria")
     charm = "ovn-dedicated-chassis"
-    exp_msg = f"Cannot upgrade '{charm}'. 'enable-version-pinning' must be set to 'false'."
+    exp_msg = (
+        f"Cannot upgrade '{charm}'. "
+        "'enable-version-pinning' must be set to 'false' because "
+        "from OVN LTS version 22.03 and onwards, rolling chassis upgrades are "
+        "supported when upgrading to minor versions as well as to any version within"
+        "the next major OVN LTS version."
+        "For move information, please refer to the charm guide at: "
+        "https://docs.openstack.org/charm-guide/latest/project/procedures/"
+        "ovn-upgrade-2203.html#disable-version-pinning"
+    )
     machines = {"0": generate_cou_machine("0", "az-0")}
     app = OVNPrincipal(
         name=charm,
@@ -1151,7 +1160,16 @@ def test_ovn_check_version_pinning_version_pinning_config_True(model):
         },
         workload_version="22.03",
     )
-    exp_msg = f"Cannot upgrade '{app.name}'. 'enable-version-pinning' must be set to 'false'."
+    exp_msg = (
+        f"Cannot upgrade '{app.name}'. "
+        "'enable-version-pinning' must be set to 'false' because "
+        "from OVN LTS version 22.03 and onwards, rolling chassis upgrades are "
+        "supported when upgrading to minor versions as well as to any version within"
+        "the next major OVN LTS version."
+        "For move information, please refer to the charm guide at: "
+        "https://docs.openstack.org/charm-guide/latest/project/procedures/"
+        "ovn-upgrade-2203.html#disable-version-pinning"
+    )
     with pytest.raises(ApplicationError, match=exp_msg):
         app._check_version_pinning()
 

--- a/tests/unit/apps/test_auxiliary.py
+++ b/tests/unit/apps/test_auxiliary.py
@@ -1030,16 +1030,6 @@ def test_ovn_version_pinning_principal(model):
     """Test the OVNPrincipal when enable-version-pinning is set to True."""
     target = OpenStackRelease("victoria")
     charm = "ovn-dedicated-chassis"
-    exp_msg = (
-        f"Cannot upgrade '{charm}'. "
-        "'enable-version-pinning' must be set to 'false' because "
-        "from OVN LTS version 22.03 and onwards, rolling chassis upgrades are "
-        "supported when upgrading to minor versions as well as to any version within"
-        "the next major OVN LTS version."
-        "For move information, please refer to the charm guide at: "
-        "https://docs.openstack.org/charm-guide/latest/project/procedures/"
-        "ovn-upgrade-2203.html#disable-version-pinning"
-    )
     machines = {"0": generate_cou_machine("0", "az-0")}
     app = OVNPrincipal(
         name=charm,
@@ -1062,7 +1052,7 @@ def test_ovn_version_pinning_principal(model):
         workload_version="22.03.2",
     )
 
-    with pytest.raises(ApplicationError, match=exp_msg):
+    with pytest.raises(ApplicationError):
         app.upgrade_plan_sanity_checks(target, list(app.units.values()))
 
 
@@ -1160,17 +1150,7 @@ def test_ovn_check_version_pinning_version_pinning_config_True(model):
         },
         workload_version="22.03",
     )
-    exp_msg = (
-        f"Cannot upgrade '{app.name}'. "
-        "'enable-version-pinning' must be set to 'false' because "
-        "from OVN LTS version 22.03 and onwards, rolling chassis upgrades are "
-        "supported when upgrading to minor versions as well as to any version within"
-        "the next major OVN LTS version."
-        "For move information, please refer to the charm guide at: "
-        "https://docs.openstack.org/charm-guide/latest/project/procedures/"
-        "ovn-upgrade-2203.html#disable-version-pinning"
-    )
-    with pytest.raises(ApplicationError, match=exp_msg):
+    with pytest.raises(ApplicationError):
         app._check_version_pinning()
 
 

--- a/tests/unit/apps/test_auxiliary_subordinate.py
+++ b/tests/unit/apps/test_auxiliary_subordinate.py
@@ -155,7 +155,16 @@ def test_ovn_version_pinning_subordinate(model):
     charm = "ovn-chassis"
     target = OpenStackRelease("victoria")
     machines = {"0": generate_cou_machine("0", "az-0")}
-    exp_msg = f"Cannot upgrade '{charm}'. 'enable-version-pinning' must be set to 'false'."
+    exp_msg = (
+        f"Cannot upgrade '{charm}'. "
+        "'enable-version-pinning' must be set to 'false' because "
+        "from OVN LTS version 22.03 and onwards, rolling chassis upgrades are "
+        "supported when upgrading to minor versions as well as to any version within"
+        "the next major OVN LTS version."
+        "For move information, please refer to the charm guide at: "
+        "https://docs.openstack.org/charm-guide/latest/project/procedures/"
+        "ovn-upgrade-2203.html#disable-version-pinning"
+    )
     app = OVNSubordinate(
         name=charm,
         can_upgrade_to="",

--- a/tests/unit/apps/test_auxiliary_subordinate.py
+++ b/tests/unit/apps/test_auxiliary_subordinate.py
@@ -155,16 +155,6 @@ def test_ovn_version_pinning_subordinate(model):
     charm = "ovn-chassis"
     target = OpenStackRelease("victoria")
     machines = {"0": generate_cou_machine("0", "az-0")}
-    exp_msg = (
-        f"Cannot upgrade '{charm}'. "
-        "'enable-version-pinning' must be set to 'false' because "
-        "from OVN LTS version 22.03 and onwards, rolling chassis upgrades are "
-        "supported when upgrading to minor versions as well as to any version within"
-        "the next major OVN LTS version."
-        "For move information, please refer to the charm guide at: "
-        "https://docs.openstack.org/charm-guide/latest/project/procedures/"
-        "ovn-upgrade-2203.html#disable-version-pinning"
-    )
     app = OVNSubordinate(
         name=charm,
         can_upgrade_to="",
@@ -180,7 +170,7 @@ def test_ovn_version_pinning_subordinate(model):
         workload_version="22.3",
     )
 
-    with pytest.raises(ApplicationError, match=exp_msg):
+    with pytest.raises(ApplicationError):
         app.generate_upgrade_plan(target, False)
 
 

--- a/tests/unit/apps/test_auxiliary_subordinate.py
+++ b/tests/unit/apps/test_auxiliary_subordinate.py
@@ -155,6 +155,7 @@ def test_ovn_version_pinning_subordinate(model):
     charm = "ovn-chassis"
     target = OpenStackRelease("victoria")
     machines = {"0": generate_cou_machine("0", "az-0")}
+    exp_regex_msg = ".*enable-version-pinning.*"
     app = OVNSubordinate(
         name=charm,
         can_upgrade_to="",
@@ -170,7 +171,7 @@ def test_ovn_version_pinning_subordinate(model):
         workload_version="22.3",
     )
 
-    with pytest.raises(ApplicationError):
+    with pytest.raises(ApplicationError, match=exp_regex_msg):
         app.generate_upgrade_plan(target, False)
 
 


### PR DESCRIPTION
Add more context on why COU is requiring version pinning set to `False` for OVN charms.

Closes: #460 