### PR TITLE
Fix order of COU upgrade

### DIFF
--- a/cou/apps/auxiliary.py
+++ b/cou/apps/auxiliary.py
@@ -38,7 +38,6 @@ from cou.utils.juju_utils import Unit
 from cou.utils.openstack import (
     OPENSTACK_TO_TRACK_MAPPING,
     TRACK_TO_OPENSTACK_MAPPING,
-    OpenStackCodenameLookup,
     OpenStackRelease,
 )
 

--- a/cou/apps/auxiliary.py
+++ b/cou/apps/auxiliary.py
@@ -447,7 +447,7 @@ class OVN(AuxiliaryApplication):
         super().upgrade_plan_sanity_checks(target)
 
 
-@AppFactory.register_application(["ovn-central", "ovn-dedicated-chassis"])
+@AppFactory.register_application(["ovn-dedicated-chassis"])
 class OVNPrincipal(OVN):
     """OVN principal application class."""
 
@@ -458,6 +458,27 @@ class OVNPrincipal(OVN):
         """
         for unit in self.units.values():
             OVNPrincipal._validate_ovn_support(unit.workload_version)
+
+
+@AppFactory.register_application(["ovn-central"])
+class OVNCentral(OVN):
+    """OVN principal application class."""
+
+    def pre_upgrade_steps(
+        self, target: OpenStackRelease, units: Optional[list[Unit]]
+    ) -> list[PreUpgradeStep]:
+        """Pre Upgrade steps planning.
+
+        :param target: OpenStack release as target to upgrade.
+        :type target: OpenStackRelease
+        :param units: Units to generate upgrade plan
+        :type units: Optional[list[Unit]]
+        :return: List of pre upgrade steps.
+        :rtype: list[PreUpgradeStep]
+        """
+        steps = self._verify_nova_compute_step(target)
+        steps.extend(super().pre_upgrade_steps(target, units))
+        return steps
 
 
 @AppFactory.register_application(["mysql-innodb-cluster"])
@@ -486,42 +507,9 @@ class CephOsd(AuxiliaryApplication):
         :return: List of pre upgrade steps.
         :rtype: list[PreUpgradeStep]
         """
-        steps = [
-            PreUpgradeStep(
-                description="Verify that all 'nova-compute' units has been upgraded",
-                coro=self._verify_nova_compute(target),
-            )
-        ]
+        steps = self._verify_nova_compute_step(target)
         steps.extend(super().pre_upgrade_steps(target, units))
         return steps
-
-    async def _verify_nova_compute(self, target: OpenStackRelease) -> None:
-        """Check if all units of nova-compute applications has upgraded their workload version.
-
-        :param target: OpenStack release as target to upgrade.
-        :type target: OpenStackRelease
-        :raises ApplicationError: When any nova-compute app workload version isn't reached.
-        """
-        units_not_upgraded = []
-        apps = await self.model.get_applications()
-
-        for app in apps.values():
-            if app.charm != "nova-compute":
-                logger.debug("skipping application %s", app.name)
-                continue
-
-            for unit in app.units.values():
-                compatible_o7k_versions = OpenStackCodenameLookup.find_compatible_versions(
-                    app.charm, unit.workload_version
-                )
-
-                if target not in compatible_o7k_versions:
-                    units_not_upgraded.append(unit.name)
-
-        if units_not_upgraded:
-            raise ApplicationError(
-                f"Units '{', '.join(units_not_upgraded)}' did not reach {target}."
-            )
 
 
 @AppFactory.register_application(["vault"])

--- a/cou/apps/core.py
+++ b/cou/apps/core.py
@@ -259,3 +259,23 @@ class Swift(OpenStackApplication):
             f"'{self.name}' application is not currently supported by COU. Please manually "
             "upgrade it."
         )
