### PR TITLE
Improve parse_args tests

### DIFF
--- a/cou/cli.py
+++ b/cou/cli.py
@@ -245,8 +245,14 @@ async def _run_command(args: CLIargs) -> None:
 
 
 def entrypoint() -> None:
-    """Execute 'charmed-openstack-upgrade' command."""
+    """Run the cli app.
+
+    Only this function and parse_args() should call sys.exit.
+    Other functions that find a blocking error should raise an Exception
+    and let it be handled by this function.
+    """
     args = parse_args(sys.argv[1:])
+
     log_file: Optional[Path] = None
     try:
         # disable progress indicator when in quiet mode to suppress its console output

--- a/cou/commands.py
+++ b/cou/commands.py
@@ -541,8 +541,6 @@ def parse_args(args: list[str]) -> CLIargs:  # pylint: disable=inconsistent-retu
     if len(args) == 0 or (len(args) == 1 and args[0] == "help"):
         parser.print_help()
         parser.exit()
-        # This line is reachable in unit tests when .exit() is mocked.
-        return  # type: ignore[unreachable]
 
     try:
         parsed_args = CLIargs(**vars(parser.parse_args(args)))
@@ -555,8 +553,6 @@ def parse_args(args: list[str]) -> CLIargs:  # pylint: disable=inconsistent-retu
                 case "upgrade":
                     subparsers.choices["upgrade"].print_help()
             parser.exit()
-            # This line is reachable in unit tests when .exit() is mocked.
-            return  # type: ignore[unreachable]
 
         # validate arguments
         validation_errors = []
@@ -564,8 +560,6 @@ def parse_args(args: list[str]) -> CLIargs:  # pylint: disable=inconsistent-retu
             validation_errors.append("--purge-before-date requires --purge")
         if validation_errors:
             parser.error("\n" + "\n".join(validation_errors))
-            # This line is reachable in unit tests when .error() is mocked.
-            return  # type: ignore[unreachable]
 
         return parsed_args
     except argparse.ArgumentError as exc:

--- a/cou/commands.py
+++ b/cou/commands.py
@@ -118,14 +118,14 @@ def purge_before_arg(value: str) -> str:
     :rtype: str
     :raises argparse.ArgumentTypeError: if string format is invalid
     """
-    formats = ["%Y-%m-%d%H:%M:%S", "%Y-%m-%d%H:%M", "%Y-%m-%d"]
+    formats = ["%Y-%m-%d %H:%M:%S", "%Y-%m-%d %H:%M", "%Y-%m-%d"]
     for fmt in formats:
         try:
             datetime.strptime(value, fmt)
             return value
         except ValueError:
             pass
-    raise argparse.ArgumentTypeError("purge before format must be YYYY-MM-DD[HH:mm][:ss]")
+    raise argparse.ArgumentTypeError("format must be YYYY-MM-DD[ HH:mm[:ss]]")
 
 
 def get_subcommand_common_opts_parser() -> argparse.ArgumentParser:
@@ -197,7 +197,7 @@ def get_subcommand_common_opts_parser() -> argparse.ArgumentParser:
         help=(
             "Providing this argument will delete data from all shadow tables"
             "\nthat is older than the date provided."
-            "\nDate string format should be YYYY-MM-DD[HH:mm][:ss]."
+            "\nDate string format should be YYYY-MM-DD[ HH:mm[:ss]]."
             "\nWithout --purge-before-date the purge step will delete all the data."
             "\nThis option requires --purge."
         ),

--- a/cou/steps/nova_cloud_controller.py
+++ b/cou/steps/nova_cloud_controller.py
@@ -76,7 +76,7 @@ async def purge(model: Model, apps: Sequence[Application], before: Optional[str]
     :type apps: Sequence of Applications
     :param before: specifying before will delete data from all shadow tables
         that is older than the data provided.
-        Date string format should be YYYY-MM-DD[HH:mm][:ss]
+        Date string format should be YYYY-MM-DD[ HH:mm[:ss]]
     :raises COUException: if action returned unexpected output or failed
     """
     action_params = {}

--- a/docs/how-to/purge-data-on-shadow-table.rst
+++ b/docs/how-to/purge-data-on-shadow-table.rst
@@ -7,7 +7,7 @@ This can be enabled with the ``--purge`` flag.
 
 This purge step is a performance optimisation, delete data from the shadow tables in nova database. The behaviour is equal to run juju action ``purge`` on nova-cloud-controller unit, which help to reduce the size of the database, make queries faster, backups efficiency, and follow the data retention policies.
 
