### PR TITLE
Migrate juju_utils from python-libjuju to jubilant

### DIFF
--- a/cou/apps/auxiliary.py
+++ b/cou/apps/auxiliary.py
@@ -563,7 +563,7 @@ class Vault(AuxiliaryApplication):
         )
 
         app_status = await self.model.get_application_status(app_name=self.name)
-        if not app_status.status.info == "Unit is sealed":
+        if not app_status.app_status.message == "Unit is sealed":
             # It's an exception if vault not in sealed after upgrading.
             raise ApplicationError(
                 "Application vault not in sealed."

--- a/cou/apps/base.py
+++ b/cou/apps/base.py
@@ -412,10 +412,10 @@ class OpenStackApplication(Application):
         await asyncio.gather(*tasks)
 
         status = await self.model.get_status()
-        app_status = status.applications.get(self.name)
+        app_status = status.apps.get(self.name)
         units_not_upgraded = []
         for unit in units:
-            workload_version = app_status.units[unit.name].workload_version
+            workload_version = app_status.units[unit.name].workload_status.version
             compatible_o7k_versions = OpenStackCodenameLookup.find_compatible_versions(
                 self.charm, workload_version
             )

--- a/cou/apps/core.py
+++ b/cou/apps/core.py
@@ -221,9 +221,7 @@ async def resume_nova_compute_unit(model: Model, unit: Unit) -> None:
 
     # If it failed because of https://bugs.launchpad.net/charm-ceilometer-agent/+bug/1947585 ,
     # apply the workaround.
-    if "Services not running that should be: ceilometer-agent-compute" in action.safe_data.get(
-        "message", ""
-    ):
+    if "Services not running that should be: ceilometer-agent-compute" in action.message:
         logger.debug("Resume failed because ceilometer-agent-compute not running.")
         logger.debug("Restarting ceilometer-agent-compute on %s", unit.name)
         await model.run_on_unit(unit.name, "sudo systemctl restart ceilometer-agent-compute")

--- a/cou/cli.py
+++ b/cou/cli.py
@@ -22,7 +22,7 @@ from pathlib import Path
 from signal import SIGINT, SIGTERM
 from typing import Optional
 
-from juju.errors import JujuError
+import jubilant
 
 from cou.commands import CLIargs, parse_args
 from cou.exceptions import COUException, HighestReleaseAchieved, TimeoutException
@@ -292,12 +292,12 @@ def entrypoint() -> None:
             "hosted.com/en/stable/reference/known-issues/"
         )
         sys.exit(1)
-    except JujuError as exc:
+    except jubilant.CLIError as exc:
         progress_indicator.fail()
         log_ssdlc_system_event(
-            SSDLCSysEvent.CRASH, msg=f"Juju library error: {type(exc).__name__} - {str(exc)}"
+            SSDLCSysEvent.CRASH, msg=f"Juju CLI error: {type(exc).__name__} - {str(exc)}"
         )
-        logger.error("Error occurred in Juju's Python library.")
+        logger.error("Error occurred in Juju's CLI.")
         logger.error(exc)
         sys.exit(1)
     except KeyboardInterrupt as exc:

--- a/cou/exceptions.py
+++ b/cou/exceptions.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Module of exceptions that charmed-openstack-upgrader may raise."""
-from juju.action import Action
+import jubilant
 
 
 class COUException(Exception):
@@ -76,32 +76,15 @@ class DataPlaneMachineFilterError(COUException):
 class ActionFailed(COUException):
     """Exception raised when action fails."""
 
-    # pylint: disable=consider-using-f-string
-    def __init__(self, action: Action):
+    def __init__(self, task: jubilant.Task):
         """Set information about action failure in message and raise.
 
-        :param action: Action that failed.
-        :type action: Action
+        :param task: Task that failed.
+        :type task: jubilant.Task
         """
-        params = {"output": action.safe_data}
-        for key in [
-            "name",
-            "parameters",
-            "receiver",
-            "message",
-            "id",
-            "status",
-            "enqueued",
-            "started",
-            "completed",
-        ]:
-            params[key] = action.safe_data.get(key, "<not-set>")
-
         message = (
-            "Run of action '{name}' with parameters '{parameters}' on "
-            "'{receiver}' failed with '{message}' (id={id} "
-            "status={status} enqueued={enqueued} started={started} "
-            "completed={completed} output={output})".format(**params)
+            f"Action '{task.id}' failed with status '{task.status}', "
+            f"message: '{task.message}', results: {task.results}"
         )
         super().__init__(message)
 

--- a/cou/steps/backup.py
+++ b/cou/steps/backup.py
@@ -61,20 +61,20 @@ async def backup(model: Model) -> Path:
     return local_file
 
 
-def _check_db_relations(app_config: dict) -> bool:
+def _check_db_relations(app_config) -> bool:
     """Check the db relations.
 
     Gets the openstack database mysql-innodb-cluster application if there are more than one
     application the one with the keystone relation is selected.
 
-    :param app_config: juju app config
-    :type app_config: str
+    :param app_config: jubilant AppStatus object
+    :type app_config: jubilant.statustypes.AppStatus
     :returns: True if it has a relation with keystone
     :rtype: bool
     """
-    for relation, app_list in app_config["relations"].items():
+    for relation, app_list in app_config.relations.items():
         if relation == "db-router":
-            if len([a for a in app_list if "keystone".casefold() in a.casefold()]) > 0:
+            if len([r for r in app_list if "keystone".casefold() in r.related_app.casefold()]) > 0:
                 return True
     return False
 
@@ -92,7 +92,7 @@ async def get_database_app_unit_name(model: Model) -> str:
     :rtype: ApplicationStatus
     """
     status = await model.get_status()
-    for app_name, app_config in status.applications.items():
+    for app_name, app_config in status.apps.items():
         charm_name = await model.get_charm_name(app_name)
         if charm_name == "mysql-innodb-cluster" and _check_db_relations(app_config):
             return list(app_config.units.keys())[0]

--- a/cou/steps/vault.py
+++ b/cou/steps/vault.py
@@ -33,7 +33,7 @@ async def verify_vault_is_unsealed(model: Model) -> None:
         app_names = await model.get_application_names(charm_name="vault")
         for app_name in app_names:
             app = await model.get_application_status(app_name=app_name)