+
+@AppFactory.register_application(["neutron-api"])
+class NeutronApi(OpenStackApplication):
+    """Neutron API application class."""
+
+    def pre_upgrade_steps(
+        self, target: OpenStackRelease, units: Optional[list[Unit]]
+    ) -> list[PreUpgradeStep]:
+        """Pre Upgrade steps planning.
+
+        :param target: OpenStack release as target to upgrade.
+        :type target: OpenStackRelease
+        :param units: Units to generate upgrade plan
+        :type units: Optional[list[Unit]]
+        :return: List of pre upgrade steps.
+        :rtype: list[PreUpgradeStep]
+        """
+        steps = self._verify_nova_compute_step(target)
+        steps.extend(super().pre_upgrade_steps(target, units))
+        return steps

--- a/cou/apps/core.py
+++ b/cou/apps/core.py
@@ -260,6 +260,7 @@ class Swift(OpenStackApplication):
             "upgrade it."
         )
 
+
 @AppFactory.register_application(["neutron-api"])
 class NeutronApi(OpenStackApplication):
     """Neutron API application class."""

--- a/cou/utils/openstack.py
+++ b/cou/utils/openstack.py
@@ -45,7 +45,14 @@ CHARM_FAMILIES = {
 }
 
 # nova-compute + other principal charms that must be upgraded after nova-compute
