### PR TITLE
Separate the mocked plans tests from check.yaml

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -63,23 +63,6 @@ jobs:
         name: coverage-unit-${{ env.SYSTEM_ARCH }}
         path: .coverage-unit
 
-
-  mocked-plans:
-    name: Mocked plans
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v4
-    - name: Set up Python 3.10
-      uses: actions/setup-python@v5
-      with:
-        python-version: '3.10'
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        python -m pip install tox
-    - name: Run mocked-plans tests
-      run: tox -e mocked-plans
-
   snap-build:
     name: Build snap
     needs:

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -68,7 +68,6 @@ jobs:
     needs:
       - lint
       - unit
-      - mocked-plans
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:

--- a/.github/workflows/mocked_plans.yaml
+++ b/.github/workflows/mocked_plans.yaml
@@ -1,0 +1,32 @@
+name: Mocked Plans Test
+
+on:
+  workflow_call:
+  workflow_dispatch:
+  pull_request:
+    types: [ opened, synchronize, reopened ]
+    branches: [ master, main ]
+    paths-ignore:
+      - '**.md'
+      - '**.rst'
+
+concurrency:
+      group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+      cancel-in-progress: true
+
+jobs:
+  mocked-plans:
+    name: Mocked plans
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python 3.10
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.10'
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install tox
+    - name: Run mocked-plans tests
+      run: tox -e mocked-plans


### PR DESCRIPTION
Mocked plan test is an unique thing of COU and because of that is harder to integrate the check workflow with out automation tool.

Separating into a different workflow will allow to follow the standard of our other projects

Unblocks: #617 