### PR TITLE
Fix tics

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -191,10 +191,6 @@ jobs:
 
   tics-analysis:
     runs-on: [self-hosted, linux, amd64, tiobe, jammy]
-    if: >
-      (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
-      (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main')
-    needs: func
     steps:
       - uses: actions/checkout@v4
         with:
@@ -215,42 +211,3 @@ jobs:
               pip3 install --requirement "${f}"
           done
 
-      - name: Determine system architecture
-        run: echo "SYSTEM_ARCH=$(uname -m)" >> $GITHUB_ENV
-
-      - name: Download Coverage Files
-        uses: actions/download-artifact@v4
-        with:
-          pattern: coverage-*-${{ env.SYSTEM_ARCH }}
-          merge-multiple: true
-          path: artifacts/
-        continue-on-error: true
-
-      - name: Merge coverage reports
-        run: |
-          # Create the path that is expected to have a coverage.xml for tics
-          mkdir -p tests/report/
-
-          coverage_files=(./artifacts/.coverage*)
-
-          if [ -e "${coverage_files[0]}" ]; then
-            echo "Merging coverage files: ${coverage_files[*]}"
-            coverage combine "${coverage_files[@]}"
-
-            # Check if there is actual data to report before generating XML with merged reports
-            if coverage report > /dev/null 2>&1; then
-              coverage report --show-missing
-              coverage xml -o tests/report/coverage.xml
-            fi
-
-          fi
-
-      - name: Run TICS analysis
-        uses: tiobe/tics-github-action@v3
-        with:
-          mode: qserver
-          project: charmed-openstack-upgrader
-          viewerUrl: https://canonical.tiobe.com/tiobeweb/TICS/api/cfg?name=default
-          branchdir: ${{ github.workspace }}
-          ticsAuthToken: ${{ secrets.TICSAUTHTOKEN }}
-          installTics: true

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -205,7 +205,10 @@ jobs:
           pip install coverage[toml]
 
       # Install everything from all requirements.txt files otherwise TICS errors.
-      - name: Install all snap dependencies
+      - name: Install all charm dependencies
+        env:
+          # to ensure that zaza installs correctly
+          TEST_JUJU3: "1"
         run: |
           for f in $(find -name '*requirements.txt'); do
               echo "${f}"

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -191,6 +191,10 @@ jobs:
 
   tics-analysis:
     runs-on: [self-hosted, linux, amd64, tiobe, jammy]
+    if: >
+      (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
+      (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main')
+    needs: func
     steps:
       - uses: actions/checkout@v4
         with:
@@ -211,3 +215,42 @@ jobs:
               pip3 install --requirement "${f}"
           done
 
+      - name: Determine system architecture
+        run: echo "SYSTEM_ARCH=$(uname -m)" >> $GITHUB_ENV
+
+      - name: Download Coverage Files
+        uses: actions/download-artifact@v4
+        with:
+          pattern: coverage-*-${{ env.SYSTEM_ARCH }}
+          merge-multiple: true
+          path: artifacts/
+        continue-on-error: true
+
+      - name: Merge coverage reports
+        run: |
+          # Create the path that is expected to have a coverage.xml for tics
+          mkdir -p tests/report/
+
+          coverage_files=(./artifacts/.coverage*)
+
+          if [ -e "${coverage_files[0]}" ]; then
+            echo "Merging coverage files: ${coverage_files[*]}"
+            coverage combine "${coverage_files[@]}"
+
+            # Check if there is actual data to report before generating XML with merged reports
+            if coverage report > /dev/null 2>&1; then
+              coverage report --show-missing
+              coverage xml -o tests/report/coverage.xml
+            fi
+
+          fi
+
+      - name: Run TICS analysis
+        uses: tiobe/tics-github-action@v3
+        with:
+          mode: qserver
+          project: charmed-openstack-upgrader
+          viewerUrl: https://canonical.tiobe.com/tiobeweb/TICS/api/cfg?name=default
+          branchdir: ${{ github.workspace }}
+          ticsAuthToken: ${{ secrets.TICSAUTHTOKEN }}
+          installTics: true


### PR DESCRIPTION
Without this, you'll see the following error:

```
INFO: pip is looking at multiple versions of charmed-openstack-upgrader[functests] to determine which version is compatible with other requirements. This could take a while.
ERROR: Cannot install -r ./tests/functional/requirements.txt (line 1), charmed-openstack-upgrader and charmed-openstack-upgrader[functests]==2.2.0.post5 because these package versions have conflicting dependencies.

The conflict is caused by:
    charmed-openstack-upgrader[functests] 2.2.0.post5 depends on juju<3.5 and >=3.0
ERROR: ResolutionImpossible: for help visit https://pip.pypa.io/en/latest/topics/dependency-resolution/#dealing-with-dependency-conflicts
    charmed-openstack-upgrader 2.2.0.post5 depends on juju<3.5 and >=3.0
    zaza 0.0.2.dev1 depends on juju<3.0.0
```