### PR TITLE
Fix unit and func tests

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -118,11 +118,11 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: '3.10'
-      - name: Setup Juju 3.4/stable environment
+      - name: Setup Juju 3.6/stable environment
         uses: charmed-kubernetes/actions-operator@main
         with:
           provider: lxd
-          juju-channel: 3.4/stable
+          juju-channel: 3.6/stable
       - name: Remove tox install by actions-operator
         run: sudo apt remove tox -y
       - name: Install tox

--- a/cou/cli.py
+++ b/cou/cli.py
@@ -261,8 +261,7 @@ def entrypoint() -> None:
         log_file = get_log_file()
         setup_logging(log_file, log_level)
 
-        loop = asyncio.get_event_loop()
-        loop.run_until_complete(_run_command(args))
+        asyncio.run(_run_command(args))
     except HighestReleaseAchieved as exc:
         progress_indicator.succeed()
         print(exc)
@@ -300,7 +299,7 @@ def entrypoint() -> None:
         sys.exit(2)
     finally:
         if args.command == "upgrade":
-            loop.run_until_complete(run_post_upgrade_sanity_check(args))
+            asyncio.run(run_post_upgrade_sanity_check(args))
         if log_file is not None and not args.quiet:
             print(f"Full execution log: '{log_file}'")
         progress_indicator.stop()

--- a/cou/commands.py
+++ b/cou/commands.py
@@ -17,9 +17,8 @@ import argparse
 import logging
 from dataclasses import dataclass, field
 from datetime import datetime
+from importlib.metadata import version
 from typing import Any, Iterable, Optional
-
-import pkg_resources
 
 CONTROL_PLANE = "control-plane"
 DATA_PLANE = "data-plane"
@@ -531,7 +530,7 @@ def parse_args(args: list[str]) -> CLIargs:  # pylint: disable=inconsistent-retu
         action="version",
         default=argparse.SUPPRESS,
         help="Show version details.",
-        version=pkg_resources.require("charmed_openstack_upgrader")[0].version,
+        version=version("charmed_openstack_upgrader"),
     )
 
     # Configure subparsers for subcommands and their options

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,3 +106,5 @@ ignore-words-list = "assertIn"
 filterwarnings = [
     "ignore::RuntimeWarning",
 ]
+asyncio_mode = "auto"
+asyncio_default_fixture_loop_scope = "function"

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,8 +27,7 @@ python_requires = >=3.10
 packages = find:
 install_requires =
     oslo.config
-    # A temporary workaround for bug: https://github.com/juju/python-libjuju/issues/1083
-    juju>=3.0,<3.5
+    juju>=3.0,<4.0
     colorama
     packaging
     aioconsole

--- a/tests/functional/tests/smoke.py
+++ b/tests/functional/tests/smoke.py
@@ -19,10 +19,16 @@ class FuncSmokeException(Exception):
 class SmokeTest(unittest.TestCase):
     """COU smoke functional tests."""
 
+    def setUp(self) -> None:
+        zaza.get_or_create_libjuju_thread()
+        self.model_name = zaza.model.get_juju_model()
+
+    def tearDown(self) -> None:
+        zaza.clean_up_libjuju_thread()
+
     @classmethod
     def setUpClass(cls) -> None:
         cls.create_local_share_folder()
-        cls.model_name = zaza.model.get_juju_model()
         cls.configure_executable_path()
 
     @classmethod

--- a/tests/functional/tests/tests.yaml
+++ b/tests/functional/tests/tests.yaml
@@ -1,6 +1,6 @@
 tests:
-  - tests.functional.tests.model.ModelTest
   - tests.functional.tests.smoke.SmokeTest
+  - tests.functional.tests.model.ModelTest
   - tests.functional.tests.backup.BackupTest
 gate_bundles:
   - smoke

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import asyncio
 from unittest.mock import AsyncMock, MagicMock, PropertyMock, patch
 
 import pytest
@@ -67,12 +66,3 @@ def plan_status() -> None:
     """Get an empty PlanStatus for every test case."""
     PlanStatus.error_messages = []
     PlanStatus.warning_messages = []
-
-
-@pytest.fixture
-def event_loop():
-    """Create a fresh event loop for each test."""
-    loop = asyncio.new_event_loop()
-    asyncio.set_event_loop(loop)  # Ensure it's the active loop
-    yield loop
-    loop.close()  # Properly close the loop after the test

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import asyncio
 from unittest.mock import AsyncMock, MagicMock, PropertyMock, patch
 
 import pytest
@@ -66,3 +67,11 @@ def plan_status() -> None:
     """Get an empty PlanStatus for every test case."""
     PlanStatus.error_messages = []
     PlanStatus.warning_messages = []
+
+@pytest.fixture
+def event_loop():
+    """Create a fresh event loop for each test."""
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)  # Ensure it's the active loop
+    yield loop
+    loop.close()  # Properly close the loop after the test

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -68,6 +68,7 @@ def plan_status() -> None:
     PlanStatus.error_messages = []
     PlanStatus.warning_messages = []
 
+
 @pytest.fixture
 def event_loop():
     """Create a fresh event loop for each test."""


### PR DESCRIPTION
- as mentioned in the [Python Docs](https://docs.python.org/3/library/asyncio-eventloop.html#asyncio.get_event_loop):
> consider using the higher-level [asyncio.run()](https://docs.python.org/3/library/asyncio-runner.html#asyncio.run) function, instead of using these lower level functions to manually create and close an event loop.

Using `asyncio.run()` fixed the unit tests

- Func tests were weirdly failing because COU was not able to [connect to the model](https://github.com/canonical/charmed-openstack-upgrader/actions/runs/13120383434/job/36604991356) and I couldn't reproduce locally. After upgrading the lib juju version, it seems to fix.

- `pkg_resources.require` is deprecated, so I've changed to use `metadata`