-DATA_PLANE_CHARMS = ["nova-compute", "ceph-osd", "swift-proxy", "swift-storage"]
+DATA_PLANE_CHARMS = [
+    "nova-compute",
+    "ovn-central",
+    "neutron-api",
+    "ceph-osd",
+    "swift-proxy",
+    "swift-storage",
+]
 
 # https://docs.openstack.org/charm-guide/latest/admin/upgrades/openstack.html#list-the-upgrade-order
 UCA_UPGRADE_ORDER = [
@@ -64,23 +71,17 @@ UCA_UPGRADE_ORDER = [
     "heat",
     "manila",
     "manila-ganesha",
-    "neutron-api",
     "neutron-gateway",
     "ovn-dedicated-chassis",
-    "ovn-central",
     "placement",
     "nova-cloud-controller",
-    "nova-compute",
     "openstack-dashboard",
-    "ceph-osd",
-    "swift-proxy",
-    "swift-storage",
     "octavia",
 ]
 
 NON_UCA_UPGRADE_ORDER = ["vault", "rabbitmq-server"]
 
-UPGRADE_ORDER = NON_UCA_UPGRADE_ORDER + UCA_UPGRADE_ORDER
+UPGRADE_ORDER = NON_UCA_UPGRADE_ORDER + UCA_UPGRADE_ORDER + DATA_PLANE_CHARMS
 
 SUBORDINATES = [
     "barbican-vault",

--- a/tests/mocked_plans/sample_plans/018346c5-f95c-46df-a34e-9a78bdec0018.yaml
+++ b/tests/mocked_plans/sample_plans/018346c5-f95c-46df-a34e-9a78bdec0018.yaml
@@ -271,18 +271,6 @@ plan: |
                 Change charm config of 'heat' 'openstack-origin' to 'cloud:focal-victoria'
                 Wait for up to 300s for app 'heat' to reach the idle state
                 Verify that the workload of 'heat' has been upgraded on units: heat/0, heat/1, heat/2
-            Upgrade plan for 'neutron-api' to 'victoria'
-                Upgrade software packages of 'neutron-api' from the current APT repositories
-                    Ψ Upgrade software packages on unit 'neutron-api/0'
-                    Ψ Upgrade software packages on unit 'neutron-api/1'
-                    Ψ Upgrade software packages on unit 'neutron-api/2'
-                Refresh 'neutron-api' to the latest revision of 'ussuri/stable'
-                Wait for up to 300s for app 'neutron-api' to reach the idle state
-                Upgrade 'neutron-api' from 'ussuri/stable' to the new channel: 'victoria/stable'
-                Wait for up to 300s for app 'neutron-api' to reach the idle state
-                Change charm config of 'neutron-api' 'openstack-origin' to 'cloud:focal-victoria'
-                Wait for up to 300s for app 'neutron-api' to reach the idle state
-                Verify that the workload of 'neutron-api' has been upgraded on units: neutron-api/0, neutron-api/1, neutron-api/2
             Upgrade plan for 'placement' to 'victoria'
                 Upgrade software packages of 'placement' from the current APT repositories
                     Ψ Upgrade software packages on unit 'placement/3'
@@ -562,6 +550,19 @@ plan: |
                 Wait for up to 2400s for model '018346c5-f95c-46df-a34e-9a78bdec0018' to reach the idle state
                 Verify that the workload of 'nova-compute-kvm' has been upgraded on units: nova-compute-kvm/4, nova-compute-kvm/6, nova-compute-kvm/7, nova-compute-kvm/8
         Remaining Data Plane principal(s) upgrade plan
+            Upgrade plan for 'neutron-api' to 'victoria'
+                Verify that all 'nova-compute' units has been upgraded
+                Upgrade software packages of 'neutron-api' from the current APT repositories
+                    Ψ Upgrade software packages on unit 'neutron-api/0'
+                    Ψ Upgrade software packages on unit 'neutron-api/1'
+                    Ψ Upgrade software packages on unit 'neutron-api/2'
+                Refresh 'neutron-api' to the latest revision of 'ussuri/stable'
+                Wait for up to 300s for app 'neutron-api' to reach the idle state
+                Upgrade 'neutron-api' from 'ussuri/stable' to the new channel: 'victoria/stable'
+                Wait for up to 300s for app 'neutron-api' to reach the idle state
+                Change charm config of 'neutron-api' 'openstack-origin' to 'cloud:focal-victoria'
+                Wait for up to 300s for app 'neutron-api' to reach the idle state
+                Verify that the workload of 'neutron-api' has been upgraded on units: neutron-api/0, neutron-api/1, neutron-api/2
             Upgrade plan for 'ceph-osd' to 'victoria'
                 Verify that all 'nova-compute' units has been upgraded
                 Upgrade software packages of 'ceph-osd' from the current APT repositories

--- a/tests/mocked_plans/sample_plans/9eb9af6a-b919-4cf9-8f2f-9df16a1556be.yaml
+++ b/tests/mocked_plans/sample_plans/9eb9af6a-b919-4cf9-8f2f-9df16a1556be.yaml
@@ -326,27 +326,6 @@ plan: |
                 Change charm config of 'heat' 'openstack-origin' to 'cloud:focal-victoria'
                 Wait for up to 300s for app 'heat' to reach the idle state
                 Verify that the workload of 'heat' has been upgraded on units: heat/0, heat/1, heat/2
-            Upgrade plan for 'neutron-api' to 'victoria'
-                Upgrade software packages of 'neutron-api' from the current APT repositories
-                    Ψ Upgrade software packages on unit 'neutron-api/0'
-                    Ψ Upgrade software packages on unit 'neutron-api/1'
-                    Ψ Upgrade software packages on unit 'neutron-api/2'
-                Change charm config of 'neutron-api' 'action-managed-upgrade' from 'True' to 'False'
-                Upgrade 'neutron-api' from 'ussuri/stable' to the new channel: 'victoria/stable'
-                Wait for up to 300s for app 'neutron-api' to reach the idle state
-                Change charm config of 'neutron-api' 'openstack-origin' to 'cloud:focal-victoria'
-                Wait for up to 300s for app 'neutron-api' to reach the idle state
-                Verify that the workload of 'neutron-api' has been upgraded on units: neutron-api/0, neutron-api/1, neutron-api/2
-            Upgrade plan for 'ovn-central' to 'victoria'
-                Upgrade software packages of 'ovn-central' from the current APT repositories
-                    Ψ Upgrade software packages on unit 'ovn-central/0'
-                    Ψ Upgrade software packages on unit 'ovn-central/1'
-                    Ψ Upgrade software packages on unit 'ovn-central/2'
-                WARNING: Changing 'ovn-central' channel from latest/stable to 22.03/stable. This may be a charm downgrade, which is generally not supported.
-                Wait for up to 300s for app 'ovn-central' to reach the idle state
-                Change charm config of 'ovn-central' 'source' to 'cloud:focal-victoria'
-                Wait for up to 300s for app 'ovn-central' to reach the idle state
-                Verify that the workload of 'ovn-central' has been upgraded on units: ovn-central/0, ovn-central/1, ovn-central/2
             Upgrade plan for 'placement' to 'victoria'
                 Upgrade software packages of 'placement' from the current APT repositories
                     Ψ Upgrade software packages on unit 'placement/0'
@@ -513,6 +492,29 @@ plan: |
                 Wait for up to 2400s for model '9eb9af6a-b919-4cf9-8f2f-9df16a1556be' to reach the idle state
                 Verify that the workload of 'nova-compute' has been upgraded on units: nova-compute/4, nova-compute/5, nova-compute/7
         Remaining Data Plane principal(s) upgrade plan
+            Upgrade plan for 'ovn-central' to 'victoria'
+                Verify that all 'nova-compute' units has been upgraded
+                Upgrade software packages of 'ovn-central' from the current APT repositories
+                    Ψ Upgrade software packages on unit 'ovn-central/0'
+                    Ψ Upgrade software packages on unit 'ovn-central/1'
+                    Ψ Upgrade software packages on unit 'ovn-central/2'
+                WARNING: Changing 'ovn-central' channel from latest/stable to 22.03/stable. This may be a charm downgrade, which is generally not supported.
+                Wait for up to 300s for app 'ovn-central' to reach the idle state
+                Change charm config of 'ovn-central' 'source' to 'cloud:focal-victoria'
+                Wait for up to 300s for app 'ovn-central' to reach the idle state
+                Verify that the workload of 'ovn-central' has been upgraded on units: ovn-central/0, ovn-central/1, ovn-central/2
+            Upgrade plan for 'neutron-api' to 'victoria'
+                Verify that all 'nova-compute' units has been upgraded
+                Upgrade software packages of 'neutron-api' from the current APT repositories
+                    Ψ Upgrade software packages on unit 'neutron-api/0'
+                    Ψ Upgrade software packages on unit 'neutron-api/1'
+                    Ψ Upgrade software packages on unit 'neutron-api/2'
+                Change charm config of 'neutron-api' 'action-managed-upgrade' from 'True' to 'False'
+                Upgrade 'neutron-api' from 'ussuri/stable' to the new channel: 'victoria/stable'
+                Wait for up to 300s for app 'neutron-api' to reach the idle state
+                Change charm config of 'neutron-api' 'openstack-origin' to 'cloud:focal-victoria'
+                Wait for up to 300s for app 'neutron-api' to reach the idle state
+                Verify that the workload of 'neutron-api' has been upgraded on units: neutron-api/0, neutron-api/1, neutron-api/2
             Upgrade plan for 'ceph-osd' to 'victoria'
                 Verify that all 'nova-compute' units has been upgraded
                 Upgrade software packages of 'ceph-osd' from the current APT repositories


### PR DESCRIPTION
COU is not respecting the upgrade order of OVN upstream [documentation](https://docs.ovn.org/en/latest/intro/install/ovn-upgrades.html#upgrade-procedures) which can cause data-plane outage. The order should be:
1. Upgrade ovn-controller (ovn-chassis)
2. Upgrade OVN Databases and ovn-northd (ovn-central)
3. Upgrade OVN Integration (neutron-api)

Because ovn-chassis is subordinate, the payload get upgraded just when nova-compute unit upgrades. That is why the ovn-central and neutron-api should upgrade after the nova-compute units.

Fix: #640