### PR TITLE
Increase COU timeout for charm refresh for Keystone

### DIFF
--- a/cou/apps/base.py
+++ b/cou/apps/base.py
@@ -66,6 +66,7 @@ class OpenStackApplication(Application):
     """
 
     packages_to_hold: Optional[list] = field(default=None, init=False)
+    charm_refresh_timeout: int = field(default=STANDARD_IDLE_TIMEOUT, init=False)
     wait_timeout: int = field(default=STANDARD_IDLE_TIMEOUT, init=False)
     wait_for_model: bool = field(default=False, init=False)  # waiting only for application itself
     # OpenStack apps rely on the workload version of the packages to evaluate current OpenStack
@@ -574,10 +575,10 @@ class OpenStackApplication(Application):
         :rtype: list[PreUpgradeStep]
         """
         wait_step = PreUpgradeStep(
-            description=f"Wait for up to {STANDARD_IDLE_TIMEOUT}s for "
+            description=f"Wait for up to {self.charm_refresh_timeout}s for "
             f"app '{self.name}' to reach the idle state",
             parallel=False,
-            coro=self.model.wait_for_idle(STANDARD_IDLE_TIMEOUT, apps=[self.name]),
+            coro=self.model.wait_for_idle(self.charm_refresh_timeout, apps=[self.name]),
         )
         if self.is_from_charm_store:
             return [self._get_charmhub_migration_step(target), wait_step]
@@ -686,10 +687,10 @@ class OpenStackApplication(Application):
                     coro=self.model.upgrade_charm(self.name, self.target_channel(target)),
                 ),
                 UpgradeStep(
-                    description=f"Wait for up to {STANDARD_IDLE_TIMEOUT}s for "
+                    description=f"Wait for up to {self.charm_refresh_timeout}s for "
                     f"app '{self.name}' to reach the idle state",
                     parallel=False,
-                    coro=self.model.wait_for_idle(STANDARD_IDLE_TIMEOUT, apps=[self.name]),
+                    coro=self.model.wait_for_idle(self.charm_refresh_timeout, apps=[self.name]),
                 ),
             ]
 

