### PR TITLE
Add cinder-back support in COU

### DIFF
--- a/cou/utils/openstack.py
+++ b/cou/utils/openstack.py
@@ -86,6 +86,7 @@ UPGRADE_ORDER = NON_UCA_UPGRADE_ORDER + UCA_UPGRADE_ORDER + DATA_PLANE_CHARMS
 SUBORDINATES = [
     "barbican-vault",
     "ceilometer-agent",
+    "cinder-backup",
     "cinder-backup-swift-proxy",
     "cinder-ceph",
     "cinder-lvm",


### PR DESCRIPTION
cinder-backup is a subordinate charm that was missing in COU

Closes: #676