### PR TITLE
Allow users redirect cou output for a file

### DIFF
--- a/cou/utils/__init__.py
+++ b/cou/utils/__init__.py
@@ -17,6 +17,7 @@
 import inspect
 import logging
 import os
+import sys
 from pathlib import Path
 from typing import Any, Optional
 
@@ -26,7 +27,43 @@ from halo import Halo
 from cou.utils.text_styler import bold, normal
 
 COU_DATA = Path(f"/home/{os.getenv('USER')}/.local/share/cou") if os.getenv("USER") else Path(".")
-progress_indicator = Halo(spinner="line", placement="right")
+
+
+class SmartHalo:
+    """SmartHalo detects non-TTY and disable spinner accordingly."""
+
+    def __init__(self) -> None:
+        self.is_tty = sys.stdout.isatty()
+        self.spinner = Halo(spinner="line", placement="right") if self.is_tty else None
+
+    def start(self, text: Optional[str] = None) -> None:
+        if self.spinner:
+            self.spinner.start(text)
+        elif text:
+            print(text, flush=True)
+
+    def info(self, text: str) -> None:
+        self.spinner.info(text) if self.spinner else print(text, flush=True)
+
+    def stop(self) -> None:
+        if self.spinner:
+            self.spinner.stop()
+
+    def succeed(self, text: Optional[str] = None) -> None:
+        if self.spinner:
+            self.spinner.succeed(text)
+        elif text:
+            print(text, flush=True)
+
+    def fail(self) -> None:
+        if self.spinner:
+            self.spinner.fail()
+
+    def stop_and_persist(self, text: str) -> None:
+        self.spinner.stop_and_persist(text) if self.spinner else print(text, flush=True)
+
+
+progress_indicator = SmartHalo()
 
 
 def print_and_debug(message: Any) -> None:

--- a/cou/utils/__init__.py
+++ b/cou/utils/__init__.py
@@ -62,6 +62,10 @@ class SmartHalo:
     def stop_and_persist(self, text: str) -> None:
         self.spinner.stop_and_persist(text) if self.spinner else print(text, flush=True)
 
+    @property
+    def spinner_id(self) -> Optional[str]:
+        return self.spinner.spinner_id if self.spinner else None
+
 
 progress_indicator = SmartHalo()
 

--- a/tests/unit/utils/test_utils.py
+++ b/tests/unit/utils/test_utils.py
@@ -11,11 +11,12 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
+from typing import Optional
 from unittest.mock import patch
 
 import pytest
 
-from cou.utils import prompt_input
+from cou.utils import SmartHalo, prompt_input
 from cou.utils.text_styler import bold, normal
 
 
@@ -68,3 +69,69 @@ async def test_prompt_input_default_choice(
     await prompt_input(["test prompt message", "Continue"], default=default_choice_input)
 
     mock_input.assert_awaited_once_with(message)
+
+
+@pytest.fixture
+def fake_halo(mocker):
+    return mocker.patch("cou.utils.Halo", autospec=True)
+
+
+@pytest.mark.parametrize(
+    "method, args, expected_call",
+    [
+        ("start", ("Loading...",), "start"),  # start with text
+        ("start", (None,), "start"),  # start without text
+        ("stop", (), "stop"),
+        ("info", ("Info...",), "info"),
+        ("succeed", ("Success!",), "succeed"),  # succeed with text
+        ("succeed", (None,), "succeed"),  # succeed without text
+        ("fail", (), "fail"),
+        ("stop_and_persist", ("Saved!",), "stop_and_persist"),
+    ],
+)
+def test_smart_halo_behavior_tty(
+    mocker,
+    fake_halo,
+    method: str,
+    args: tuple,
+    expected_call: Optional[str],
+):
+    mocker.patch("sys.stdout.isatty", return_value=True)
+    halo_instance = fake_halo.return_value
+
+    halo = SmartHalo()
+
+    getattr(halo, method)(*args)
+
+    getattr(halo_instance, expected_call).assert_called_once_with(*[arg for arg in args])
+
+
+@pytest.mark.parametrize(
+    "method, args",
+    [
+        ("start", ("Loading...",)),  # start with text
+        ("start", (None,)),  # start without text
+        ("stop", ()),
+        ("info", ("Info...",)),
+        ("succeed", ("Success!",)),  # succeed with text
+        ("succeed", (None,)),  # succeed without text
+        ("fail", ()),
+        ("stop_and_persist", ("Saved!",)),
+    ],
+)
+def test_smart_halo_behavior_non_tty(
+    mocker,
+    method: str,
+    args: tuple,
+):
+    mocker.patch("sys.stdout.isatty", return_value=False)
+    mock_print = mocker.patch("builtins.print")
+
+    halo = SmartHalo()
+
+    getattr(halo, method)(*args)
+
+    if args and args[0] is not None:
+        mock_print.assert_called_once_with(*[arg for arg in args], flush=True)
+    else:
+        mock_print.assert_not_called()

--- a/tests/unit/utils/test_utils.py
+++ b/tests/unit/utils/test_utils.py
@@ -135,3 +135,22 @@ def test_smart_halo_behavior_non_tty(
         mock_print.assert_called_once_with(*[arg for arg in args], flush=True)
     else:
         mock_print.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "isatty, spinner_id",
+    [
+        (
+            True,
+            "my-id",
+        ),
+        (False, None),
+    ],
+)
+def test_smart_halo_behavior_spinner_id(mocker, fake_halo, isatty, spinner_id):
+    mocker.patch("sys.stdout.isatty", return_value=isatty)
+    fake_halo.return_value.spinner_id = spinner_id
+
+    halo = SmartHalo()
+
+    assert halo.spinner_id == spinner_id


### PR DESCRIPTION
sys.stdout.isatty() is a smart module that detect if the command used is going to run in the shell or redirected.

With the class SmartHalo If it's detected that is a non-tty, hallo is not used and will just print messages.

Now it's possible to run something like `cou plan > my_plan.txt` or `cou plan | less`

Closes: #436