### PR TITLE
Fix lint with the newer mypy version

### DIFF
--- a/cou/steps/__init__.py
+++ b/cou/steps/__init__.py
@@ -39,7 +39,12 @@ def compare_step_coroutines(coro1: Optional[Coroutine], coro2: Optional[Coroutin
     :return: True if coroutines are equal
     :rtype: bool
     """
-    if coro1 is None or coro2 is None:
+    if (
+        coro1 is None
+        or coro2 is None
+        or not hasattr(coro1, "cr_code")
+        or not hasattr(coro2, "cr_code")
+    ):
         # compare two None or one None and one Coroutine
         return coro1 == coro2
 

--- a/tox.ini
+++ b/tox.ini
@@ -25,8 +25,6 @@ commands =
     codespell
 deps =
     .[lint]
-    {[testenv:unit]deps}
-    {[testenv:func]deps}
 
 [testenv:reformat]
 deps = {[testenv:lint]deps}


### PR DESCRIPTION
Since the new release of the new mypy version (1.15.0), our lint started failing. The bug discription can be found here:
- https://github.com/python/mypy/issues/18634

I propose we pin the version to lower than the new release until the upstream code fix it.