-The ``purge-before-date`` flag is supported to delete the data older than the date provided. The date string format should be ``YYYY-MM-DD[HH:mm][:ss]``. This flag is useful to retain recent data for debugging or data retention policies.
+The ``--purge-before-date`` flag is supported to delete the data older than the date provided. The date string format should be ``YYYY-MM-DD[ HH:mm[:ss]]``. This flag is useful to retain recent data for debugging or data retention policies.
 
 
 Usage examples

--- a/tests/unit/test_commands.py
+++ b/tests/unit/test_commands.py
@@ -191,7 +191,7 @@ def test_parse_args_quiet_verbose_exclusive(mock_error, args):
             ),
         ),
         (
-            ["plan", "--purge", "--purge-before-date", "2000-01-0203:04"],
+            ["plan", "--purge", "--purge-before-date", "2000-01-02 03:04"],
             CLIargs(
                 command="plan",
                 model_name=None,
@@ -200,12 +200,12 @@ def test_parse_args_quiet_verbose_exclusive(mock_error, args):
                 backup=True,
                 force=False,
                 purge=True,
-                purge_before="2000-01-0203:04",
+                purge_before="2000-01-02 03:04",
                 **{"upgrade_group": None}
             ),
         ),
         (
-            ["plan", "--purge", "--purge-before-date", "2000-01-0203:04:05"],
+            ["plan", "--purge", "--purge-before-date", "2000-01-02 03:04:05"],
             CLIargs(
                 command="plan",
                 model_name=None,
@@ -214,7 +214,7 @@ def test_parse_args_quiet_verbose_exclusive(mock_error, args):
                 backup=True,
                 force=False,
                 purge=True,
-                purge_before="2000-01-0203:04:05",
+                purge_before="2000-01-02 03:04:05",
                 **{"upgrade_group": None}
             ),
         ),
@@ -551,7 +551,7 @@ def test_parse_args_plan(args, expected_CLIargs):
             ),
         ),
         (
-            ["upgrade", "--purge", "--purge-before-date", "2000-01-0203:04:05"],
+            ["upgrade", "--purge", "--purge-before-date", "2000-01-02 03:04:05"],
             CLIargs(
                 command="upgrade",
                 model_name=None,
@@ -561,7 +561,7 @@ def test_parse_args_plan(args, expected_CLIargs):
                 backup=True,
                 force=False,
                 purge=True,
-                purge_before="2000-01-0203:04:05",
+                purge_before="2000-01-02 03:04:05",
                 **{"upgrade_group": None}
             ),
         ),
@@ -862,8 +862,8 @@ def test_parse_args_hypervisors_exclusive_options_reverse_order(mock_error):
         ["upgrade", "--archive-batch-size", "0"],
         ["plan", "--archive-batch-size", "0"],
         ["plan", "--purge_before", "2000-01-02"],
-        ["plan", "--purge_before", "2000-01-0203:04"],
-        ["plan", "--purge_before", "2000-01-0203:04:05"],
+        ["plan", "--purge_before", "2000-01-02 03:04"],
+        ["plan", "--purge_before", "2000-01-02 03:04:05"],
         ["upgrade", "--skip-apps", "vault keystone"],
         ["plan", "--skip_apps", "vault keystone"],
     ],
@@ -929,8 +929,8 @@ def test_capitalize_help_message():
 @pytest.mark.parametrize(
     "val",
     [
-        "2000-01-02 03:04",
-        "2000-01-02 03:04:05",
+        "2000-01-0203:04",
+        "2000-01-0203:04:05",
         "2000-01-02 03:04:05 something-wrong",
     ],
 )
@@ -944,8 +944,8 @@ def test_purge_before_arg_invalid(val):
     "val",
     [
         "2000-01-02",
-        "2000-01-0203:04",
-        "2000-01-0203:04:05",
+        "2000-01-02 03:04",
+        "2000-01-02 03:04:05",
     ],
 )
 def test_purge_before_arg_valid(val):


### PR DESCRIPTION
Make the tests more precise, so we can be more confident
that the tests are verifying the expected cases.

Also fix a bug in datetime format parsing in purge_before_arg().

Fixes: #442
