### PR TITLE
Remove unused arg from _check_mismatched_versions

### DIFF
--- a/cou/apps/auxiliary.py
+++ b/cou/apps/auxiliary.py
@@ -423,15 +423,11 @@ class OVN(AuxiliaryApplication):
                 )
             )
 
-    def upgrade_plan_sanity_checks(
-        self, target: OpenStackRelease, units: Optional[list[Unit]]
-    ) -> None:
+    def upgrade_plan_sanity_checks(self, target: OpenStackRelease) -> None:
         """Run sanity checks before generating upgrade plan.
 
         :param target: OpenStack release as target to upgrade.
         :type target: OpenStackRelease
-        :param units: Units to generate upgrade plan, defaults to None
-        :type units: Optional[list[Unit]], optional
         :raises ApplicationError: When application is wrongly configured.
         :raises HaltUpgradePlanGeneration: When the application halt the upgrade plan generation.
         :raises MismatchedOpenStackVersions: When the units of the app are running different
@@ -439,7 +435,7 @@ class OVN(AuxiliaryApplication):
         """
         self._check_ovn_support()
         self._check_version_pinning()
-        super().upgrade_plan_sanity_checks(target, units)
+        super().upgrade_plan_sanity_checks(target)
 
 
 @AppFactory.register_application(["ovn-central", "ovn-dedicated-chassis"])

--- a/cou/apps/base.py
+++ b/cou/apps/base.py
@@ -398,15 +398,11 @@ class OpenStackApplication(Application):
                 "COU in a few minutes."
             )
 
-    def upgrade_plan_sanity_checks(
-        self, target: OpenStackRelease, units: Optional[list[Unit]]
-    ) -> None:
+    def upgrade_plan_sanity_checks(self, target: OpenStackRelease) -> None:
         """Run sanity checks before generating upgrade plan.
 
         :param target: OpenStack release as target to upgrade.
         :type target: OpenStackRelease
-        :param units: Units to generate upgrade plan, defaults to None
-        :type units: Optional[list[Unit]], optional
         :raises ApplicationError: When application is wrongly configured.
         :raises HaltUpgradePlanGeneration: When the application halt the upgrade plan generation.
         :raises MismatchedOpenStackVersions: When the units of the app are running
@@ -414,7 +410,7 @@ class OpenStackApplication(Application):
         """
         self._check_channel()
         self._check_application_target(target)
-        self._check_mismatched_versions(units)
+        self._check_mismatched_versions()
         self._check_auto_restarts()
         logger.info(
             "%s application met all the necessary prerequisites to generate the upgrade plan",
@@ -497,7 +493,7 @@ class OpenStackApplication(Application):
         :return: Full upgrade plan if the Application is able to generate it.
         :rtype: ApplicationUpgradePlan
         """
-        self.upgrade_plan_sanity_checks(target, units)
+        self.upgrade_plan_sanity_checks(target)
 
         upgrade_plan = ApplicationUpgradePlan(f"Upgrade plan for '{self.name}' to '{target}'")
         upgrade_plan.add_steps(self.pre_upgrade_steps(target, units))
@@ -912,14 +908,9 @@ class OpenStackApplication(Application):
                 f"than {target}. Ignoring."
             )
 
-    def _check_mismatched_versions(self, units: Optional[list[Unit]]) -> None:
+    def _check_mismatched_versions(self) -> None:
         """Check that there are no mismatched versions on app units.
 
-        If units are passed, the application will be upgraded in unit-by-unit fashion,
-        and mismatch is not checked.
-
-        :param units: Units to generate upgrade plan
-        :type units: Optional[list[Unit]]
         :raises MismatchedOpenStackVersions: When the units of the app are running
                                              different OpenStack versions.
         """

--- a/cou/apps/core.py
+++ b/cou/apps/core.py
@@ -247,15 +247,11 @@ class Swift(OpenStackApplication):
     valid OpenStack components, but not currently supported by COU for upgrade.
     """
 
-    def upgrade_plan_sanity_checks(
-        self, target: OpenStackRelease, units: Optional[list[Unit]]
-    ) -> None:
+    def upgrade_plan_sanity_checks(self, target: OpenStackRelease) -> None:
         """Run sanity checks before generating upgrade plan.
 
         :param target: OpenStack release as target to upgrade.
         :type target: OpenStackRelease
-        :param units: Units to generate upgrade plan, defaults to None
-        :type units: Optional[list[Unit]], optional
         :raises ApplicationNotSupported: When application is known but not currently
                                          supported by COU.
         """

--- a/cou/steps/hypervisor.py
+++ b/cou/steps/hypervisor.py
@@ -180,11 +180,10 @@ class HypervisorUpgradePlanner:
                 )
                 continue
 