--- a/cou/apps/core.py
+++ b/cou/apps/core.py
@@ -35,6 +35,7 @@ class Keystone(OpenStackApplication):
     """
 
     wait_timeout = LONG_IDLE_TIMEOUT
+    charm_refresh_timeout = 1200
     wait_for_model = True
 
 

--- a/tests/mocked_plans/sample_plans/018346c5-f95c-46df-a34e-9a78bdec0018.yaml
+++ b/tests/mocked_plans/sample_plans/018346c5-f95c-46df-a34e-9a78bdec0018.yaml
@@ -162,9 +162,9 @@ plan: |
                     Ψ Upgrade software packages on unit 'keystone/1'
                     Ψ Upgrade software packages on unit 'keystone/2'
                 Refresh 'keystone' to the latest revision of 'ussuri/stable'
-                Wait for up to 300s for app 'keystone' to reach the idle state
+                Wait for up to 1200s for app 'keystone' to reach the idle state
                 Upgrade 'keystone' from 'ussuri/stable' to the new channel: 'victoria/stable'
-                Wait for up to 300s for app 'keystone' to reach the idle state
+                Wait for up to 1200s for app 'keystone' to reach the idle state
                 Change charm config of 'keystone' 'openstack-origin' to 'cloud:focal-victoria'
                 Wait for up to 2400s for model '018346c5-f95c-46df-a34e-9a78bdec0018' to reach the idle state
                 Verify that the workload of 'keystone' has been upgraded on units: keystone/0, keystone/1, keystone/2

--- a/tests/mocked_plans/sample_plans/9eb9af6a-b919-4cf9-8f2f-9df16a1556be.yaml
+++ b/tests/mocked_plans/sample_plans/9eb9af6a-b919-4cf9-8f2f-9df16a1556be.yaml
@@ -212,7 +212,7 @@ plan: |
                     Ψ Upgrade software packages on unit 'keystone/2'
                 Change charm config of 'keystone' 'action-managed-upgrade' from 'True' to 'False'
                 Upgrade 'keystone' from 'ussuri/stable' to the new channel: 'victoria/stable'
-                Wait for up to 300s for app 'keystone' to reach the idle state
+                Wait for up to 1200s for app 'keystone' to reach the idle state
                 Change charm config of 'keystone' 'openstack-origin' to 'cloud:focal-victoria'
                 Wait for up to 2400s for model '9eb9af6a-b919-4cf9-8f2f-9df16a1556be' to reach the idle state
                 Verify that the workload of 'keystone' has been upgraded on units: keystone/0, keystone/1, keystone/2

--- a/tests/mocked_plans/sample_plans/base.yaml
+++ b/tests/mocked_plans/sample_plans/base.yaml
@@ -16,10 +16,10 @@ plan: |
                 Upgrade software packages of 'keystone' from the current APT repositories
                     Ψ Upgrade software packages on unit 'keystone/0'
                 Refresh 'keystone' to the latest revision of 'ussuri/stable'
-                Wait for up to 300s for app 'keystone' to reach the idle state
+                Wait for up to 1200s for app 'keystone' to reach the idle state
                 Change charm config of 'keystone' 'action-managed-upgrade' from 'True' to 'False'
                 Upgrade 'keystone' from 'ussuri/stable' to the new channel: 'victoria/stable'
-                Wait for up to 300s for app 'keystone' to reach the idle state
+                Wait for up to 1200s for app 'keystone' to reach the idle state
                 Change charm config of 'keystone' 'openstack-origin' to 'cloud:focal-victoria'
                 Wait for up to 2400s for model 'base' to reach the idle state
                 Verify that the workload of 'keystone' has been upgraded on units: keystone/0

--- a/tests/unit/apps/test_core.py
+++ b/tests/unit/apps/test_core.py
@@ -212,9 +212,9 @@ def test_upgrade_plan_ussuri_to_victoria(model):
             coro=model.upgrade_charm(app.name, "ussuri/stable"),
         ),
         PreUpgradeStep(
-            description=f"Wait for up to 300s for app '{app.name}' to reach the idle state",
+            description=f"Wait for up to {app.charm_refresh_timeout}s for app '{app.name}' to reach the idle state",
             parallel=False,
-            coro=model.wait_for_idle(300, apps=[app.name]),
+            coro=model.wait_for_idle(app.charm_refresh_timeout, apps=[app.name]),
         ),
         UpgradeStep(
             description=f"Change charm config of '{app.name}' 'action-managed-upgrade' "
@@ -229,9 +229,9 @@ def test_upgrade_plan_ussuri_to_victoria(model):
             coro=model.upgrade_charm(app.name, "victoria/stable"),
         ),
         UpgradeStep(
-            description=f"Wait for up to 300s for app '{app.name}' to reach the idle state",
+            description=f"Wait for up to {app.charm_refresh_timeout}s for app '{app.name}' to reach the idle state",
             parallel=False,
-            coro=model.wait_for_idle(300, apps=[app.name]),
+            coro=model.wait_for_idle(app.charm_refresh_timeout, apps=[app.name]),
         ),
         UpgradeStep(
             description=f"Change charm config of '{app.name}' "
@@ -308,9 +308,9 @@ def test_upgrade_plan_ussuri_to_victoria_ch_migration(model):
             coro=model.upgrade_charm(app.name, "ussuri/stable", switch="ch:keystone"),
         ),
         PreUpgradeStep(
-            description=f"Wait for up to 300s for app '{app.name}' to reach the idle state",
+            description=f"Wait for up to 1200s for app '{app.name}' to reach the idle state",
             parallel=False,
-            coro=model.wait_for_idle(300, apps=[app.name]),
+            coro=model.wait_for_idle(1200, apps=[app.name]),
         ),
         UpgradeStep(
             description=f"Change charm config of '{app.name}' 'action-managed-upgrade' "
@@ -325,9 +325,9 @@ def test_upgrade_plan_ussuri_to_victoria_ch_migration(model):
             coro=model.upgrade_charm(app.name, "victoria/stable"),
         ),
         UpgradeStep(
-            description=f"Wait for up to 300s for app '{app.name}' to reach the idle state",
+            description=f"Wait for up to {app.charm_refresh_timeout}s for app '{app.name}' to reach the idle state",
             parallel=False,
-            coro=model.wait_for_idle(300, apps=[app.name]),
+            coro=model.wait_for_idle(app.charm_refresh_timeout, apps=[app.name]),
         ),
         UpgradeStep(
             description=f"Change charm config of '{app.name}' "
@@ -486,9 +486,9 @@ def test_upgrade_plan_origin_already_on_next_openstack_release(model):
             coro=model.upgrade_charm(app.name, "ussuri/stable"),
         ),
         PreUpgradeStep(
-            description=f"Wait for up to 300s for app '{app.name}' to reach the idle state",
+            description=f"Wait for up to {app.charm_refresh_timeout}s for app '{app.name}' to reach the idle state",
             parallel=False,
-            coro=model.wait_for_idle(300, apps=[app.name]),
+            coro=model.wait_for_idle(app.charm_refresh_timeout, apps=[app.name]),
         ),
         UpgradeStep(
             description=f"Change charm config of '{app.name}' 'action-managed-upgrade' "
@@ -503,9 +503,9 @@ def test_upgrade_plan_origin_already_on_next_openstack_release(model):
             coro=model.upgrade_charm(app.name, "victoria/stable"),
         ),
         UpgradeStep(
-            description=f"Wait for up to 300s for app '{app.name}' to reach the idle state",
+            description=f"Wait for up to {app.charm_refresh_timeout}s for app '{app.name}' to reach the idle state",
             parallel=False,
-            coro=model.wait_for_idle(300, apps=[app.name]),
+            coro=model.wait_for_idle(app.charm_refresh_timeout, apps=[app.name]),
         ),
         PostUpgradeStep(
             description=f"Wait for up to 2400s for model '{model.name}' to reach the idle state",
@@ -612,9 +612,9 @@ def test_upgrade_plan_application_already_disable_action_managed(model):
             coro=model.upgrade_charm(app.name, "ussuri/stable"),
         ),
         PreUpgradeStep(
-            description=f"Wait for up to 300s for app '{app.name}' to reach the idle state",
+            description=f"Wait for up to {app.charm_refresh_timeout}s for app '{app.name}' to reach the idle state",
             parallel=False,
-            coro=model.wait_for_idle(300, apps=[app.name]),
+            coro=model.wait_for_idle(app.charm_refresh_timeout, apps=[app.name]),
         ),
         UpgradeStep(
             description=f"Upgrade '{app.name}' from 'ussuri/stable' to the new channel: "
@@ -623,9 +623,9 @@ def test_upgrade_plan_application_already_disable_action_managed(model):
             coro=model.upgrade_charm(app.name, "victoria/stable"),
         ),
         UpgradeStep(
-            description=f"Wait for up to 300s for app '{app.name}' to reach the idle state",
+            description=f"Wait for up to {app.charm_refresh_timeout}s for app '{app.name}' to reach the idle state",
             parallel=False,
-            coro=model.wait_for_idle(300, apps=[app.name]),
+            coro=model.wait_for_idle(app.charm_refresh_timeout, apps=[app.name]),
         ),
         UpgradeStep(
             description=f"Change charm config of '{app.name}' "

--- a/tests/unit/steps/test_plan.py
+++ b/tests/unit/steps/test_plan.py
@@ -172,10 +172,10 @@ async def test_generate_plan(mock_filter_hypervisors, model, cli_args):
                 Upgrade software packages of 'keystone' from the current APT repositories
                     Ψ Upgrade software packages on unit 'keystone/0'
                 Refresh 'keystone' to the latest revision of 'ussuri/stable'
-                Wait for up to 300s for app 'keystone' to reach the idle state
+                Wait for up to 1200s for app 'keystone' to reach the idle state
                 Change charm config of 'keystone' 'action-managed-upgrade' from 'True' to 'False'
                 Upgrade 'keystone' from 'ussuri/stable' to the new channel: 'victoria/stable'
-                Wait for up to 300s for app 'keystone' to reach the idle state
+                Wait for up to 1200s for app 'keystone' to reach the idle state
                 Change charm config of 'keystone' 'openstack-origin' to 'cloud:focal-victoria'
                 Wait for up to 2400s for model 'test_model' to reach the idle state
                 Verify that the workload of 'keystone' has been upgraded on units: keystone/0


### PR DESCRIPTION
The charm refresh in keystone can take more than the default 5 minutes. Although the user can set a custom STANDARD_IDLE_TIMEOUT by env var, it's good to have more time to applications that we know that can take more time.

Closes: #155