### PR TITLE
Improve message with unsupported channel

### DIFF
--- a/cou/apps/base.py
+++ b/cou/apps/base.py
@@ -669,7 +669,7 @@ class OpenStackApplication(Application):
 
         :param target: OpenStack release as target to upgrade.
         :type target: OpenStackRelease
-        :raises ApplicationError: When the current channel is ahead from expected and the target.
+        :raises ApplicationError: When the current channel is ahead of the upgrade target.
         :return: List of steps for upgrading the charm.
         :rtype: list[UpgradeStep]
         """
@@ -698,9 +698,11 @@ class OpenStackApplication(Application):
             ]
 
         raise ApplicationError(
-            f"The '{self.name}' application is using channel '{self.channel}'. Channels supported "
-            f"during this transition: '{self.expected_current_channel(target)}', "
-            f"'{self.target_channel(target)}'. Manual intervention is required."
+            f"The '{self.name}' application is using an unexpected channel: '{self.channel}'. "
+            "Channels supported during this upgrade are, "
+            f"before upgrade: '{self.expected_current_channel(target)}', "
+            f"or after upgrade: '{self.target_channel(target)}'. "
+            "Please manually downgrade to a supported release."
         )
 
     def _set_action_managed_upgrade(self, enable: bool) -> UpgradeStep:

--- a/cou/apps/base.py
+++ b/cou/apps/base.py
@@ -702,7 +702,8 @@ class OpenStackApplication(Application):
             "Channels supported during this upgrade are, "
             f"before upgrade: '{self.expected_current_channel(target)}', "
             f"or after upgrade: '{self.target_channel(target)}'. "
-            "Please manually downgrade to a supported release."
+            "Manual intervention required, most likely to manually upgrade "
+            "other cloud components until all are consistent releases."
         )
 
     def _set_action_managed_upgrade(self, enable: bool) -> UpgradeStep:

--- a/tests/unit/apps/test_auxiliary.py
+++ b/tests/unit/apps/test_auxiliary.py
@@ -1653,13 +1653,7 @@ def test_auxiliary_wrong_channel(model):
     # plan will raise exception because the channel is on quincy and was expected to be on octopus
     # or pacific. The user will need manual intervention
 
-    exp_msg = (
-        r"^The 'ceph-mon' application is using channel 'quincy/stable'\. Channels supported during"
-        r" this transition: '(octopus/stable)', '(octopus/stable)'\. "
-        r"Manual intervention is required\.$"
-    )
-
-    with pytest.raises(ApplicationError, match=exp_msg):
+    with pytest.raises(ApplicationError, match=".*unexpected channel.*"):
         app.generate_upgrade_plan(target, force=False)
 
 

--- a/tests/unit/apps/test_core.py
+++ b/tests/unit/apps/test_core.py
@@ -1128,14 +1128,7 @@ def test_core_wrong_channel(model):
 
     # plan will raise exception because the channel is on wallaby and was expected to be on ussuri
     # or victoria. The user will need manual intervention
-
-    exp_msg = (
-        r"^The 'keystone' application is using channel 'wallaby/stable'\. Channels supported "
-        r"during this transition: '(ussuri/stable)', '(victoria/stable)'\. "
-        r"Manual intervention is required\.$"
-    )
-
-    with pytest.raises(ApplicationError, match=exp_msg):
+    with pytest.raises(ApplicationError, match=".*unexpected channel.*"):
         app.generate_upgrade_plan(target, force=False)
 
 


### PR DESCRIPTION
This is the message that's printed when COU finds a charm that is a newer channel than supported by the current OpenStack deployment.

Fixes: #461