### PR TITLE
Fetch full git history for snap build job

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -80,6 +80,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: true
+          fetch-depth: 0  # Complete git history is required to generate the version from git tags.
       - name: Setup Python
         uses: actions/setup-python@v5
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -25,8 +25,6 @@ jobs:
         runs-on: [[ubuntu-22.04]]
     steps:
       - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0  # Complete git history is required to generate the version from git tags.
 
       - name: Determine system architecture
         run: echo "SYSTEM_ARCH=$(uname -m)" >> $GITHUB_ENV


### PR DESCRIPTION
Snapcraft needs full git history
so it can build the version string for the snap from git tags.