-            if app.status.info == "Unit is sealed" and app.status.status == "blocked":
+            if app.app_status.message == "Unit is sealed" and app.is_blocked:
                 raise VaultSealed(
                     "Vault is sealed, please follow the steps on "
                     "https://charmhub.io/vault to unseal the vault manually before upgrade"

--- a/cou/utils/juju_utils.py
+++ b/cou/utils/juju_utils.py
@@ -17,23 +17,15 @@
 from __future__ import annotations
 
 import asyncio
+import json
 import logging
 import os
+import shlex
 from dataclasses import dataclass, field
 from datetime import datetime
 from typing import Any, Callable, List, Optional, Sequence
 
 import jubilant
-from juju.action import Action
-from juju.application import Application as JujuApplication
-from juju.client._definitions import ApplicationStatus, Base, FullStatus
-from juju.client.connector import NoConnectionException
-from juju.client.jujudata import FileJujuData
-from juju.errors import JujuConnectionError, JujuError
-from juju.model import Model as JujuModel
-from juju.unit import Unit as JujuUnit
-from juju.utils import get_version_series
-from macaroonbakery.httpbakery import BakeryException
 from six import wraps
 
 from cou.exceptions import (
@@ -47,10 +39,6 @@ from cou.exceptions import (
 )
 from cou.utils.openstack import is_charm_supported
 
-# Increase Juju websocket connection MAX_FRAME_SIZE to 1024MiB to stop
-# "RPC: Connection closed, reconnecting" errors and then a failure in the log.
-# See https://github.com/juju/python-libjuju/issues/458 for more details
-JUJU_MAX_FRAME_SIZE: int = 2**30
 DEFAULT_TIMEOUT: int = int(os.environ.get("COU_TIMEOUT", 10))
 DEFAULT_MAX_WAIT: int = 5
 DEFAULT_WAIT: float = 1.1
@@ -58,19 +46,41 @@ DEFAULT_MODEL_RETRIES: int = int(os.environ.get("COU_MODEL_RETRIES", 5))
 DEFAULT_MODEL_RETRY_BACKOFF: int = int(os.environ.get("COU_MODEL_RETRY_BACKOFF", 2))
 DEFAULT_MODEL_IDLE_PERIOD: int = 30
 
+_VERSION_SERIES_MAP: dict[str, str] = {
+    "18.04": "bionic",
+    "20.04": "focal",
+    "22.04": "jammy",
+    "24.04": "noble",
+}
+
 logger = logging.getLogger(__name__)
 
 
-def _convert_base_to_series(base: Base) -> str:
+def _convert_base_to_series(base: jubilant.statustypes.FormattedBase) -> str:
     """Convert base to series.
 
-    :param base: Base object
-    :type base: juju.client._definitions.Base
+    :param base: FormattedBase object
+    :type base: jubilant.statustypes.FormattedBase
     :return: converted channel to series, e.g. 20.04 -> focal
     :rtype: str
     """
     version, *_ = base.channel.split("/")
-    return get_version_series(version)
+    return _VERSION_SERIES_MAP.get(version, version)
+
+
+def _parse_availability_zone(hardware: str) -> Optional[str]:
+    """Parse availability zone from hardware string.
+
+    :param hardware: Hardware string from juju status, e.g.
+        "arch=amd64 availability-zone=nova"
+    :type hardware: str
+    :return: Availability zone if present, else None
+    :rtype: Optional[str]
+    """
+    for part in hardware.split():
+        if part.startswith("availability-zone="):
+            return part.split("=", 1)[1]
+    return None
 
 
 def retry(
@@ -270,7 +280,7 @@ class JubilantModelMixin:
 
         # jubilant init only init the python object, no connection is created.
         # so it's safy to init every time.
-        _juju = jubilant.Juju(model=self._juju_data.current_model(), wait_timeout=timeout)
+        _juju = jubilant.Juju(model=self._juju.model, wait_timeout=timeout)
 
         ready_callable = self._get_ready_callable(status)
         error_callable = self._get_error_callable(raise_on_error, raise_on_blocked)
@@ -299,117 +309,71 @@ class Model(JubilantModelMixin):
     """
 
     def __init__(self, name: Optional[str]):
-        """COU Model initialization with name and juju.model.Model."""
-        self._juju_data = FileJujuData()
-        self._model = JujuModel(max_frame_size=JUJU_MAX_FRAME_SIZE, jujudata=self.juju_data)
+        """COU Model initialization with name and jubilant.Juju."""
         self._name = name
+        self._juju = jubilant.Juju(model=name)
 
     @property
     def connected(self) -> bool:
-        """Check if model is connected."""
+        """Check if model is accessible."""
         try:
-            connection = self._model.connection()
-            return connection is not None and connection.is_open
-        except NoConnectionException:
+            self._juju.show_model()
+            return True
+        except Exception:  # pylint: disable=broad-exception-caught
             return False
-
-    @property
-    def juju_data(self) -> FileJujuData:
-        """Juju data."""
-        return self._juju_data
 
     @property
     def name(self) -> str:
         """Return model name."""
-        if self.connected:
-            return self._model.name
+        if self._name is not None:
+            return self._name
+        return self._juju.show_model().short_name
 
+    async def connect(self) -> None:
+        """Validate the model is accessible.
+
+        In jubilant, connections are established implicitly per CLI call.
+        This method validates accessibility and caches the model name.
+        """
+        model_info = self._juju.show_model()
         if self._name is None:
-            self._name = self.juju_data.current_model(model_only=True)
+            self._name = model_info.short_name
 
-        return self._name
-
-    @retry(no_retry_exceptions=(ActionFailed,))
-    async def _get_waited_action_object(self, action: Action, raise_on_failure: bool) -> Action:
-        """Get waited action object.
-
-        To access action data from the returned action object, use `action_obj.data`, which
-        contains action parameters, results, status, and metadata. Alternatively, it is possible
-        to access action results directly with `action_obj.results`.
-
-        :param action: Action object
-        :type: Action
-        :param raise_on_failure: Whether to raise ActionFailed exception on failure, defaults
-                                 to False
-        :type raise_on_failure: bool
-        :return: the awaited action object
-        :rtype: Action
-        :raises ActionFailed: When the application status is in error (it's not 'completed').
-        """
-        action_obj = await action.wait()
-        if raise_on_failure and action_obj.status != "completed":
-            logger.error("action %s failed", action_obj)
-            raise ActionFailed(action)
-
-        return action_obj
-
-    async def _get_application(self, name: str) -> JujuApplication:
-        """Get juju.application.Application from model.
-
-        :param name: Name of application
-        :type name: str
-        :raises ApplicationNotFound: When application is not found in the model.
-        :return: Application
-        :rtype: JujuApplication
-        """
-        model = await self._get_model()
-        app = model.applications.get(name)
-        if app is None:
-            raise ApplicationNotFound(f"Application {name} was not found in model {model.name}.")
-
-        return app
-
-    async def _get_machines(self) -> dict[str, Machine]:
-        """Get all the machines in the model.
-
-        :return: Dictionary of the machines found in the model. E.g: {'0': Machine0}
-        :rtype: dict[str, Machine]
-        """
-        model = await self._get_model()
-
-        return {
-            machine.id: Machine(
-                machine_id=machine.id,
-                apps_charms=self._get_machine_apps_and_charms(machine.id),
-                az=machine.hardware_characteristics.get("availability-zone"),
-            )
-            for machine in model.machines.values()
-        }
-
-    def _get_machine_apps_and_charms(self, machine_id: int) -> tuple[tuple[str, str], ...]:
-        """Get machine apps amd charm names.
+    def _get_machine_apps_and_charms(
+        self, machine_id: str, status: jubilant.Status
+    ) -> tuple[tuple[str, str], ...]:
+        """Get machine apps and charm names.
 
         :param machine_id: Machine id.
-        :type machine_id: int
+        :type machine_id: str
+        :param status: Jubilant Status object.
+        :type status: jubilant.Status
         :return: Tuple of tuple contains app name and charm name.
         :rtype: tuple[tuple[str, str], ...]
         """
         return tuple(
-            (str(unit.application), str(self._model.applications[unit.application].charm_name))
-            for unit in self._model.units.values()
-            if unit.machine.id == machine_id
+            (app_name, app_status.charm_name)
+            for app_name, app_status in status.apps.items()
+            for unit_status in app_status.units.values()
+            if unit_status.machine == machine_id
         )
 
-    async def _get_model(self) -> JujuModel:
-        """Get juju.model.Model and make sure that it is connected.
+    async def _get_machines(self, status: jubilant.Status) -> dict[str, Machine]:
+        """Get all the machines in the model.
 
-        :return: Model
-        :rtype: JujuModel
+        :param status: Optional pre-fetched jubilant Status. Fetched if not provided.
+        :type status: Optional[jubilant.Status]
+        :return: Dictionary of the machines found in the model. E.g: {'0': Machine0}
+        :rtype: dict[str, Machine]
         """
-        if not self.connected:
-            await self.connect()
-
-        return self._model
+        return {
+            machine_id: Machine(
+                machine_id=machine_id,
+                apps_charms=self._get_machine_apps_and_charms(machine_id, status),
+                az=_parse_availability_zone(machine_status.hardware),
+            )
+            for machine_id, machine_status in status.machines.items()
+        }
 
     async def _get_supported_apps(self) -> list[str]:
         """Get all applications supported by COU deployed in model.
@@ -417,36 +381,27 @@ class Model(JubilantModelMixin):
         :return: List of applications names supported by COU
         :rtype: list[str]
         """
-        model = await self._get_model()
+        status = self._juju.status()
         return [
-            name for name, app in model.applications.items() if is_charm_supported(app.charm_name)
+            app_name
+            for app_name, app_status in status.apps.items()
+            if is_charm_supported(app_status.charm_name)
         ]
 
-    async def get_unit(self, name: str) -> JujuUnit:
-        """Get juju.unit.unit from model.
+    async def get_unit(self, name: str) -> jubilant.statustypes.UnitStatus:
+        """Get jubilant UnitStatus from model.
 
         :param name: Name of unit
         :type name: str
         :raises UnitNotFound: When unit is not found in the model.
-        :return: Unit
-        :rtype: JujuUnit
+        :return: UnitStatus
+        :rtype: jubilant.statustypes.UnitStatus
         """
-        model = await self._get_model()
-        unit = model.units.get(name)
-        if unit is None:
-            raise UnitNotFound(f"Unit {name} was not found in model {model.name}.")
-
-        return unit
-
-    @retry(no_retry_exceptions=(BakeryException, JujuConnectionError))
-    async def connect(self) -> None:
-        """Make sure that model is connected."""
-        await self._model.disconnect()
-        await self._model.connect(
-            model_name=self._name,
-            retries=DEFAULT_MODEL_RETRIES,
-            retry_backoff=DEFAULT_MODEL_RETRY_BACKOFF,
-        )
+        status = self._juju.status()
+        for app_status in status.apps.values():
+            if name in app_status.units:
+                return app_status.units[name]
+        raise UnitNotFound(f"Unit {name} was not found in model {self.name}.")
 
     @retry
     async def get_applications(self) -> dict[str, Application]:
@@ -455,47 +410,66 @@ class Model(JubilantModelMixin):
         :returns: list of application with all information
         :rtype: list[Application]
         """
-        model = await self._get_model()
-        # note(rgildein): We get the applications from the Juju status, since we can get more
-        #                 information the status than from objects. e.g. workload_version for unit
-        full_status = await self.get_status()
-        machines = await self._get_machines()
+        status = await self.get_status()
+        machines = await self._get_machines(status)
 
-        return {
-            app: Application(
-                name=app,
-                can_upgrade_to=status.can_upgrade_to,
-                charm=model.applications[app].charm_name,
-                channel=status.charm_channel,
-                config=await model.applications[app].get_config(),
-                machines={
-                    unit.machine.id: machines[unit.machine.id]
-                    for unit in model.applications[app].units
-                },
-                model=self,
-                origin=status.charm.split(":")[0],
-                series=_convert_base_to_series(status.base),
-                subordinate_to=status.subordinate_to,
-                units={
-                    name: Unit(
-                        name,
-                        machines[unit.machine],
-                        unit.workload_version,
-                        [
-                            SubordinateUnit(
-                                subordinate,
-                                model.applications[subordinate.split("/")[0]].charm_name,
-                            )
-                            for subordinate, subordinate_unit in unit.subordinates.items()
-                        ],
-                    )
-                    for name, unit in status.units.items()
-                },
-                workload_version=status.workload_version,
-                actions=await model.applications[app].get_actions(),
+        result = {}
+        for app_name, app_status in status.apps.items():
+            config = json.loads(self._juju.cli("config", app_name, "--format", "json")).get(
+                "settings", {}
             )
-            for app, status in full_status.applications.items()
-        }
+
+            try:
+                actions_stdout = self._juju.cli("actions", app_name, "--format", "json")
+                actions_raw = json.loads(actions_stdout) if actions_stdout.strip() else {}
+                actions = {
+                    k: v.get("description", "") if isinstance(v, dict) else str(v)
+                    for k, v in actions_raw.items()
+                }
+            except (jubilant.CLIError, json.JSONDecodeError, ValueError):
+                actions = {}
+
+            app_machines = {}
+            for unit_status in app_status.units.values():
+                machine_id = unit_status.machine
+                if machine_id and machine_id in machines:
+                    app_machines[machine_id] = machines[machine_id]
+
+            units = {
+                unit_name: Unit(
+                    name=unit_name,
+                    machine=machines.get(unit_status.machine, Machine(unit_status.machine, ())),
+                    workload_version=unit_status.workload_status.version,
+                    subordinates=[
+                        SubordinateUnit(
+                            sub_name,
+                            status.apps[sub_name.split("/")[0]].charm_name,
+                        )
+                        for sub_name in unit_status.subordinates
+                    ],
+                )
+                for unit_name, unit_status in app_status.units.items()
+            }
+
+            series = _convert_base_to_series(app_status.base) if app_status.base else ""
+
+            result[app_name] = Application(
+                name=app_name,
+                can_upgrade_to=app_status.can_upgrade_to,
+                charm=app_status.charm,
+                channel=app_status.charm_channel,
+                config=config,
+                machines=app_machines,
+                model=self,
+                origin=app_status.charm_origin,
+                series=series,
+                subordinate_to=app_status.subordinate_to,
+                units=units,
+                workload_version=app_status.version,
+                actions=actions,
+            )
+
+        return result
 
     @retry(no_retry_exceptions=(ApplicationNotFound,))
     async def get_application_config(self, name: str) -> dict:
@@ -507,33 +481,38 @@ class Model(JubilantModelMixin):
         :rtype: dict
         :raises: ApplicationNotFound
         """
-        app = await self._get_application(name)
-        return await app.get_config()
+        try:
+            return json.loads(self._juju.cli("config", name, "--format", "json")).get(
+                "settings", {}
+            )
+        except jubilant.CLIError as e:
+            raise ApplicationNotFound(
+                f"Application {name} was not found in model {self.name}."
+            ) from e
 
     async def get_charm_name(self, application_name: str) -> str:
         """Get the charm name from the application.
 
         :param application_name: Name of application
         :type application_name: str
-        :raises ApplicationError: if charm_name is None
+        :raises ApplicationError: if charm_name is None or app not found
         :return: Charm name
         :rtype: str
         """
-        app = await self._get_application(application_name)
-        if app.charm_name is None:
+        status = self._juju.status()
+        app = status.apps.get(application_name)
+        if app is None or not app.charm_name:
             raise ApplicationError(f"Cannot obtain charm_name for {application_name}")
-
         return app.charm_name
 
     @retry
-    async def get_status(self) -> FullStatus:
+    async def get_status(self) -> jubilant.Status:
         """Return the full juju status output.
 
         :returns: Full juju status output
-        :rtype: FullStatus
+        :rtype: jubilant.Status
         """
-        model = await self._get_model()
-        return await model.get_status()
+        return self._juju.status()
 
     async def _dispatch_update_status_hook(self, unit_name: str) -> None:
         """Use dispatch to run the update-status hook.
@@ -591,14 +570,14 @@ class Model(JubilantModelMixin):
         logger.debug("Skipped updating status: file does not exist")
 
     # NOTE (rgildein): There is no need to add retry here, because we don't want to repeat
-    # `unit.run_action(...)` and the rest of the function is covered by retry.
+    # `juju.run(...)` and the rest of the function is covered by retry.
     async def run_action(
         self,
         unit_name: str,
         action_name: str,
         action_params: Optional[dict] = None,
         raise_on_failure: bool = False,
-    ) -> Action:
+    ) -> jubilant.Task:
         """Run action on given unit.
 
         :param unit_name: Name of unit to run action on
@@ -610,18 +589,21 @@ class Model(JubilantModelMixin):
         :param raise_on_failure: Raise ActionFailed exception on failure, defaults to False
         :type raise_on_failure: bool
         :raises UnitNotFound: When a valid unit cannot be found.
-        :raises ActionFailed: When the application status is in error (it's not 'completed').
-        :return: When status is different from "completed"
-        :rtype: Action
+        :raises ActionFailed: When the action status is in error (it's not 'completed').
+        :return: Task result
+        :rtype: jubilant.Task
         """
         action_params = action_params or {}
-        unit = await self.get_unit(unit_name)
-        action = await unit.run_action(action_name, **action_params)
-        action_obj = await self._get_waited_action_object(action, raise_on_failure)
-        return action_obj
+        try:
+            task = self._juju.run(unit_name, action_name, params=action_params or None)
+        except jubilant.TaskError as e:
+            if raise_on_failure:
+                raise ActionFailed(e.task) from e
+            return e.task
+        return task
 
     # NOTE (rgildein): There is no need to add retry here, because we don't want to repeat
-    # `unit.run(...)` and the rest of the function is static.
+    # `juju.exec(...)` and the rest of the function is static.
     async def run_on_unit(
         self, unit_name: str, command: str, timeout: Optional[int] = None
     ) -> dict[str, str]:
@@ -633,21 +615,29 @@ class Model(JubilantModelMixin):
         :type command: str
         :param timeout: How long in seconds to wait for command to complete
         :type timeout: Optional[int]
-        :returns: action.results {'return-code': 0, 'stderr': '', 'stdout': ''}
+        :returns: dict {'return-code': 0, 'stderr': '', 'stdout': ''}
         :rtype: dict[str, str]
         :raises UnitNotFound: When a valid unit cannot be found.
         :raises CommandRunFailed: When a command fails to run.
         """
         logger.debug("Running '%s' on '%s'", command, unit_name)
 
-        unit = await self.get_unit(unit_name)
-        action = await unit.run(command, timeout=timeout, block=True)
-        results = action.results
+        try:
+            task = self._juju.exec(command, unit=unit_name, wait=timeout)
+        except jubilant.TaskError as e:
+            result = {
+                "return-code": e.task.return_code,
+                "stdout": e.task.stdout,
+                "stderr": e.task.stderr,
+            }
+            raise CommandRunFailed(cmd=command, result=result) from e
+
+        results = {
+            "return-code": task.return_code,
+            "stdout": task.stdout,
+            "stderr": task.stderr,
+        }
         logger.debug("results: %s", results)
-
-        if results["return-code"] != 0:
-            raise CommandRunFailed(cmd=command, result=results)
-
         return results
 
     @retry(no_retry_exceptions=(ApplicationNotFound,))
@@ -659,8 +649,7 @@ class Model(JubilantModelMixin):
         :param configuration: Dictionary of configuration setting(s)
         :type configuration: dict[str, Any]
         """
-        app = await self._get_application(name)
-        await app.set_config(configuration)
+        self._juju.config(name, configuration)
 
     @retry(no_retry_exceptions=(UnitNotFound,))
     async def scp_from_unit(  # pylint: disable=too-many-arguments,too-many-positional-arguments
@@ -688,15 +677,18 @@ class Model(JubilantModelMixin):
         :type scp_opts: str
         :raises: UnitNotFound
         """
-        unit = await self.get_unit(unit_name)
-        await unit.scp_from(source, destination, user=user, proxy=proxy, scp_opts=scp_opts)
+        scp_options = shlex.split(scp_opts) if scp_opts else []
+        remote_path = (
+            f"{user}@{unit_name}:{source}" if user != "ubuntu" else f"{unit_name}:{source}"
+        )
+        self._juju.scp(remote_path, destination, scp_options=scp_options)
 
     @retry(
         no_retry_exceptions=(
             ApplicationNotFound,
             NotImplementedError,
             ValueError,
-            JujuError,
+            jubilant.CLIError,
         )
     )
     async def upgrade_charm(  # pylint: disable=too-many-arguments,too-many-positional-arguments
@@ -730,57 +722,59 @@ class Model(JubilantModelMixin):
         :type switch: str
         :raises: ApplicationNotFound
         """
-        app = await self._get_application(application_name)
-        await app.upgrade_charm(
-            channel=channel,
-            force_series=force_series,
-            force_units=force_units,
-            path=path,
-            revision=revision,
-            switch=switch,
-        )
+        if switch is not None:
+            args = ["refresh", application_name, "--switch", switch]
+            if channel is not None:
+                args.extend(["--channel", channel])
+            if force_series or force_units:
+                args.extend(["--force", "--force-base", "--force-units"])
+            self._juju.cli(*args)
+        else:
+            self._juju.refresh(
+                application_name,
+                channel=channel,
+                force=force_series or force_units,
+                path=path,
+                revision=revision,
+            )
 
     async def resolve_all(self) -> None:
         """Resolve all the units in the model if they are in error status."""
-        model = await self._get_model()
-        for _, juju_app in model.applications.items():
-            for unit in juju_app.units:
-                if unit.workload_status == "error":
-                    await unit.resolved(retry=True)
+        self._juju.cli("resolve", "--all")
 
     async def get_application_names(self, charm_name: str) -> list[str]:
         """Get application name by charm name.
 
         :param charm_name: charm name of application
         :type charm_name: str
-        :return: ApplicationStatus object
-        :rtype: ApplicationStatus
+        :return: List of application names with that charm
+        :rtype: list[str]
         :raises ApplicationNotFound: When charm is not found in the model.
         """
-        app_names = []
-        model = await self._get_model()
-        for app_name, app in model.applications.items():
-            if app.charm_name == charm_name:
-                app_names.append(app_name)
+        status = self._juju.status()
+        app_names = [
+            app_name
+            for app_name, app_status in status.apps.items()
+            if app_status.charm_name == charm_name
+        ]
         if not app_names:
             raise ApplicationNotFound(f"Cannot find '{charm_name}' charm in model '{self.name}'.")
         return app_names
 
-    async def get_application_status(self, app_name: str) -> ApplicationStatus:
-        """Get ApplicationStatus by charm name.
+    async def get_application_status(self, app_name: str) -> jubilant.statustypes.AppStatus:
+        """Get AppStatus by application name.
 
         :param app_name: name of application
         :type app_name: str
-        :return: ApplicationStatus object
-        :rtype: ApplicationStatus
+        :return: AppStatus object
+        :rtype: jubilant.statustypes.AppStatus
         :raises ApplicationNotFound: When application is not found in the model.
         """
-        model = await self._get_model()
-        status = await model.get_status(filters=[app_name])
-        for name, app in status.applications.items():
-            if name == app_name:
-                return app
-        raise ApplicationNotFound(f"Cannot find '{app_name}' in model '{self.name}'.")
+        status = self._juju.status()
+        app = status.apps.get(app_name)
+        if app is None:
+            raise ApplicationNotFound(f"Cannot find '{app_name}' in model '{self.name}'.")
+        return app
 
 
 def get_applications_by_charm_name(

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,10 +27,6 @@ python_requires = >=3.10
 packages = find:
 install_requires =
     oslo.config
-    # A temporary workaround for bug: https://github.com/juju/python-libjuju/issues/1083
-    juju>=3.0,<3.5
-    # Apply recommendation to workaround bug: https://github.com/juju/python-libjuju/issues/1260
-    websockets>=9.0,<14.0
     colorama
     packaging
     aioconsole
@@ -59,6 +55,7 @@ unittests =
     pytest-cov
     pytest-mock
     pytest-asyncio
+    pytest-jubilant
     aiounittest
     gevent
 

--- a/tests/functional/tests/backup.py
+++ b/tests/functional/tests/backup.py
@@ -1,11 +1,13 @@
 """Generic setup for functional tests."""
 
+import asyncio
 import logging
 import os
 import unittest
 from unittest.mock import patch
 
 import zaza
+import zaza.model
 
 from cou.steps.backup import backup
 from cou.utils import COU_DATA
@@ -18,14 +20,12 @@ class BackupTest(unittest.TestCase):
     """Code for backup test."""
 
     def setUp(self) -> None:
-        zaza.get_or_create_libjuju_thread()
         model_name = zaza.model.get_juju_model()
         self.model = Model(model_name)
-        zaza.sync_wrapper(self.model.connect)()
+        asyncio.get_event_loop().run_until_complete(self.model.connect())
 
     def tearDown(self) -> None:
-        zaza.sync_wrapper(self.model._model.disconnect)()
-        zaza.clean_up_libjuju_thread()
+        pass  # jubilant is CLI-based; no persistent connection to tear down
 
     def test_backup(self):
         """Backup Test."""

--- a/tests/functional/tests/model.py
+++ b/tests/functional/tests/model.py
@@ -2,9 +2,6 @@ import logging
 import os
 import unittest
 
-import zaza
-import zaza.model
-
 from cou.utils.juju_utils import Model
 
 log = logging.getLogger(__name__)
@@ -17,77 +14,102 @@ class ModelTest(unittest.TestCase):
     """Model functional tests."""
 
     def setUp(self) -> None:
-        zaza.get_or_create_libjuju_thread()
+        import zaza.model
+
         model_name = zaza.model.get_juju_model()
         self.model = Model(model_name)
 
     def tearDown(self) -> None:
-        zaza.sync_wrapper(self.model._model.disconnect)()
-        zaza.clean_up_libjuju_thread()
+        pass  # jubilant is CLI-based; no persistent connection to tear down
 
     def test_connection(self):
         """Test model connection."""
-        zaza.sync_wrapper(self.model.connect)()
+        import asyncio
+
+        asyncio.get_event_loop().run_until_complete(self.model.connect())
         self.assertTrue(self.model.connected)
-        zaza.sync_wrapper(self.model._model.disconnect)()
-        self.assertFalse(self.model.connected)
 
     def test_get_charm_name(self):
         """Test get charm name."""
-        charm = zaza.sync_wrapper(self.model.get_charm_name)(TESTED_APP)
+        import asyncio
+
+        charm = asyncio.get_event_loop().run_until_complete(self.model.get_charm_name(TESTED_APP))
         self.assertEqual(TESTED_APP, charm)
 
     def test_get_status(self):
         """Test Model.get_status."""
-        status = zaza.sync_wrapper(self.model.get_status)()
-        self.assertIn(TESTED_APP, status.applications)
+        import asyncio
+
+        status = asyncio.get_event_loop().run_until_complete(self.model.get_status())
+        self.assertIn(TESTED_APP, status.apps)
 
     def test_run_action(self):
         """Test run action."""
-        action = zaza.sync_wrapper(self.model.run_action)(TESTED_UNIT, "resume")
-        self.assertEqual(0, action.results["return-code"])
-        self.assertEqual("completed", action.data["status"])
+        import asyncio
+
+        action = asyncio.get_event_loop().run_until_complete(
+            self.model.run_action(TESTED_UNIT, "resume")
+        )
+        self.assertEqual(0, action.return_code)
+        self.assertEqual("completed", action.status)
 
     def test_run_on_unit(self):
         """Test run command on unit."""
-        results = zaza.sync_wrapper(self.model.run_on_unit)(TESTED_UNIT, "actions/resume")
+        import asyncio
+
+        results = asyncio.get_event_loop().run_until_complete(
+            self.model.run_on_unit(TESTED_UNIT, "actions/resume")
+        )
         self.assertIn("active", results["stdout"])
 
     def test_scp_from_unit(self):
         """Test copy file from unit."""
-        tmp_dir = zaza.model.tempfile.gettempdir()
+        import asyncio
+        import tempfile
+
+        tmp_dir = tempfile.gettempdir()
         test_file = "test.txt"
         path = f"/tmp/{test_file}"
         exp_path = os.path.join(tmp_dir, test_file)
-        zaza.model.run_on_unit(unit_name=TESTED_UNIT, command=f"echo 'test' > {path}")
+        self.model._juju.exec(f"echo 'test' > {path}", unit=TESTED_UNIT)
 
-        zaza.sync_wrapper(self.model.scp_from_unit)(TESTED_UNIT, path, tmp_dir)
+        asyncio.get_event_loop().run_until_complete(
+            self.model.scp_from_unit(TESTED_UNIT, path, tmp_dir)
+        )
         self.assertTrue(os.path.exists(exp_path))
 
     def test_changing_app_configuration(self):
-        """Test change of app configuration.
+        """Test change of app configuration."""
+        import asyncio
 
-        This test covers set and get configuration option along with waiting for model to be idle.
-        """
         original_config = {"debug": "false"}
         new_config = {"debug": "true"}
-        self.addCleanup(zaza.model.set_application_config, TESTED_APP, original_config)
-        self.addCleanup(zaza.model.wait_for_unit_idle, TESTED_UNIT)
 
-        # changing configuration and validating it was changed
-        zaza.sync_wrapper(self.model.set_application_config)(TESTED_APP, new_config)
-        zaza.sync_wrapper(self.model.wait_for_idle)(120, apps=[TESTED_APP])
-        config = zaza.sync_wrapper(self.model.get_application_config)(TESTED_APP)
-
+        asyncio.get_event_loop().run_until_complete(
+            self.model.set_application_config(TESTED_APP, new_config)
+        )
+        asyncio.get_event_loop().run_until_complete(
+            self.model.wait_for_idle(120, apps=[TESTED_APP])
+        )
+        config = asyncio.get_event_loop().run_until_complete(
+            self.model.get_application_config(TESTED_APP)
+        )
         self.assertTrue(config["debug"]["value"])
 
-    def test_upgrade_charm(self):
-        """Test upgrade charm to the latest revision of the current channel.
+        # cleanup
+        asyncio.get_event_loop().run_until_complete(
+            self.model.set_application_config(TESTED_APP, original_config)
+        )
 
-        This test only checks the results of such an upgrade operation.
-        """
-        status = zaza.model.get_status()
-        # get the current channel, so we will not change it
-        channel = status.applications[TESTED_APP].charm_channel
-        zaza.sync_wrapper(self.model.upgrade_charm)(TESTED_APP, channel=channel)
-        zaza.sync_wrapper(self.model.wait_for_idle)(120, apps=[TESTED_APP])
+    def test_upgrade_charm(self):
+        """Test upgrade charm to the latest revision of the current channel."""
+        import asyncio
+
+        status = self.model._juju.status()
+        channel = status.apps[TESTED_APP].charm_channel
+        asyncio.get_event_loop().run_until_complete(
+            self.model.upgrade_charm(TESTED_APP, channel=channel)
+        )
+        asyncio.get_event_loop().run_until_complete(
+            self.model.wait_for_idle(120, apps=[TESTED_APP])
+        )

--- a/tests/unit/apps/test_auxiliary.py
+++ b/tests/unit/apps/test_auxiliary.py
@@ -1945,7 +1945,7 @@ def vault_o7k_app(model):
 
 @pytest.mark.asyncio
 async def test_vault_wait_for_sealed_status(vault_o7k_app):
-    vault_o7k_app.model.get_application_status.return_value.status.info = "Unit is sealed"
+    vault_o7k_app.model.get_application_status.return_value.app_status.message = "Unit is sealed"
     await vault_o7k_app._wait_for_sealed_status()
 
     vault_o7k_app.model.wait_for_idle.assert_awaited_once_with(
@@ -1959,7 +1959,7 @@ async def test_vault_wait_for_sealed_status(vault_o7k_app):
 @pytest.mark.asyncio
 async def test_vault_wait_for_sealed_status_failed(vault_o7k_app):
     vault_o7k_app.model.wait_for_idle = AsyncMock()
-    vault_o7k_app.model.get_application_status.return_value.status.info = "Unit is ready"
+    vault_o7k_app.model.get_application_status.return_value.app_status.message = "Unit is ready"
     with pytest.raises(
         ApplicationError,
         match=(

--- a/tests/unit/apps/test_core.py
+++ b/tests/unit/apps/test_core.py
@@ -13,8 +13,8 @@
 #  limitations under the License.
 from unittest.mock import AsyncMock, MagicMock, Mock, call, patch
 
+import jubilant
 import pytest
-from juju.client._definitions import ApplicationStatus, UnitStatus
 
 from cou.apps.base import OpenStackApplication
 from cou.apps.core import Keystone, NeutronApi, NovaCompute, Swift, resume_nova_compute_unit
@@ -107,11 +107,11 @@ async def test_application_verify_workload_upgrade(model):
 
     # workload version changed from ussuri to victoria
     mock_status = AsyncMock()
-    mock_app_status = MagicMock(spec_set=ApplicationStatus())
-    mock_unit_status = MagicMock(spec_set=UnitStatus())
-    mock_unit_status.workload_version = "18.1.0"
+    mock_app_status = MagicMock()
+    mock_unit_status = MagicMock()
+    mock_unit_status.workload_status.version = "18.1.0"
     mock_app_status.units = {"keystone/0": mock_unit_status}
-    mock_status.return_value.applications = {"keystone": mock_app_status}
+    mock_status.return_value.apps = {"keystone": mock_app_status}
     model.get_status = mock_status
 
     assert await app._verify_workload_upgrade(target, app.units.values()) is None
@@ -152,11 +152,11 @@ async def test_application_verify_workload_upgrade_fail(model):
 
     # workload version didn't change from ussuri to victoria
     mock_status = AsyncMock()
-    mock_app_status = MagicMock(spec_set=ApplicationStatus())
-    mock_unit_status = MagicMock(spec_set=UnitStatus())
-    mock_unit_status.workload_version = "17.1.0"
+    mock_app_status = MagicMock()
+    mock_unit_status = MagicMock()
+    mock_unit_status.workload_status.version = "17.1.0"
     mock_app_status.units = {"keystone/0": mock_unit_status}
-    mock_status.return_value.applications = {"keystone": mock_app_status}
+    mock_status.return_value.apps = {"keystone": mock_app_status}
     model.get_status = mock_status
 
     with pytest.raises(ApplicationError, match=exp_msg):
@@ -1153,8 +1153,8 @@ async def test_resume_nova_compute_success(model):
 @pytest.mark.asyncio
 async def test_resume_nova_compute_unknown_failure(model):
     """Verify that the unknown failure case bails out."""
-    model.run_action.return_value = Mock(
-        status="failed", safe_data={"message": "it crashed and we don't know why"}
+    model.run_action.return_value = jubilant.Task(
+        id="1", status="failed", message="it crashed and we don't know why"
     )
     unit = Unit(
         name="nova-compute/0",
@@ -1174,15 +1174,14 @@ async def test_resume_nova_compute_unknown_failure(model):
 @pytest.mark.asyncio
 async def test_resume_nova_compute_ceilometer_failure(model):
     """Verify that the ceilometer failure case performs the workaround."""
-    model.run_action.return_value = Mock(
+    model.run_action.return_value = jubilant.Task(
+        id="1",
         status="failed",
-        safe_data={
-            "message": (
-                "Action resume failed: Couldn't resume: "
-                "ceilometer-agent-compute didn't resume cleanly.; "
-                "Services not running that should be: ceilometer-agent-compute"
-            ),
-        },
+        message=(
+            "Action resume failed: Couldn't resume: "
+            "ceilometer-agent-compute didn't resume cleanly.; "
+            "Services not running that should be: ceilometer-agent-compute"
+        ),
     )
     unit = Unit(
         name="nova-compute/0",

--- a/tests/unit/steps/test_backup.py
+++ b/tests/unit/steps/test_backup.py
@@ -15,6 +15,7 @@
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, call, patch
 
+import jubilant
 import pytest
 
 from cou.exceptions import UnitNotFound
@@ -58,19 +59,22 @@ async def test_get_database_app_name(model):
 
 
 def test_check_db_relations():
-    app_config = {
-        "relations": {
-            "cluster": ["mysql"],
-            "coordinator": ["mysql"],
-            "db-router": [
-                "cinder-mysql-router",
-                "glance-mysql-router",
-                "neutron-api-mysql-router",
-                "nova-cloud-controller-mysql-router",
-                "openstack-dashboard-mysql-router",
-                "placement-mysql-router",
-            ],
-        }
+    app_config = MagicMock()
+    app_config.relations = {
+        "cluster": [jubilant.statustypes.AppStatusRelation("mysql", "", "global")],
+        "coordinator": [jubilant.statustypes.AppStatusRelation("mysql", "", "global")],
+        "db-router": [
+            jubilant.statustypes.AppStatusRelation("cinder-mysql-router", "", "global"),
+            jubilant.statustypes.AppStatusRelation("glance-mysql-router", "", "global"),
+            jubilant.statustypes.AppStatusRelation("neutron-api-mysql-router", "", "global"),
+            jubilant.statustypes.AppStatusRelation(
+                "nova-cloud-controller-mysql-router", "", "global"
+            ),
+            jubilant.statustypes.AppStatusRelation(
+                "openstack-dashboard-mysql-router", "", "global"
+            ),
+            jubilant.statustypes.AppStatusRelation("placement-mysql-router", "", "global"),
+        ],
     }
     result = _check_db_relations(app_config)
     assert not result

--- a/tests/unit/steps/test_vault.py
+++ b/tests/unit/steps/test_vault.py
@@ -23,9 +23,8 @@ from cou.steps.vault import verify_vault_is_unsealed
 async def test_verify_vault_is_unsealed_sealed(model) -> None:
     model.get_application_names.return_value = ["app1", "app2"]
     model.get_application_status.return_value = MagicMock()
-    model.get_application_status.return_value.status = MagicMock()
-    model.get_application_status.return_value.status.info = "Unit is sealed"
-    model.get_application_status.return_value.status.status = "blocked"
+    model.get_application_status.return_value.app_status.message = "Unit is sealed"
+    model.get_application_status.return_value.is_blocked = True
     err_msg = (
         "Vault is sealed, please follow the steps on "
         "https://charmhub.io/vault to unseal the vault manually before upgrade"
@@ -35,19 +34,18 @@ async def test_verify_vault_is_unsealed_sealed(model) -> None:
 
 
 @pytest.mark.parametrize(
-    "case,info,status",
+    "case,info,is_blocked",
     [
-        ["wrong info", "wrong info msg", "blocked"],
-        ["wrong status", "Unit is sealed", "wrong status"],
+        ["wrong info", "wrong info msg", True],
+        ["not blocked", "Unit is sealed", False],
     ],
 )
 @pytest.mark.asyncio
-async def test_verify_vault_is_unsealed_unseal(case, info, status, model) -> None:
+async def test_verify_vault_is_unsealed_unseal(case, info, is_blocked, model) -> None:
     model.get_application_names.return_value = ["app1", "app2"]
     model.get_application_status.return_value = MagicMock()
-    model.get_application_status.return_value.status = MagicMock()
-    model.get_application_status.return_value.status.info = info
-    model.get_application_status.return_value.status.status = status
+    model.get_application_status.return_value.app_status.message = info
+    model.get_application_status.return_value.is_blocked = is_blocked
     await verify_vault_is_unsealed(model)
 
 

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -14,8 +14,8 @@
 
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import jubilant
 import pytest
-from juju.errors import JujuError
 
 from cou import cli
 from cou.exceptions import COUException, HighestReleaseAchieved, TimeoutException
@@ -460,8 +460,8 @@ def test_entrypoint_failure_cou_exception(mock_run_command, mock_indicator, mock
 @patch("cou.cli.setup_logging", new=MagicMock())
 @patch("cou.cli._run_command")
 def test_entrypoint_failure_juju_error(mock_run_command, mock_indicator, mock_log_ssdlc):
-    """Test JujuError exception during entrypoint execution."""
-    mock_run_command.side_effect = JujuError
+    """Test jubilant.CLIError exception during entrypoint execution."""
+    mock_run_command.side_effect = jubilant.CLIError(1, ["juju"], "", "juju error")
 
     with pytest.raises(SystemExit, match="1"):
         cli.entrypoint()

--- a/tests/unit/test_exceptions.py
+++ b/tests/unit/test_exceptions.py
@@ -11,34 +11,24 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from unittest import mock
-
-from juju.action import Action
+import jubilant
 
 from cou.exceptions import ActionFailed
 
 
 def test_action_failed():
     """Test error message composition for ActionFailed."""
-    action = mock.Mock(spec_set=Action)()
-    action.safe_data = {
-        "model-uuid": "12885f47-4dfa-4457-8ed1-1f08c1b278dd",
-        "id": "4",
-        "receiver": "my-charm/0",
-        "name": "test-action",
-        "status": "failed",
-        "message": "error message",
-        "enqueued": "2024-05-29T14:50:08Z",
-        "started": "2024-05-29T14:50:11Z",
-        "completed": "2024-05-29T14:50:11Z",
-    }
-
-    error = ActionFailed(action=action)
-    assert str(error) == (
-        "Run of action 'test-action' with parameters '<not-set>' on 'my-charm/0' failed with "
-        "'error message' (id=4 status=failed enqueued=2024-05-29T14:50:08Z started=2024-05-29T14:"
-        "50:11Z completed=2024-05-29T14:50:11Z output={'model-uuid': '12885f47-4dfa-4457-8ed1-1f0"
-        "8c1b278dd', 'id': '4', 'receiver': 'my-charm/0', 'name': 'test-action', 'status': "
-        "'failed', 'message': 'error message', 'enqueued': '2024-05-29T14:50:08Z', 'started': "
-        "'2024-05-29T14:50:11Z', 'completed': '2024-05-29T14:50:11Z'})"
+    task = jubilant.Task(
+        id="4",
+        status="failed",
+        results={"instance-count": "5"},
+        return_code=1,
+        stdout="",
+        stderr="some error",
+        message="error message",
     )
+
+    error = ActionFailed(task=task)
+    assert "4" in str(error)
+    assert "failed" in str(error)
+    assert "error message" in str(error)

--- a/tests/unit/utils.py
+++ b/tests/unit/utils.py
@@ -12,11 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Module to provide helper for writing unit tests."""
+import json
 from pathlib import Path
 from textwrap import dedent
 from unittest.mock import MagicMock
 
-from juju.client.client import FullStatus
+import jubilant
 
 from cou.steps import BaseStep
 from cou.utils.juju_utils import Application, Machine, Unit
@@ -69,9 +70,22 @@ def get_status():
     """Help function to load Juju status from json file."""
     current_path = Path(__file__).parent.resolve()
     with open(current_path / "jujustatus.json", "r") as file:
-        status = file.read().rstrip()
+        data = json.loads(file.read().rstrip())
 
-    return FullStatus.from_json(status)
+    # Convert old relations format (list of strings) to jubilant's expected format
+    # (list of dicts with related-application, interface, scope keys)
+    for app_data in data.get("applications", {}).values():
+        for rel_name, rel_list in app_data.get("relations", {}).items():
+            app_data["relations"][rel_name] = [
+                (
+                    {"related-application": r, "interface": "", "scope": "global"}
+                    if isinstance(r, str)
+                    else r
+                )
+                for r in rel_list
+            ]
+
+    return jubilant.Status._from_dict(data)
 
 
 async def get_charm_name(value: str):

--- a/tests/unit/utils/test_juju_utils.py
+++ b/tests/unit/utils/test_juju_utils.py
@@ -12,17 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import asyncio
+import json
 from unittest.mock import AsyncMock, MagicMock, call, patch
 
 import jubilant
 import pytest
-from juju.action import Action
-from juju.application import Application
-from juju.client._definitions import ApplicationStatus, Base, UnitStatus
-from juju.client.connector import NoConnectionException
-from juju.machine import Machine
-from juju.model import Model
-from juju.unit import Unit
 
 from cou.exceptions import (
     ActionFailed,
@@ -36,32 +30,12 @@ from cou.exceptions import (
 from cou.utils import juju_utils
 
 
-@pytest.mark.parametrize(
-    "base, exp_series",
-    [
-        (Base("18.04/stable", "ubuntu"), "bionic"),
-        (Base("20.04/stable", "ubuntu"), "focal"),
-        (Base("22.04/stable", "ubuntu"), "jammy"),
-    ],
-)
-def test_convert_base_to_series(base, exp_series):
-    """Test helper function to convert base to series."""
-    assert juju_utils._convert_base_to_series(base) == exp_series
-
-
 @pytest.fixture
-def mocked_model(mocker):
-    """Fixture providing mocked juju.model.Model object."""
-    mocker.patch("cou.utils.juju_utils.FileJujuData")
-    model_mocker = mocker.patch(
-        "cou.utils.juju_utils.JujuModel", return_value=MagicMock(spec_set=Model)
-    )
-    model = model_mocker.return_value
-    model.connection.return_value.is_open = True  # simulate already connected model
-    model.disconnect = AsyncMock()
-    model.connect = AsyncMock()
-    model.wait_for_idle = AsyncMock()
-    yield model
+def mocked_juju(mocker):
+    """Fixture providing mocked jubilant.Juju instance."""
+    mock_juju = MagicMock(spec_set=jubilant.Juju)
+    mocker.patch("cou.utils.juju_utils.jubilant.Juju", return_value=mock_juju)
+    yield mock_juju
 
 
 @pytest.fixture
@@ -82,6 +56,34 @@ def mocked_jubilant_juju(mocker):
     mocker.patch("cou.utils.juju_utils.jubilant.all_agents_idle", MagicMock())
 
     yield mock_juju_instance
+
+
+@pytest.mark.parametrize(
+    "channel, exp_series",
+    [
+        ("18.04/stable", "bionic"),
+        ("20.04/stable", "focal"),
+        ("22.04/stable", "jammy"),
+    ],
+)
+def test_convert_base_to_series(channel, exp_series):
+    """Test helper function to convert base to series."""
+    base = jubilant.statustypes.FormattedBase(name="ubuntu", channel=channel)
+    assert juju_utils._convert_base_to_series(base) == exp_series
+
+
+@pytest.mark.parametrize(
+    "hardware, exp_az",
+    [
+        ("arch=amd64 availability-zone=nova", "nova"),
+        ("arch=amd64 availability-zone=us-east-1a", "us-east-1a"),
+        ("arch=amd64 mem=1G", None),
+        ("", None),
+    ],
+)
+def test_parse_availability_zone(hardware, exp_az):
+    """Test helper function to parse availability zone from hardware string."""
+    assert juju_utils._parse_availability_zone(hardware) == exp_az
 
 
 @pytest.mark.asyncio
@@ -190,188 +192,142 @@ def test_machine_eq():
     assert machine_0 == machine_1
 
 
-@patch("cou.utils.juju_utils.FileJujuData")
-def test_coumodel_init(mock_juju_data, mocker):
+def test_coumodel_init(mocked_juju):
     """Test Model initialization."""
-    model_mocker = mocker.patch("cou.utils.juju_utils.JujuModel")
-    mocked_model = model_mocker.return_value
-    mocked_model.connection.side_effect = NoConnectionException  # simulate an unconnected model
     name = "test-model"
-
     model = juju_utils.Model(name)
 
-    mock_juju_data.assert_called_once_with()
-    model_mocker.assert_called_once_with(
-        max_frame_size=juju_utils.JUJU_MAX_FRAME_SIZE,
-        jujudata=mock_juju_data.return_value,
-    )
-    assert model._model == mocked_model
+    assert model._name == name
+    assert model._juju is mocked_juju
 
 
-def test_coumodel_connected_no_connection(mocked_model):
-    """Test Model connected property."""
-    mocked_model.connection.side_effect = NoConnectionException
+def test_coumodel_connected_no_connection(mocked_juju):
+    """Test Model connected property when model not accessible."""
+    mocked_juju.show_model.side_effect = jubilant.CLIError(1, ["juju"], "", "error")
 
     model = juju_utils.Model("test-model")
 
     assert model.connected is False
 
 
-def test_coumodel_connected(mocked_model):
-    """Test Model connected property."""
-    mocked_model.connection.return_value.is_open = True
+def test_coumodel_connected(mocked_juju):
+    """Test Model connected property when model is accessible."""
+    mocked_juju.show_model.return_value = MagicMock()
 
     model = juju_utils.Model("test-model")
 
     assert model.connected is True
 
 
-def test_coumodel_name(mocked_model):
-    """Test Model name property without model name."""
+def test_coumodel_name(mocked_juju):
+    """Test Model name property with a provided name."""
     exp_model_name = "test-model"
-    mocked_model.connection.side_effect = NoConnectionException  # simulate an unconnected model
 
     model = juju_utils.Model(exp_model_name)
 
     assert model.name == exp_model_name
-    model.juju_data.current_model.assert_not_called()
+    mocked_juju.show_model.assert_not_called()
 
 
-def test_coumodel_name_no_name(mocked_model):
-    """Test Model name property without model name."""
-    mocked_model.connection.side_effect = NoConnectionException  # simulate an unconnected model
-
-    model = juju_utils.Model(None)
-
-    assert model.name == model.juju_data.current_model.return_value
-    model.juju_data.current_model.assert_called_once_with(model_only=True)
-
-
-def test_coumodel_name_connected(mocked_model):
-    """Test Model initialization without model name, but connected."""
-    mocked_model.connection.return_value.is_open = True
+def test_coumodel_name_no_name(mocked_juju):
+    """Test Model name property without model name uses show_model."""
+    mocked_juju.show_model.return_value.short_name = "current-model"
 
     model = juju_utils.Model(None)
 
-    assert model.name == mocked_model.name
-    model.juju_data.current_model.assert_not_called()
+    assert model.name == "current-model"
+    mocked_juju.show_model.assert_called_once_with()
 
 
 @pytest.mark.asyncio
-async def test_coumodel_connect(mocked_model):
-    """Test Model connection."""
-    name = "test-model"
-    model = juju_utils.Model(name)
+async def test_coumodel_connect(mocked_juju):
+    """Test Model connection validates model and caches name."""
+    mocked_juju.show_model.return_value.short_name = "resolved-model"
+    model = juju_utils.Model(None)
+
     await model.connect()
 
-    mocked_model.disconnect.assert_awaited_once_with()
-    mocked_model.connect.assert_awaited_once_with(
-        model_name=name,
-        retries=juju_utils.DEFAULT_MODEL_RETRIES,
-        retry_backoff=juju_utils.DEFAULT_MODEL_RETRY_BACKOFF,
-    )
+    mocked_juju.show_model.assert_called()
+    assert model._name == "resolved-model"
 
 
 @pytest.mark.asyncio
-async def test_coumodel_get_application(mocked_model):
-    """Test Model get application."""
-    app_name = "test-app"
-    model = juju_utils.Model("test-model")
-
-    app = await model._get_application(app_name)
-
-    mocked_model.applications.get.assert_called_once_with(app_name)
-    assert app == mocked_model.applications.get.return_value
-
-
-@pytest.mark.asyncio
-async def test_coumodel_get_application_failure(mocked_model):
-    """Test Model get not existing application."""
-    model = juju_utils.Model("test-model")
-    mocked_model.applications.get.return_value = None
-
-    with pytest.raises(ApplicationNotFound):
-        await model._get_application("test-app")
-
-
-@pytest.mark.asyncio
-async def test_coumodel_get_model(mocked_model):
-    """Test Model get connected model object."""
-    mocked_model.connection.return_value = None  # simulate disconnected model
-
-    model = juju_utils.Model("test-model")
-    juju_model = await model._get_model()
-
-    mocked_model.disconnect.assert_awaited_once()
-    mocked_model.connect.assert_awaited_once()
-    assert juju_model == mocked_model
-
-
-@pytest.mark.asyncio
-async def test_coumodel_get_unit(mocked_model):
+async def test_coumodel_get_unit(mocked_juju):
     """Test Model get unit."""
-    unit_name = "test-unit"
-    model = juju_utils.Model("test-model")
+    unit_name = "test-app/0"
+    mock_unit_status = MagicMock()
+    mock_status = MagicMock()
+    mock_status.apps = {"test-app": MagicMock(units={unit_name: mock_unit_status})}
+    mocked_juju.status.return_value = mock_status
 
+    model = juju_utils.Model("test-model")
     unit = await model.get_unit(unit_name)
 
-    mocked_model.units.get.assert_called_once_with(unit_name)
-    assert unit == mocked_model.units.get.return_value
+    assert unit is mock_unit_status
 
 
 @pytest.mark.asyncio
-async def test_coumodel_get_unit_failure(mocked_model):
+async def test_coumodel_get_unit_failure(mocked_juju):
     """Test Model get not existing unit."""
+    mock_status = MagicMock()
+    mock_status.apps = {"test-app": MagicMock(units={})}
+    mocked_juju.status.return_value = mock_status
+
     model = juju_utils.Model("test-model")
-    mocked_model.units.get.return_value = None
 
     with pytest.raises(UnitNotFound):
-        await model.get_unit("test-unit")
+        await model.get_unit("missing-unit/0")
 
 
 @pytest.mark.asyncio
 @patch("cou.utils.juju_utils.is_charm_supported")
-async def test_coumodel_get_supported_apps(mock_is_charm_supported, mocked_model):
+async def test_coumodel_get_supported_apps(mock_is_charm_supported, mocked_juju):
     """Test Model providing list of supported applications."""
     mock_is_charm_supported.side_effect = [False, True]
-    model = juju_utils.Model("test-model")
-    app = MagicMock(spec_set=Application).return_value
-    mocked_model.applications = {"unsupported": app, "supported": app}
+    mock_status = MagicMock()
+    mock_status.apps = {
+        "unsupported": MagicMock(charm_name="charm-a"),
+        "supported": MagicMock(charm_name="charm-b"),
+    }
+    mocked_juju.status.return_value = mock_status
 
+    model = juju_utils.Model("test-model")
     apps = await model._get_supported_apps()
 
-    mock_is_charm_supported.assert_has_calls([call(app.charm_name), call(app.charm_name)])
     assert apps == ["supported"]
 
 
 @pytest.mark.asyncio
-async def test_coumodel_get_application_configs(mocked_model):
+async def test_coumodel_get_application_configs(mocked_juju):
     """Test Model get application configuration."""
-    mocked_model.applications.get.return_value = mocked_app = AsyncMock(Application)
+    config_data = {"settings": {"key": {"value": "val", "type": "string"}}}
+    mocked_juju.cli.return_value = json.dumps(config_data)
     model = juju_utils.Model("test-model")
 
-    app = await model.get_application_config("test-app")
+    config = await model.get_application_config("test-app")
 
-    mocked_app.get_config.assert_awaited_once_with()
-    assert app == mocked_app.get_config.return_value
+    assert config == config_data["settings"]
 
 
 @pytest.mark.asyncio
-async def test_coumodel_get_charm_name(mocked_model):
+async def test_coumodel_get_charm_name(mocked_juju):
     """Test Model get charm name from application by application name."""
-    mocked_model.applications.get.return_value = mocked_app = AsyncMock(Application)
-    model = juju_utils.Model("test-model")
+    mock_status = MagicMock()
+    mock_status.apps = {"test-app": MagicMock(charm_name="my-charm")}
+    mocked_juju.status.return_value = mock_status
 
+    model = juju_utils.Model("test-model")
     charm_name = await model.get_charm_name("test-app")
 
-    assert charm_name == mocked_app.charm_name
+    assert charm_name == "my-charm"
 
 
 @pytest.mark.asyncio
-async def test_coumodel_get_charm_name_failure(mocked_model):
-    """Test Model get charm name from application by application name."""
-    mocked_model.applications.get.return_value = mocked_app = AsyncMock(Application)
-    mocked_app.charm_name = None
+async def test_coumodel_get_charm_name_failure(mocked_juju):
+    """Test Model get charm name failure when app has no charm_name."""
+    mock_status = MagicMock()
+    mock_status.apps = {"test-app": MagicMock(charm_name=None)}
+    mocked_juju.status.return_value = mock_status
     app_name = "test-app"
     model = juju_utils.Model("test-model")
 
@@ -380,90 +336,94 @@ async def test_coumodel_get_charm_name_failure(mocked_model):
 
 
 @pytest.mark.asyncio
-async def test_coumodel_get_status(mocked_model):
+async def test_coumodel_get_status(mocked_juju):
     """Test Model get model status."""
-    model = juju_utils.Model("test-model")
+    mock_status = MagicMock(spec=jubilant.Status)
+    mocked_juju.status.return_value = mock_status
 
+    model = juju_utils.Model("test-model")
     status = await model.get_status()
 
-    mocked_model.get_status.assert_awaited_once_with()
-    assert status == mocked_model.get_status.return_value
+    mocked_juju.status.assert_called_once_with()
+    assert status is mock_status
 
 
 @pytest.mark.asyncio
-async def test_coumodel_get_waited_action_object_object(mocked_model):
-    """Test Model get action result."""
-    mocked_action = AsyncMock(spec_set=Action).return_value
-    model = juju_utils.Model("test-model")
-
-    action = await model._get_waited_action_object(mocked_action, False)
-
-    mocked_action.wait.assert_awaited_once_with()
-    assert action == mocked_action.wait.return_value
-
-
-@pytest.mark.asyncio
-async def test_coumodel_get_waited_action_object_failure(mocked_model):
-    """Test Model get action result failing."""
-    mocked_action = AsyncMock(spec_set=Action).return_value
-    mocked_action.wait.return_value = mocked_action
-    mocked_action.wait.status = "failed"
-    model = juju_utils.Model("test-model")
-
-    with pytest.raises(ActionFailed):
-        await model._get_waited_action_object(mocked_action, True)
-
-
-@pytest.mark.asyncio
-@patch("cou.utils.juju_utils.Model._get_waited_action_object")
-async def test_coumodel_run_action(mock_get_waited_action_object, mocked_model):
+async def test_coumodel_run_action(mocked_juju):
     """Test Model run action."""
     action_name = "test-action"
     action_params = {"test-arg": "test"}
-    mocked_model.units.get.return_value = mocked_unit = AsyncMock(Unit)
-    mock_get_waited_action_object.return_value = mocked_result = AsyncMock(Action)
+    mock_task = MagicMock(spec=jubilant.Task)
+    mocked_juju.run.return_value = mock_task
     model = juju_utils.Model("test-model")
 
-    action = await model.run_action("test_unit/0", action_name, action_params=action_params)
+    task = await model.run_action("test_unit/0", action_name, action_params=action_params)
 
-    mocked_unit.run_action.assert_awaited_once_with(action_name, **action_params)
-    mock_get_waited_action_object.assert_awaited_once_with(
-        mocked_unit.run_action.return_value, False
-    )
-    assert action == mocked_result
+    mocked_juju.run.assert_called_once_with("test_unit/0", action_name, params=action_params)
+    assert task is mock_task
 
 
 @pytest.mark.asyncio
-async def test_coumodel_run_on_unit(mocked_model):
+async def test_coumodel_run_action_failure_raise(mocked_juju):
+    """Test Model run action failure with raise_on_failure=True."""
+    mock_task = MagicMock(spec=jubilant.Task)
+    mock_task.id = "1"
+    mock_task.status = "failed"
+    mock_task.message = "oops"
+    mock_task.results = {}
+    mocked_juju.run.side_effect = jubilant.TaskError(mock_task)
+    model = juju_utils.Model("test-model")
+
+    with pytest.raises(ActionFailed):
+        await model.run_action("test_unit/0", "test-action", raise_on_failure=True)
+
+
+@pytest.mark.asyncio
+async def test_coumodel_run_action_failure_no_raise(mocked_juju):
+    """Test Model run action failure with raise_on_failure=False returns task."""
+    mock_task = MagicMock(spec=jubilant.Task)
+    mock_task.status = "failed"
+    mocked_juju.run.side_effect = jubilant.TaskError(mock_task)
+    model = juju_utils.Model("test-model")
+
+    result = await model.run_action("test_unit/0", "test-action", raise_on_failure=False)
+
+    assert result is mock_task
+
+
+@pytest.mark.asyncio
+async def test_coumodel_run_on_unit(mocked_juju):
     """Test Model run on unit."""
     command = "test-command"
-    expected_results = {"return-code": 0, "stdout": "some results"}
-    mocked_model.units.get.return_value = mocked_unit = AsyncMock(Unit)
-    mocked_unit.run.return_value = mocked_action = AsyncMock(Action)
-    mocked_action.results = expected_results
+    mock_task = MagicMock(spec=jubilant.Task)
+    mock_task.return_code = 0
+    mock_task.stdout = "some results"
+    mock_task.stderr = ""
+    mocked_juju.exec.return_value = mock_task
     model = juju_utils.Model("test-model")
 
     results = await model.run_on_unit("test-unit/0", command)
 
-    mocked_unit.run.assert_awaited_once_with(command, timeout=None, block=True)
-    assert results == expected_results
+    mocked_juju.exec.assert_called_once_with(command, unit="test-unit/0", wait=None)
+    assert results == {"return-code": 0, "stdout": "some results", "stderr": ""}
 
 
 @pytest.mark.asyncio
-async def test_coumodel_run_on_unit_failed_command(mocked_model):
-    """Test Model run on unit."""
+async def test_coumodel_run_on_unit_failed_command(mocked_juju):
+    """Test Model run on unit with failed command."""
     command = "test-command"
-    expected_results = {"return-code": 1, "stderr": "Error!"}
-    mocked_model.units.get.return_value = mocked_unit = AsyncMock(Unit)
-    mocked_unit.run.return_value = mocked_action = AsyncMock(Action)
-    mocked_action.results = expected_results
+    mock_task = MagicMock(spec=jubilant.Task)
+    mock_task.return_code = 1
+    mock_task.stdout = None
+    mock_task.stderr = "Error!"
+    mocked_juju.exec.side_effect = jubilant.TaskError(mock_task)
     model = juju_utils.Model("test-model")
 
     expected_err = "Command test-command failed with code 1, output None and error Error!"
     with pytest.raises(CommandRunFailed, match=expected_err):
         await model.run_on_unit("test-unit/0", command)
 
-    mocked_unit.run.assert_awaited_once_with(command, timeout=None, block=True)
+    mocked_juju.exec.assert_called_once_with(command, unit="test-unit/0", wait=None)
 
 
 @pytest.mark.asyncio
@@ -471,7 +431,7 @@ async def test_coumodel_run_on_unit_failed_command(mocked_model):
 @patch("cou.utils.juju_utils.Model._run_update_status_hook")
 @patch("cou.utils.juju_utils.Model._dispatch_update_status_hook")
 async def test_coumodel_update_status_use_dispatch(
-    use_dispatch, use_hooks, mocked_logger, mocked_model
+    use_dispatch, use_hooks, mocked_logger, mocked_juju
 ):
     """Test Model update_status using dispatch."""
     model = juju_utils.Model("test-model")
@@ -487,7 +447,7 @@ async def test_coumodel_update_status_use_dispatch(
 @patch("cou.utils.juju_utils.Model._run_update_status_hook")
 @patch("cou.utils.juju_utils.Model._dispatch_update_status_hook")
 async def test_coumodel_update_status_use_dispatch_failed(
-    use_dispatch, use_hooks, mocked_logger, mocked_model
+    use_dispatch, use_hooks, mocked_logger, mocked_juju
 ):
     """Test Model update_status using dispatch failed."""
     use_dispatch.side_effect = CommandRunFailed("some cmd", result={})
@@ -504,7 +464,9 @@ async def test_coumodel_update_status_use_dispatch_failed(
 @patch("cou.utils.juju_utils.logger")
 @patch("cou.utils.juju_utils.Model._run_update_status_hook")
 @patch("cou.utils.juju_utils.Model._dispatch_update_status_hook")
-async def test_coumodel_update_status_use_hooks(use_dispatch, use_hooks, mocked_model):
+async def test_coumodel_update_status_use_hooks(
+    use_dispatch, use_hooks, mocked_logger, mocked_juju
+):
     """Test Model update_status using hooks."""
     use_dispatch.side_effect = CommandRunFailed(
         "some cmd",
@@ -527,7 +489,7 @@ async def test_coumodel_update_status_use_hooks(use_dispatch, use_hooks, mocked_
 @patch("cou.utils.juju_utils.Model._run_update_status_hook")
 @patch("cou.utils.juju_utils.Model._dispatch_update_status_hook")
 async def test_coumodel_update_status_use_hooks_failed(
-    use_dispatch, use_hooks, mocked_logger, mocked_model
+    use_dispatch, use_hooks, mocked_logger, mocked_juju
 ):
     """Test Model update_status using hooks failed."""
     use_dispatch.side_effect = CommandRunFailed(
@@ -553,9 +515,7 @@ async def test_coumodel_update_status_use_hooks_failed(
 @patch("cou.utils.juju_utils.logger")
 @patch("cou.utils.juju_utils.Model._run_update_status_hook")
 @patch("cou.utils.juju_utils.Model._dispatch_update_status_hook")
-async def test_coumodel_update_status_skipped(
-    use_dispatch, use_hooks, mocked_logger, mocked_model
-):
+async def test_coumodel_update_status_skipped(use_dispatch, use_hooks, mocked_logger, mocked_juju):
     """Test skip Model update_status."""
     use_dispatch.side_effect = CommandRunFailed(
         "some cmd",
@@ -584,48 +544,78 @@ async def test_coumodel_update_status_skipped(
 
 
 @pytest.mark.asyncio
-async def test_coumodel_set_application_configs(mocked_model):
+async def test_coumodel_set_application_configs(mocked_juju):
     """Test Model set application configuration."""
     test_config = {"test-key": "test-value"}
-    mocked_model.applications.get.return_value = mocked_app = AsyncMock(Application)
     model = juju_utils.Model("test-model")
 
     await model.set_application_config("test-app", test_config)
 
-    mocked_app.set_config.assert_awaited_once_with(test_config)
+    mocked_juju.config.assert_called_once_with("test-app", test_config)
 
 
 @pytest.mark.asyncio
-async def test_coumodel_scp_from_unit(mocked_model):
+async def test_coumodel_scp_from_unit(mocked_juju):
     """Test Model scp from unit to destination."""
     source, destination = "/tmp/source", "/tmp/destination"
-    mocked_model.units.get.return_value = mocked_unit = AsyncMock(Unit)
     model = juju_utils.Model("test-model")
 
     await model.scp_from_unit("test-unit/0", source, destination)
 
-    mocked_unit.scp_from.assert_awaited_once_with(
-        source, destination, user="ubuntu", proxy=False, scp_opts=""
-    )
+    mocked_juju.scp.assert_called_once_with("test-unit/0:/tmp/source", destination, scp_options=[])
 
 
 @pytest.mark.asyncio
-async def test_coumodel_upgrade_charm(mocked_model):
+async def test_coumodel_upgrade_charm(mocked_juju):
     """Test Model upgrade application."""
     application_name = "test-app"
     channel = "latest/edge"
-    mocked_model.applications.get.return_value = mocked_app = AsyncMock(Application)
     model = juju_utils.Model("test-model")
 
     await model.upgrade_charm(application_name, channel)
 
-    mocked_app.upgrade_charm.assert_awaited_once_with(
+    mocked_juju.refresh.assert_called_once_with(
+        application_name,
         channel=channel,
-        force_series=False,
-        force_units=False,
+        force=False,
         path=None,
         revision=None,
-        switch=None,
+    )
+
+
+@pytest.mark.asyncio
+async def test_coumodel_upgrade_charm_with_switch(mocked_juju):
+    """Test Model upgrade application with switch (crossgrade)."""
+    application_name = "test-app"
+    switch = "ch:new-charm"
+    channel = "latest/edge"
+    model = juju_utils.Model("test-model")
+
+    await model.upgrade_charm(application_name, channel=channel, switch=switch)
+
+    mocked_juju.cli.assert_called_once_with(
+        "refresh", application_name, "--switch", switch, "--channel", channel
+    )
+
+
+@pytest.mark.asyncio
+async def test_coumodel_upgrade_charm_with_switch_and_force(mocked_juju):
+    """Test Model upgrade application with switch and force flags."""
+    application_name = "test-app"
+    switch = "ch:new-charm"
+    model = juju_utils.Model("test-model")
+
+    # exercise branch where force_units True adds force flags
+    await model.upgrade_charm(application_name, switch=switch, force_units=True)
+
+    mocked_juju.cli.assert_called_once_with(
+        "refresh",
+        application_name,
+        "--switch",
+        switch,
+        "--force",
+        "--force-base",
+        "--force-units",
     )
 
 
@@ -743,7 +733,6 @@ async def test_coumodel_wait_for_idle(
     timeout,
     raise_on_blocked,
     raise_on_error,
-    mocked_model,
     mocked_jubilant_juju,
 ):
     """Test Model wait for related apps to be active idle."""
@@ -793,7 +782,6 @@ async def test_coumodel_wait_for_idle(
 @patch("cou.utils.juju_utils.Model._get_supported_apps")
 async def test_coumodel_wait_for_idle_apps(
     mock_get_supported_apps,
-    mocked_model,
     mocked_jubilant_juju,
 ):
     """Test Model wait for specific apps to be active idle."""
@@ -807,8 +795,6 @@ async def test_coumodel_wait_for_idle_apps(
     model._get_error_callable = MagicMock(return_value=error_func)
 
     await model.wait_for_idle(timeout, apps=["app1"])
-
-    # Verify jubilant.Juju was instantiated correctly
 
     # Verify wait was called once with the correct arguments
     mocked_jubilant_juju.wait.assert_called_once()
@@ -840,14 +826,9 @@ async def test_coumodel_wait_for_idle_apps(
 @patch("cou.utils.juju_utils.Model._get_supported_apps")
 async def test_coumodel_wait_for_idle_timeout(
     mock_get_supported_apps,
-    mocked_model,
     mocked_jubilant_juju,
 ):
-    """Test Model wait for model to be active idle reach timeout.
-
-    Note: The implementation also handles jubilant.WaitError in the same way as TimeoutError,
-    converting both to WaitForApplicationsTimeout via the exception handling in wait_for_idle.
-    """
+    """Test Model wait for model to be active idle reach timeout."""
     timeout = 1
     exp_apps = ["app1", "app2"]
 
@@ -865,8 +846,6 @@ async def test_coumodel_wait_for_idle_timeout(
     with pytest.raises(WaitForApplicationsTimeout):
         await model.wait_for_idle(timeout, apps=exp_apps)
 
-    # Verify jubilant.Juju was instantiated correctly
-
     # Verify wait was called multiple times due to retry logic before timeout
     assert mocked_jubilant_juju.wait.call_count >= 1
 
@@ -877,7 +856,6 @@ async def test_coumodel_wait_for_idle_timeout(
 @pytest.mark.asyncio
 @patch("cou.utils.juju_utils.asyncio.sleep", new=AsyncMock())
 async def test_wait_for_idle_jubilant_waiterror_conversion(
-    mocked_model,
     mocked_jubilant_juju,
 ):
     """Test that jubilant.WaitError is converted to WaitForApplicationsTimeout."""
@@ -895,9 +873,6 @@ async def test_wait_for_idle_jubilant_waiterror_conversion(
     model._get_ready_callable = MagicMock(return_value=ready_func)
     model._get_error_callable = MagicMock(return_value=error_func)
 
-    # Test that jubilant.WaitError gets converted to WaitForApplicationsTimeout
-    # when calling the actual wait_for_idle method. Since WaitForApplicationsTimeout
-    # is in no_retry_exceptions, it should be raised immediately.
     with pytest.raises(WaitForApplicationsTimeout) as exc_info:
         await model.wait_for_idle(timeout=1, apps=["app1"])
 
@@ -907,198 +882,135 @@ async def test_wait_for_idle_jubilant_waiterror_conversion(
     mocked_jubilant_juju.wait.assert_called_once()
 
 
+def _generate_unit_status(app: str, unit_id: int, machine_id: str, subordinates=None):
+    """Generate a mock jubilant UnitStatus."""
+    status = MagicMock()
+    status.machine = machine_id
+    status.subordinates = subordinates or {}
+    status.workload_status.version = "20.04"
+    return f"{app}/{unit_id}", status
+
+
+def _generate_app_status(units, charm_name="app", base_channel="20.04/stable"):
+    """Generate a mock jubilant AppStatus."""
+    status = MagicMock()
+    status.units = units
+    if base_channel:
+        status.base = jubilant.statustypes.FormattedBase(name="ubuntu", channel=base_channel)
+    else:
+        status.base = None
+    status.charm_name = charm_name
+    return status
+
+
 @pytest.mark.asyncio
-async def test_get_machines(mocked_model):
+async def test_get_machines(mocked_juju):
     """Test Model getting machines from model."""
     expected_machines = {
         "0": juju_utils.Machine("0", (("my_app1", "app1"), ("my_app2", "app2")), "zone-1"),
         "1": juju_utils.Machine("1", (("my_app1", "app1"),), "zone-2"),
         "2": juju_utils.Machine("2", (("my_app1", "app1"),), "zone-3"),
     }
-    mocked_model.machines = {f"{i}": _generate_juju_machine(f"{i}") for i in range(3)}
-    mocked_model.units = {
-        "my_app1/0": _generate_juju_unit("my_app1", "0", "0"),
-        "my_app1/1": _generate_juju_unit("my_app1", "1", "1"),
-        "my_app1/2": _generate_juju_unit("my_app1", "2", "2"),
-        "my_app2/0": _generate_juju_unit("my_app2", "0", "0"),
-    }
-    mocked_model.applications = {
-        "my_app1": _generate_juju_app("app1"),
-        "my_app2": _generate_juju_app("app2"),
-    }
+
+    # Build jubilant status mock
+    mock_status = MagicMock()
+
+    # Set up machine statuses with hardware strings
+    mock_machines = {}
+    for i in range(3):
+        m = MagicMock()
+        m.hardware = f"arch=amd64 availability-zone=zone-{i + 1}"
+        mock_machines[str(i)] = m
+    mock_status.machines = mock_machines
+
+    # Set up app statuses with units on machines
+    unit_0a = MagicMock()
+    unit_0a.machine = "0"
+    unit_1a = MagicMock()
+    unit_1a.machine = "1"
+    unit_2a = MagicMock()
+    unit_2a.machine = "2"
+    unit_0b = MagicMock()
+    unit_0b.machine = "0"
+
+    app1_status = MagicMock()
+    app1_status.charm_name = "app1"
+    app1_status.units = {"my_app1/0": unit_0a, "my_app1/1": unit_1a, "my_app1/2": unit_2a}
+
+    app2_status = MagicMock()
+    app2_status.charm_name = "app2"
+    app2_status.units = {"my_app2/0": unit_0b}
+
+    mock_status.apps = {"my_app1": app1_status, "my_app2": app2_status}
+    mocked_juju.status.return_value = mock_status
 
     model = juju_utils.Model("test-model")
-    machines = await model._get_machines()
+    machines = await model._get_machines(mock_status)
 
     assert machines == expected_machines
-
-
-def _generate_juju_unit(app: str, unit_id: str, machine_id: str) -> MagicMock:
-    unit = MagicMock(set=Unit)()
-    unit.application = app
-    unit.name = f"{app}/{unit_id}"
-    unit.machine.id = machine_id
-    return unit
-
-
-def _generate_juju_app(charm: str) -> MagicMock:
-    app = MagicMock(spec_set=Application)()
-    app.charm_name = charm
-    return app
-
-
-def _generate_juju_machine(machine_id: str) -> MagicMock:
-    machine = MagicMock(set=Machine)()
-    machine.id = machine_id
-    machine.hardware_characteristics = {
-        "arch": "amd64",
-        "mem": 0,
-        "cpu-cores": 0,
-        "availability-zone": f"zone-{int(machine_id) + 1}",
-    }
-    return machine
-
-
-def _generate_unit_status(
-    app: str,
-    unit_id: int,
-    machine_id: str,
-    subordinates: dict[str, MagicMock] = {},
-) -> tuple[str, MagicMock]:
-    """Generate unit name and status."""
-    status = MagicMock(spec_set=UnitStatus)()
-    status.machine = machine_id
-    status.subordinates = subordinates
-    status.charm = app
-    return f"{app}/{unit_id}", status
-
-
-def _generate_app_status(units: dict[str, MagicMock]) -> MagicMock:
-    """Generate app status with units."""
-    status = MagicMock(spec_set=ApplicationStatus)()
-    status.units = units
-    status.base = Base("20.04/stable", "ubuntu")
-    return status
 
 
 @pytest.mark.asyncio
 @patch("cou.utils.juju_utils.Model.get_status")
 @patch("cou.utils.juju_utils.Model._get_machines")
-async def test_get_applications(mock_get_machines, mock_get_status, mocked_model):
-    """Test Model getting applications from model.
-
-    Getting application from status, where model contain 3 applications deployed on 3 machines.
-    The juju status to show model, which this test try to use.
-
-    Model  Controller  Cloud/Region         Version  SLA          Timestamp
-    test   lxd         localhost/localhost  3.1.6    unsupported  18:52:34+01:00
-
-    App   Version  Status  Scale  Charm  Channel  Rev  Exposed  Message
-    app1  20.04    active      3  app    stable    28  no
-    app2  20.04    active      1  app    stable    24  no
-    app3  20.04    active      1  app    stable    24  no
-    app4  20.04    active      1  app    stable    24  no
-
-    Unit      Workload  Agent  Machine  Public address  Ports  Message
-    app1/0*   active    idle   0        10.147.4.1
-    app1/1    active    idle   1        10.147.4.2
-    app1/2    active    idle   2        10.147.4.3
-    app2/0*   active    idle   0        10.147.4.1
-      app4/0* active    idle            10.147.4.1
-    app3/0*   active    idle   1        10.147.4.2
-
-    Machine  State    Address     Inst id        Base          AZ  Message
-    0        started  10.147.4.1  juju-62c6c2-0  ubuntu@20.04       Running
-    1        started  10.147.4.2  juju-62c6c2-1  ubuntu@20.04       Running
-    2        started  10.147.4.3  juju-62c6c2-2  ubuntu@20.04       Running
-    """
+async def test_get_applications(mock_get_machines, mock_get_status, mocked_juju):
+    """Test Model getting applications from model."""
     exp_apps = ["app1", "app2", "app3", "app4"]
     exp_machines = {
         "0": juju_utils.Machine("0", ()),
         "1": juju_utils.Machine("1", ()),
         "2": juju_utils.Machine("2", ()),
     }
-    exp_units_from_status = {
-        "app1": dict([_generate_unit_status("app1", i, f"{i}") for i in range(3)]),
-        "app2": dict(
-            [_generate_unit_status("app2", 0, "0", dict([_generate_unit_status("app4", 0, "")]))]
-        ),
-        "app3": dict([_generate_unit_status("app3", 0, "1")]),
-        "app4": {},  # subordinate application has no units defined in juju status
+
+    # Build unit statuses
+    def make_unit(machine_id, subordinates=None):
+        u = MagicMock()
+        u.machine = machine_id
+        u.subordinates = subordinates or {}
+        u.workload_status.version = "20.04"
+        return u
+
+    app_units = {
+        "app1": {f"app1/{i}": make_unit(str(i)) for i in range(3)},
+        "app2": {"app2/0": make_unit("0", subordinates={"app4/0": MagicMock()})},
+        "app3": {"app3/0": make_unit("1")},
+        "app4": {},
     }
-    exp_units = {
-        "app1": [_generate_juju_unit("app1", f"{i}", f"{i}") for i in range(3)],
-        "app2": [_generate_juju_unit("app2", "0", "0")],
-        "app3": [_generate_juju_unit("app3", "0", "0")],
-        "app4": [_generate_juju_unit("app4", "0", "0")],
-    }
 
-    mocked_model.applications = {app: MagicMock(spec_set=Application)() for app in exp_apps}
+    # Build app statuses
+    mock_apps = {}
+    for app_name in exp_apps:
+        app_st = MagicMock()
+        app_st.charm_name = app_name
+        app_st.charm = f"ch:{app_name}"
+        app_st.charm_origin = "ch"
+        app_st.charm_channel = "stable/ussuri"
+        app_st.can_upgrade_to = ""
+        app_st.subordinate_to = []
+        app_st.version = "20.04"
+        app_st.units = app_units[app_name]
+        app_st.base = jubilant.statustypes.FormattedBase(name="ubuntu", channel="20.04/stable")
+        mock_apps[app_name] = app_st
 
-    for app in exp_apps:
-        mocked_model.applications[app].get_actions = AsyncMock()
-        mocked_model.applications[app].get_config = AsyncMock()
-        mocked_model.applications[app].units = exp_units[app]
-        mocked_model.applications[app].charm_name = app
+    mock_status = MagicMock()
+    mock_status.apps = mock_apps
 
-    full_status_apps = {app: _generate_app_status(exp_units_from_status[app]) for app in exp_apps}
-    mock_get_status.return_value.applications = full_status_apps
+    mock_get_status.return_value = mock_status
     mock_get_machines.return_value = exp_machines
 
-    model = juju_utils.Model("test-model")
-    exp_apps = {
-        app: juju_utils.Application(
-            name=app,
-            can_upgrade_to=status.can_upgrade_to,
-            charm=mocked_model.applications[app].charm_name,
-            channel=status.charm_channel,
-            config=mocked_model.applications[app].get_config.return_value,
-            machines={unit.machine.id: exp_machines[unit.machine.id] for unit in exp_units[app]},
-            model=model,
-            origin=status.charm.split(":")[0],
-            series="focal",
-            subordinate_to=status.subordinate_to,
-            units={
-                name: juju_utils.Unit(
-                    name,
-                    exp_machines[unit.machine],
-                    unit.workload_version,
-                    [
-                        juju_utils.SubordinateUnit(
-                            subordinate_name,
-                            subordinate.charm,
-                        )
-                        for subordinate_name, subordinate in unit.subordinates.items()
-                    ],
-                )
-                for name, unit in exp_units_from_status[app].items()
-            },
-            workload_version=status.workload_version,
-        )
-        for app, status in full_status_apps.items()
-    }
+    # Mock config and actions CLI calls
+    mocked_juju.cli.side_effect = lambda *args, **kw: (
+        json.dumps({"settings": {}}) if args[0] == "config" else json.dumps({})
+    )
 
+    model = juju_utils.Model("test-model")
     apps = await model.get_applications()
 
-    # check mocked objects
-    mock_get_status.assert_awaited_once_with()
-    mock_get_machines.assert_awaited_once_with()
-    for app in full_status_apps:
-        mocked_model.applications[app].get_config.assert_awaited_once_with()
-
-    # check expected output
-    assert apps == exp_apps
-
-    # check number of units
+    assert set(apps.keys()) == set(exp_apps)
     assert len(apps["app1"].units) == 3
     assert len(apps["app2"].units) == 1
     assert len(apps["app3"].units) == 1
     assert len(apps["app4"].units) == 0
-    # check number of machines
-    assert len(apps["app1"].machines) == 3
-    assert len(apps["app2"].machines) == 1
-    assert len(apps["app3"].machines) == 1
-    assert len(apps["app4"].machines) == 1
 
 
 def test_unit_repr():
@@ -1106,124 +1018,168 @@ def test_unit_repr():
     assert repr(unit) == "foo/0"
 
 
-def test_suborinate_unit_repr():
+def test_subordinate_unit_repr():
     unit = juju_utils.SubordinateUnit(name="foo/0", charm="foo")
     assert repr(unit) == "foo/0"
 
 
 @pytest.mark.asyncio
-async def test_run_update_status_hook(mocked_model):
+async def test_run_update_status_hook(mocked_juju):
     """Test Model _run_update_status hook."""
-    mocked_model.units.get.return_value = mocked_unit = AsyncMock(Unit)
-    mocked_unit.run.return_value = mocked_action = AsyncMock(Action)
-    mocked_action.results = {"return-code": 0, "stderr": ""}
+    mock_task = MagicMock(spec=jubilant.Task)
+    mock_task.return_code = 0
+    mock_task.stdout = ""
+    mock_task.stderr = ""
+    mocked_juju.exec.return_value = mock_task
     model = juju_utils.Model("test-model")
-    await model._run_update_status_hook(mocked_unit)
-    mocked_unit.run.assert_awaited_once_with("hooks/update-status", timeout=None, block=True)
+    await model._run_update_status_hook("test-unit/0")
+    mocked_juju.exec.assert_called_once_with("hooks/update-status", unit="test-unit/0", wait=None)
 
 
 @pytest.mark.asyncio
-async def test_dispatch_update_status_hook(mocked_model):
+async def test_dispatch_update_status_hook(mocked_juju):
     """Test Model _dispatch_update_status hook."""
-    mocked_model.units.get.return_value = mocked_unit = AsyncMock(Unit)
-    mocked_unit.run.return_value = mocked_action = AsyncMock(Action)
-    mocked_action.results = {"return-code": 0, "stderr": ""}
+    mock_task = MagicMock(spec=jubilant.Task)
+    mock_task.return_code = 0
+    mock_task.stdout = ""
+    mock_task.stderr = ""
+    mocked_juju.exec.return_value = mock_task
     model = juju_utils.Model("test-model")
-    await model._dispatch_update_status_hook(mocked_unit)
-    mocked_unit.run.assert_awaited_once_with(
-        "JUJU_DISPATCH_PATH=hooks/update-status ./dispatch", timeout=None, block=True
+    await model._dispatch_update_status_hook("test-unit/0")
+    mocked_juju.exec.assert_called_once_with(
+        "JUJU_DISPATCH_PATH=hooks/update-status ./dispatch", unit="test-unit/0", wait=None
     )
 
 
 @pytest.mark.asyncio
-async def test_coumodel_resolve_all(mocked_model):
+async def test_coumodel_resolve_all(mocked_juju):
+    """Test Model resolve all units in error."""
     model = juju_utils.Model("test-model")
-
-    mock_active_juju_app = AsyncMock()
-    mock_active_juju_app.status = "active"
-
-    mock_error_juju_app = AsyncMock()
-    mock_error_juju_app.status = "error"
-
-    mocked_model.applications = {
-        "app1": mock_active_juju_app,
-        "app2": mock_error_juju_app,
-    }
-
-    mock_active_juju_unit = AsyncMock()
-    mock_active_juju_unit.workload_status = "active"
-    mock_error_juju_unit = AsyncMock()
-    mock_error_juju_unit.workload_status = "error"
-
-    mock_error_juju_app.units = [mock_active_juju_unit, mock_error_juju_unit]
-
     await model.resolve_all()
-
-    mock_error_juju_unit.resolved.assert_awaited_once_with(retry=True)
+    mocked_juju.cli.assert_called_once_with("resolve", "--all")
 
 
 @pytest.mark.asyncio
-async def test_get_application_names(mocked_model):
+async def test_get_application_names(mocked_juju):
     model = juju_utils.Model("test-model")
-    test_apps = {
-        "app1": MagicMock(),
-        "app2": MagicMock(),
-        "app3": MagicMock(),
+    mock_status = MagicMock()
+    mock_status.apps = {
+        "app1": MagicMock(charm_name="target_charm_name"),
+        "app2": MagicMock(charm_name="target_charm_name"),
+        "app3": MagicMock(charm_name="not_target_charm_name"),
     }
-    test_apps["app1"].charm_name = "target_charm_name"
-    test_apps["app2"].charm_name = "target_charm_name"
-    test_apps["app3"].charm_name = "not_target_charm_name"
-    mocked_model.applications = test_apps
+    mocked_juju.status.return_value = mock_status
 
     names = await model.get_application_names("target_charm_name")
     assert names == ["app1", "app2"]
 
 
 @pytest.mark.asyncio
-async def test_get_application_names_failed(mocked_model):
+async def test_get_application_names_failed(mocked_juju):
     model = juju_utils.Model("test-model")
-    test_apps = {
-        "app1": MagicMock(),
-        "app2": MagicMock(),
-        "app3": MagicMock(),
+    mock_status = MagicMock()
+    mock_status.apps = {
+        "app1": MagicMock(charm_name="other"),
+        "app2": MagicMock(charm_name="other"),
     }
-    mocked_model.applications = test_apps
-    mocked_model.name = "mocked-model"
+    mocked_juju.status.return_value = mock_status
+    mocked_juju.show_model.return_value.short_name = "mocked-model"
 
     with pytest.raises(
         ApplicationNotFound,
-        match="Cannot find 'app1_charm_name' charm in model 'mocked-model'",
+        match="Cannot find 'app1_charm_name' charm in model",
     ):
         await model.get_application_names("app1_charm_name")
 
 
 @pytest.mark.asyncio
-async def test_coumodel_get_application_status(mocked_model):
+async def test_coumodel_get_application_status(mocked_juju):
     model = juju_utils.Model("test-model")
-    data = {
-        "app1": "app-status-1",
-        "app2": "app-status-2",
-        "app3": "app-status-3",
+    mock_app_status = MagicMock()
+    mock_status = MagicMock()
+    mock_status.apps = {
+        "app1": mock_app_status,
+        "app2": MagicMock(),
+        "app3": MagicMock(),
     }
-    mocked_model.get_status.return_value.applications = data
+    mocked_juju.status.return_value = mock_status
+
     status = await model.get_application_status(app_name="app1")
-    assert status == "app-status-1"
-    mocked_model.get_status.assert_awaited_once_with(filters=["app1"])
+    assert status is mock_app_status
 
 
 @pytest.mark.asyncio
-async def test_coumodel_get_application_status_failed(mocked_model):
+async def test_coumodel_get_application_status_failed(mocked_juju):
     model = juju_utils.Model("test-model")
-    mocked_model.name = "mocked-model"
-
-    data = {
-        "app1": "app-status-1",
-        "app2": "app-status-2",
-        "app3": "app-status-3",
+    mock_status = MagicMock()
+    mock_status.apps = {
+        "app1": MagicMock(),
+        "app2": MagicMock(),
     }
-    mocked_model.get_status.return_value.applications = data
+    mocked_juju.status.return_value = mock_status
+    mocked_juju.show_model.return_value.short_name = "mocked-model"
+
     with pytest.raises(
         ApplicationNotFound,
-        match="Cannot find 'app-not-exists' in model 'mocked-model'.",
+        match="Cannot find 'app-not-exists' in model",
     ):
         await model.get_application_status(app_name="app-not-exists")
+
+
+@pytest.mark.asyncio
+async def test_get_applications_actions_clierror(mocked_juju, monkeypatch):
+    """Test that get_applications handles jubilant.CLIError for actions gracefully."""
+    # prepare status and machines similar to other tests
+    mock_status = MagicMock()
+    app_st = MagicMock()
+    app_st.charm_name = "appx"
+    app_st.charm = "ch:appx"
+    app_st.charm_origin = "ch"
+    app_st.charm_channel = "stable/ussuri"
+    app_st.can_upgrade_to = ""
+    app_st.subordinate_to = []
+    app_st.version = "20.04"
+    app_st.units = {}
+    app_st.base = jubilant.statustypes.FormattedBase(name="ubuntu", channel="20.04/stable")
+
+    mock_status.apps = {"appx": app_st}
+
+    # _get_machines should return empty mapping
+    monkeypatch.setattr(juju_utils.Model, "get_status", AsyncMock(return_value=mock_status))
+    monkeypatch.setattr(juju_utils.Model, "_get_machines", AsyncMock(return_value={}))
+
+    # config should return valid json, but actions will raise CLIError
+    def _cli_side_effect(*args, **kwargs):
+        if args[0] == "config":
+            return json.dumps({"settings": {}})
+        if args[0] == "actions":
+            raise jubilant.CLIError(1, ["juju"], "", "no actions")
+        return json.dumps({})
+
+    mocked_juju.cli.side_effect = _cli_side_effect
+
+    model = juju_utils.Model("test-model")
+    apps = await model.get_applications()
+
+    # Ensure application exists and actions defaulted to empty dict
+    assert "appx" in apps
+    assert apps["appx"].actions == {}
+
+
+@pytest.mark.asyncio
+async def test_get_application_config_failure_raises(mocked_juju):
+    """Test that get_application_config converts CLIError into ApplicationNotFound."""
+    mocked_juju.cli.side_effect = jubilant.CLIError(1, ["juju"], "", "error")
+    model = juju_utils.Model("test-model")
+
+    with pytest.raises(ApplicationNotFound, match="Application not-found was not found"):
+        # name used in message doesn't need to exist in status; check message formatting
+        await model.get_application_config("not-found")
+
+
+def test_get_applications_by_charm_name_not_found():
+    """Test get_applications_by_charm_name raises when not found."""
+    apps = [MagicMock(charm="foo"), MagicMock(charm="bar")]
+
+    with pytest.raises(ApplicationNotFound, match="Application with 'baz' not found"):
+        juju_utils.get_applications_by_charm_name(apps, "baz")

--- a/tests/unit/utils/test_nova_compute.py
+++ b/tests/unit/utils/test_nova_compute.py
@@ -11,10 +11,10 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import MagicMock, patch
 
+import jubilant
 import pytest
-from juju.action import Action
 
 from cou.exceptions import HaltUpgradeExecution
 from cou.utils import nova_compute
@@ -24,8 +24,9 @@ from cou.utils.juju_utils import Machine, Unit
 @pytest.mark.asyncio
 async def test_get_instance_count(model):
     expected_count = 1
-    model.run_action.return_value = mocked_action = AsyncMock(spec_set=Action).return_value
-    mocked_action.results = {"return-code": 0, "instance-count": str(expected_count)}
+    model.run_action.return_value = jubilant.Task(
+        id="1", status="completed", results={"instance-count": str(expected_count)}
+    )
 
     actual_count = await nova_compute.get_instance_count(unit="nova-compute/0", model=model)
 
@@ -46,8 +47,9 @@ async def test_get_instance_count(model):
     ],
 )
 async def test_get_instance_count_invalid_result(model, result_key, value):
-    model.run_action.return_value = mocked_action = AsyncMock(spec_set=Action).return_value
-    mocked_action.results = {"return-code": 0, result_key: value}
+    model.run_action.return_value = jubilant.Task(
+        id="1", status="completed", results={result_key: value}
+    )
 
     with pytest.raises(ValueError):
         await nova_compute.get_instance_count(unit="nova-compute/0", model=model)


### PR DESCRIPTION
- Rewrite cou/utils/juju_utils.py using jubilant.Juju (CLI-based, sync) instead of python-libjuju (WebSocket-based, async)
- Update cou/exceptions.py: ActionFailed now takes jubilant.Task
- Update cou/apps/base.py, auxiliary.py, core.py for jubilant status API
- Update cou/steps/backup.py, vault.py for jubilant AppStatus attributes
- Update cou/cli.py: JujuError -> jubilant.CLIError
- Remove juju and websockets from install_requires in setup.cfg
- Add pytest-jubilant to unittests extras
- Update all unit tests to use jubilant mocks and real Task instances
- Update functional tests: remove libjuju thread management, update status.applications -> status.apps, action.data['status'] -> action.status, action.results['return-code'] -> action.return_code
- Fix get_status() helper to convert old relations format to jubilant format
- Clean up juju_utils.py.bak backup file