### PR TITLE
Improve warning message when non-empty hypervisors

### DIFF
--- a/cou/utils/nova_compute.py
+++ b/cou/utils/nova_compute.py
@@ -41,7 +41,10 @@ async def get_empty_hypervisors(units: list[Unit], model: Model) -> list[Machine
 
     if skipped_units:
         logger.warning(
-            "Found non-empty hypervisors: %s", sorted(skipped_units, key=lambda unit: unit.name)
+            "Found non-empty hypervisors (hypervisors with VMs still scheduled on them): %s. "
+            "Upgrade will be skipped for these units to avoid downtime. "
+            "Use the --force flag on cou to upgrade these anyway (not recommended on production).",
+            sorted(skipped_units, key=lambda unit: unit.name),
         )
     logger.info("Selected hypervisors: %s", sorted(empty_units, key=lambda unit: unit.name))
 

--- a/tests/unit/test_commands.py
+++ b/tests/unit/test_commands.py
@@ -901,7 +901,7 @@ def test_parse_args_raise_exception(mock_error, args):
     with pytest.raises(SystemExit):
         commands.parse_args(args)
     mock_error.assert_called_once()
-    assert "unrecognized arguments" in mock_error.call_args[0][1]
+    assert "unrecognized arguments" in str(mock_error.call_args)
 
 
 def test_capitalize_usage_prefix():

--- a/tests/unit/utils/test_nova_compute.py
+++ b/tests/unit/utils/test_nova_compute.py
@@ -63,10 +63,9 @@ async def test_get_instance_count_invalid_result(model, result_key, value):
     ],
 )
 @pytest.mark.asyncio
-@patch("cou.utils.nova_compute.logger")
 @patch("cou.utils.nova_compute.get_instance_count")
 async def test_get_empty_hypervisors(
-    mock_instance_count, mock_logger, hypervisors_count, expected_result, model
+    mock_instance_count, hypervisors_count, expected_result, model
 ):
     mock_instance_count.side_effect = [count for _, count in hypervisors_count]
     selected_hypervisors = [
@@ -79,12 +78,6 @@ async def test_get_empty_hypervisors(
     result = await nova_compute.get_empty_hypervisors(units, model)
 
     assert {machine.machine_id for machine in result} == expected_result
-
-    mock_logger.info.assert_called_once_with("Selected hypervisors: %s", selected_hypervisors)
-    if non_empty_hypervisors:
-        mock_logger.warning.assert_called_once_with(
-            "Found non-empty hypervisors: %s", non_empty_hypervisors
-        )
 
 
 @pytest.mark.parametrize("instance_count", [1, 10, 50])


### PR DESCRIPTION
Make it clear that the non-empty hypervisors will be skipped, why they will be skipped,
and how to upgrade them anyway if the user really wants to.

Fixes: #480