-            units = group.app_units[app.name]
-            logger.info("running sanity checks for %s units of %s app", app.name, units)
+            logger.info("running sanity checks for %s app", app.name)
             # Note(rgildein): We don't catch the error here because we shouldn't generate any
             #                 update plan if sanity checks for any application fails.
-            app.upgrade_plan_sanity_checks(target, units)
+            app.upgrade_plan_sanity_checks(target)
 
     def _generate_pre_upgrade_steps(
         self, target: OpenStackRelease, group: HypervisorGroup

--- a/tests/unit/apps/test_auxiliary.py
+++ b/tests/unit/apps/test_auxiliary.py
@@ -1054,7 +1054,7 @@ def test_ovn_version_pinning_principal(model):
     )
 
     with pytest.raises(ApplicationError, match=exp_regex_msg):
-        app.upgrade_plan_sanity_checks(target, list(app.units.values()))
+        app.upgrade_plan_sanity_checks(target)
 
 
 @pytest.mark.parametrize("channel", ["55.7", "19.03"])

--- a/tests/unit/apps/test_base.py
+++ b/tests/unit/apps/test_base.py
@@ -456,7 +456,7 @@ def test_check_mismatched_versions_exception(mock_o7k_release_units, model):
     )
 
     with pytest.raises(MismatchedOpenStackVersions, match=exp_error_msg):
-        app._check_mismatched_versions(None)
+        app._check_mismatched_versions()
 
 
 @patch("cou.apps.base.OpenStackApplication.o7k_release_units", new_callable=PropertyMock)
@@ -506,7 +506,7 @@ def test_check_mismatched_versions_with_nova_compute(mock_o7k_release_units, mod
         workload_version="18.1.0",
     )
 
-    assert app._check_mismatched_versions(None) is None
+    assert app._check_mismatched_versions() is None
 
 
 @patch("cou.apps.base.OpenStackApplication.o7k_release_units", new_callable=PropertyMock)
@@ -550,7 +550,7 @@ def test_check_mismatched_versions(mock_o7k_release_units, model):
         workload_version="17.0.1",
     )
 
-    assert app._check_mismatched_versions([units["my-app/0"]]) is None
+    assert app._check_mismatched_versions() is None
 
 
 @patch("cou.apps.base.OpenStackApplication.o7k_release", new_callable=PropertyMock)

--- a/tests/unit/steps/test_hypervisor.py
+++ b/tests/unit/steps/test_hypervisor.py
@@ -57,8 +57,8 @@ def test_upgrade_plan_sanity_checks():
 
     planner._upgrade_plan_sanity_checks(target, group)
 
-    apps[0].upgrade_plan_sanity_checks.assert_called_once_with(target, app_units["app1"])
-    apps[1].upgrade_plan_sanity_checks.assert_called_once_with(target, app_units["app2"])
+    apps[0].upgrade_plan_sanity_checks.assert_called_once_with(target)
+    apps[1].upgrade_plan_sanity_checks.assert_called_once_with(target)
     apps[2].upgrade_plan_sanity_checks.assert_not_called()
 
 


### PR DESCRIPTION
`units` was not referenced in `_check_mismatched_versions`, so we can remove it.