### PR TITLE
feat: add APT source verification during plan phase

### DIFF
--- a/cou/steps/apt_sources.py
+++ b/cou/steps/apt_sources.py
@@ -17,6 +17,7 @@ import os
 import re
 from urllib.parse import urlparse
 
+from cou.exceptions import CommandRunFailed
 from cou.utils.juju_utils import Model
 
 logger = logging.getLogger(__name__)
@@ -115,20 +116,23 @@ def verify_apt_sources(model: Model) -> dict[str, set[str]]:
     """
     results = model.run_on_all_machines(APT_CACHE_POLICY_CMD, 30)
 
-    if not results:
-        logger.warning("No results from running '%s' on machines.", APT_CACHE_POLICY_CMD)
-        return {}
-
     unexpected_by_machine: dict[str, set[str]] = {}
     for machine_id, task in results.items():
         if not task.success:
-            logger.warning(
+            logger.error(
                 "Failed to run '%s' on machine %s: %s",
                 APT_CACHE_POLICY_CMD,
                 machine_id,
                 task.stderr or task.message,
             )
-            continue
+            raise CommandRunFailed(
+                cmd=APT_CACHE_POLICY_CMD,
+                result={
+                    "return-code": task.return_code,
+                    "stdout": task.stdout,
+                    "stderr": task.stderr,
+                },
+            )
 
         uris = parse_apt_policy_uris(task.stdout)
         unexpected = find_unexpected_uris(uris)

--- a/cou/steps/apt_sources.py
+++ b/cou/steps/apt_sources.py
@@ -15,9 +15,9 @@
 import logging
 import os
 import re
+from dataclasses import dataclass, field
 from urllib.parse import urlparse
 
-from cou.exceptions import CommandRunFailed
 from cou.utils.juju_utils import Model
 
 logger = logging.getLogger(__name__)
@@ -102,37 +102,49 @@ def find_unexpected_uris(uris: set[str]) -> set[str]:
     return unexpected
 
 
-def verify_apt_sources(model: Model) -> dict[str, set[str]]:
+@dataclass
+class AptSourcesVerification:
+    """Result of verifying APT sources across all machines.
+
+    :param failed: Mapping of machine ID to error message for machines where
+        apt-cache policy could not be run.
+    :param unexpected: Mapping of machine ID to set of unexpected URIs for
+        machines that have non-standard APT sources.
+    """
+
+    failed: dict[str, str] = field(default_factory=dict)
+    unexpected: dict[str, set[str]] = field(default_factory=dict)
+
+
+def verify_apt_sources(model: Model) -> AptSourcesVerification:
     """Verify APT sources on all machines in the model.
 
     Runs `apt-cache policy` on all machines using juju exec --all,
     parses the output, and identifies any unexpected repository sources.
+    Machines that fail to return results are recorded but do not abort
+    the check on remaining machines.
 
     :param model: Juju model to check.
     :type model: Model
-    :return: Dictionary mapping machine identifiers to sets of unexpected URIs.
-        Only machines with unexpected sources are included.
-    :rtype: dict[str, set[str]]
+    :return: Verification result containing failed machines and machines with
+        unexpected sources.
+    :rtype: AptSourcesVerification
     """
     results = model.run_on_all_machines(APT_CACHE_POLICY_CMD, 30)
 
+    failed: dict[str, str] = {}
     unexpected_by_machine: dict[str, set[str]] = {}
     for machine_id, task in results.items():
         if not task.success:
+            error = task.stderr or task.message
             logger.error(
                 "Failed to run '%s' on machine %s: %s",
                 APT_CACHE_POLICY_CMD,
                 machine_id,
-                task.stderr or task.message,
+                error,
             )
-            raise CommandRunFailed(
-                cmd=APT_CACHE_POLICY_CMD,
-                result={
-                    "return-code": task.return_code,
-                    "stdout": task.stdout,
-                    "stderr": task.stderr,
-                },
-            )
+            failed[machine_id] = error
+            continue
 
         uris = parse_apt_policy_uris(task.stdout)
         unexpected = find_unexpected_uris(uris)
@@ -144,4 +156,4 @@ def verify_apt_sources(model: Model) -> dict[str, set[str]]:
             )
             unexpected_by_machine[machine_id] = unexpected
 
-    return unexpected_by_machine
+    return AptSourcesVerification(failed=failed, unexpected=unexpected_by_machine)

--- a/cou/steps/apt_sources.py
+++ b/cou/steps/apt_sources.py
@@ -1,0 +1,143 @@
+# Copyright 2025 Canonical Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Functions for verifying APT sources on machines before an upgrade."""
+import logging
+import os
+import re
+from urllib.parse import urlparse
+
+from cou.utils.juju_utils import Model
+
+logger = logging.getLogger(__name__)
+
+# Hostnames that are considered safe/expected for OpenStack upgrades.
+# This covers standard Ubuntu archives, Ubuntu Cloud Archive (UCA),
+# and Ubuntu ports (for non-amd64 architectures).
+ALLOWED_HOST_PATTERNS: list[re.Pattern] = [
+    re.compile(r"^([a-z]{2}\.)?archive\.ubuntu\.com$"),
+    re.compile(r"^security\.ubuntu\.com$"),
+    re.compile(r"^ubuntu-cloud\.archive\.canonical\.com$"),
+    re.compile(r"^cloud-archive\.canonical\.com$"),
+    re.compile(r"^ports\.ubuntu\.com$"),
+    re.compile(r"^esm\.ubuntu\.com$"),
+]
+
+APT_CACHE_POLICY_CMD = "apt-cache policy"
+
+
+def _get_allowed_host_patterns() -> list[re.Pattern]:
+    """Build list of allowed host patterns including landscape mirror if configured.
+
+    :return: List of compiled regex patterns for allowed APT source hosts.
+    :rtype: list[re.Pattern]
+    """
+    patterns = list(ALLOWED_HOST_PATTERNS)
+    landscape_uri = os.environ.get("LANDSCAPE_MIRROR_URI", "")
+    if landscape_uri:
+        try:
+            parsed = urlparse(landscape_uri)
+            if parsed.hostname:
+                escaped = re.escape(parsed.hostname)
+                patterns.append(re.compile(f"^{escaped}$"))
+        except ValueError:
+            logger.warning("Invalid LANDSCAPE_MIRROR_URI: %s", landscape_uri)
+    return patterns
+
+
+def parse_apt_policy_uris(apt_cache_output: str) -> set[str]:
+    """Parse apt-cache policy output and extract unique repository URIs.
+
+    Lines in apt-cache policy output that describe repository sources look like:
+      500 http://archive.ubuntu.com/ubuntu jammy/main amd64 Packages
+      100 /var/lib/dpkg/status
+
+    We extract the URIs (http/https) from these lines.
+
+    :param apt_cache_output: Raw output from `apt-cache policy`.
+    :type apt_cache_output: str
+    :return: Set of unique repository URIs found.
+    :rtype: set[str]
+    """
+    uris: set[str] = set()
+    for line in apt_cache_output.splitlines():
+        match = re.match(r"^\s*\d+\s+(https?://\S+)", line)
+        if match:
+            uris.add(match.group(1))
+    return uris
+
+
+def find_unexpected_uris(uris: set[str]) -> set[str]:
+    """Check URIs against the allowlist and return any that don't match.
+
+    :param uris: Set of repository URIs to check.
+    :type uris: set[str]
+    :return: Set of URIs that are not in the allowlist.
+    :rtype: set[str]
+    """
+    allowed_patterns = _get_allowed_host_patterns()
+    unexpected: set[str] = set()
+    for uri in uris:
+        try:
+            parsed = urlparse(uri)
+            hostname = parsed.hostname or ""
+        except ValueError:
+            unexpected.add(uri)
+            continue
+
+        if not any(pattern.search(hostname) for pattern in allowed_patterns):
+            unexpected.add(uri)
+
+    return unexpected
+
+
+def verify_apt_sources(model: Model) -> dict[str, set[str]]:
+    """Verify APT sources on all machines in the model.
+
+    Runs `apt-cache policy` on all machines using juju exec --all,
+    parses the output, and identifies any unexpected repository sources.
+
+    :param model: Juju model to check.
+    :type model: Model
+    :return: Dictionary mapping machine identifiers to sets of unexpected URIs.
+        Only machines with unexpected sources are included.
+    :rtype: dict[str, set[str]]
+    """
+    results = model.run_on_all_machines(APT_CACHE_POLICY_CMD, 30)
+
+    if not results:
+        logger.warning("No results from running '%s' on machines.", APT_CACHE_POLICY_CMD)
+        return {}
+
+    unexpected_by_machine: dict[str, set[str]] = {}
+    for machine_id, task in results.items():
+        if not task.success:
+            logger.warning(
+                "Failed to run '%s' on machine %s: %s",
+                APT_CACHE_POLICY_CMD,
+                machine_id,
+                task.stderr or task.message,
+            )
+            continue
+
+        uris = parse_apt_policy_uris(task.stdout)
+        unexpected = find_unexpected_uris(uris)
+        if unexpected:
+            logger.info(
+                "Machine %s has unexpected APT sources: %s",
+                machine_id,
+                ", ".join(sorted(unexpected)),
+            )
+            unexpected_by_machine[machine_id] = unexpected
+
+    return unexpected_by_machine

--- a/cou/steps/plan.py
+++ b/cou/steps/plan.py
@@ -52,6 +52,7 @@ from cou.exceptions import (
 )
 from cou.steps import PostUpgradeStep, PreUpgradeStep, UpgradePlan, ceph
 from cou.steps.analyze import Analysis
+from cou.steps.apt_sources import verify_apt_sources
 from cou.steps.backup import backup
 from cou.steps.hypervisor import HypervisorUpgradePlanner
 from cou.steps.nova_cloud_controller import archive, purge
@@ -108,6 +109,7 @@ async def verify_cloud(analysis_result: Analysis, args: CLIargs) -> None:
     :param args: CLI arguments
     :type args: CLIargs
     """
+    _verify_apt_sources(args, analysis_result)
     _verify_supported_series(analysis_result)
     _verify_highest_release_achieved(analysis_result)
     _verify_data_plane_ready_to_upgrade(args, analysis_result)
@@ -405,6 +407,52 @@ async def _verify_model_idle(analysis_result: Analysis) -> None:
         )
     except Exception as e:  # pylint: disable=broad-exception-caught
         PlanStatus.add_message(f"Model is not idle: {str(e)}", MessageType.ERROR)
+
+
+def _verify_apt_sources(args: CLIargs, analysis_result: Analysis) -> None:
+    """Verify APT sources on all machines are expected.
+
+    Check that all machines in the model only have expected APT sources configured
+    (standard Ubuntu archives, Ubuntu Cloud Archive, or Landscape mirrors).
+    If unexpected sources are found and --force is not set, an error message
+    will be added to `PlanStatus`. If --force is set, a warning message will be added instead.
+
+    :param args: CLI arguments
+    :type args: CLIargs
+    :param analysis_result: Analysis result
+    :type analysis_result: Analysis
+    """
+    try:
+        unexpected_by_machine = verify_apt_sources(analysis_result.model)
+    except Exception as e:  # pylint: disable=broad-exception-caught
+        logger.warning("Failed to verify APT sources: %s", e)
+        PlanStatus.add_message(
+            f"Failed to verify APT sources on machines: {e}",
+            MessageType.ERROR,
+        )
+        return
+
+    if not unexpected_by_machine:
+        logger.info("APT sources found are as expected.")
+        return
+
+    details = "\n".join(
+        f"  - Machine {machine_id}: {', '.join(sorted(uris))}"
+        for machine_id, uris in sorted(unexpected_by_machine.items())
+    )
+    message = (
+        "Unexpected APT sources found on machines. This may cause issues during the upgrade. "
+        "Only standard Ubuntu, Ubuntu Cloud Archive, and Landscape sources are expected.\n"
+        f"{details}"
+    )
+
+    if args.force:
+        PlanStatus.add_message(message, MessageType.WARNING)
+    else:
+        PlanStatus.add_message(
+            f"{message}\nUse --force to override this check.",
+            MessageType.ERROR,
+        )
 
 
 def _is_control_plane_upgraded(analysis_result: Analysis) -> bool:

--- a/cou/steps/plan.py
+++ b/cou/steps/plan.py
@@ -409,6 +409,25 @@ async def _verify_model_idle(analysis_result: Analysis) -> None:
         PlanStatus.add_message(f"Model is not idle: {str(e)}", MessageType.ERROR)
 
 
+def _report_verification_result(message: str, force: bool) -> None:
+    """Report verification failure, adding the appropriate message to PlanStatus.
+
+    If --force is set the message is logged as a warning, otherwise it is logged
+    as an error with a hint about using --force to override.
+
+    :param message: Message to report
+    :type message: str
+    :param force: If True, add as WARNING; if False, add as ERROR
+    :type force: bool
+    """
+    if force:
+        PlanStatus.add_message(message, MessageType.WARNING)
+    else:
+        PlanStatus.add_message(
+            f"{message}\nUse --force to override this check.", MessageType.ERROR
+        )
+
+
 def _verify_apt_sources(args: CLIargs, analysis_result: Analysis) -> None:
     """Verify APT sources on all machines are expected.
 
@@ -425,15 +444,15 @@ def _verify_apt_sources(args: CLIargs, analysis_result: Analysis) -> None:
     try:
         unexpected_by_machine = verify_apt_sources(analysis_result.model)
     except Exception as e:  # pylint: disable=broad-exception-caught
-        logger.warning("Failed to verify APT sources: %s", e)
-        PlanStatus.add_message(
-            f"Failed to verify APT sources on machines: {e}",
-            MessageType.ERROR,
-        )
+        message = f"Failed to verify APT sources on machines: {str(e)}"
+        logger.error(message)
+        _report_verification_result(message, args.force)
         return
 
     if not unexpected_by_machine:
-        logger.info("APT sources found are as expected.")
+        logger.info(
+            "Successfully verified APT sources on all machines, no unexpected sources found."
+        )
         return
 
     details = "\n".join(
@@ -445,14 +464,7 @@ def _verify_apt_sources(args: CLIargs, analysis_result: Analysis) -> None:
         "Only standard Ubuntu, Ubuntu Cloud Archive, and Landscape sources are expected.\n"
         f"{details}"
     )
-
-    if args.force:
-        PlanStatus.add_message(message, MessageType.WARNING)
-    else:
-        PlanStatus.add_message(
-            f"{message}\nUse --force to override this check.",
-            MessageType.ERROR,
-        )
+    _report_verification_result(message, args.force)
 
 
 def _is_control_plane_upgraded(analysis_result: Analysis) -> bool:

--- a/cou/steps/plan.py
+++ b/cou/steps/plan.py
@@ -433,8 +433,10 @@ def _verify_apt_sources(args: CLIargs, analysis_result: Analysis) -> None:
 
     Check that all machines in the model only have expected APT sources configured
     (standard Ubuntu archives, Ubuntu Cloud Archive, or Landscape mirrors).
-    If unexpected sources are found and --force is not set, an error message
-    will be added to `PlanStatus`. If --force is set, a warning message will be added instead.
+    Machines where apt-cache policy could not be run are reported, and the user
+    is advised to check them manually. If unexpected sources or failures are found
+    and --force is not set, an error message will be added to `PlanStatus`. If
+    --force is set, a warning message will be added instead.
 
     :param args: CLI arguments
     :type args: CLIargs
@@ -442,28 +444,45 @@ def _verify_apt_sources(args: CLIargs, analysis_result: Analysis) -> None:
     :type analysis_result: Analysis
     """
     try:
-        unexpected_by_machine = verify_apt_sources(analysis_result.model)
+        result = verify_apt_sources(analysis_result.model)
     except Exception as e:  # pylint: disable=broad-exception-caught
-        message = f"Failed to verify APT sources on machines: {str(e)}"
+        message = f"Failed to verify APT sources: {str(e)}"
         logger.error(message)
         _report_verification_result(message, args.force)
         return
 
-    if not unexpected_by_machine:
+    sections: list[str] = []
+
+    if result.failed:
+        failed_details = "\n".join(
+            f"  - Machine {machine_id}: {error}"
+            for machine_id, error in sorted(result.failed.items())
+        )
+        sections.append(
+            "Failed to get apt-cache policy on the following machines. "
+            "It is advised to manually check apt-cache policy on these machines "
+            "before proceeding:\n"
+            f"{failed_details}"
+        )
+
+    if result.unexpected:
+        unexpected_details = "\n".join(
+            f"  - Machine {machine_id}: {', '.join(sorted(uris))}"
+            for machine_id, uris in sorted(result.unexpected.items())
+        )
+        sections.append(
+            "Unexpected APT sources found on machines. This may cause issues during the upgrade. "
+            "Only standard Ubuntu, Ubuntu Cloud Archive, and Landscape sources are expected.\n"
+            f"{unexpected_details}"
+        )
+
+    if not sections:
         logger.info(
             "Successfully verified APT sources on all machines, no unexpected sources found."
         )
         return
 
-    details = "\n".join(
-        f"  - Machine {machine_id}: {', '.join(sorted(uris))}"
-        for machine_id, uris in sorted(unexpected_by_machine.items())
-    )
-    message = (
-        "Unexpected APT sources found on machines. This may cause issues during the upgrade. "
-        "Only standard Ubuntu, Ubuntu Cloud Archive, and Landscape sources are expected.\n"
-        f"{details}"
-    )
+    message = "\n".join(sections)
     _report_verification_result(message, args.force)
 
 

--- a/cou/utils/juju_utils.py
+++ b/cou/utils/juju_utils.py
@@ -17,6 +17,7 @@
 from __future__ import annotations
 
 import asyncio
+import json
 import logging
 import os
 from dataclasses import dataclass, field
@@ -649,6 +650,38 @@ class Model(JubilantModelMixin):
             raise CommandRunFailed(cmd=command, result=results)
 
         return results
+
+    def run_on_all_machines(
+        self, command: str, timeout: Optional[int] = None
+    ) -> dict[str, jubilant.Task]:
+        """Run a command on all machines in the model using juju exec --all.
+
+        :param command: Command to execute on all machines
+        :type command: str
+        :param timeout: How long in seconds to wait for command to complete
+        :type timeout: Optional[int]
+        :returns: Dictionary mapping machine identifiers to jubilant Task results
+        :rtype: dict[str, jubilant.Task]
+        """
+        logger.debug("Running '%s' on all machines", command)
+        _juju = jubilant.Juju(model=self._juju_data.current_model())
+
+        cli_args = ["exec", "--format", "json", "--all"]
+        if timeout is not None:
+            cli_args.extend(["--wait", f"{timeout}s"])
+        cli_args.extend(["--", command])
+
+        try:
+            stdout = _juju.cli(*cli_args)
+        except jubilant.CLIError as exc:
+            logger.warning("Failed to run '%s' on all machines: %s", command, exc)
+            return {}
+
+        results: dict[str, Any] = json.loads(stdout) if stdout.strip() else {}
+        return {
+            machine_id: jubilant.Task._from_dict(task_dict)
+            for machine_id, task_dict in results.items()
+        }
 
     @retry(no_retry_exceptions=(ApplicationNotFound,))
     async def set_application_config(self, name: str, configuration: dict[str, str]) -> None:

--- a/cou/utils/juju_utils.py
+++ b/cou/utils/juju_utils.py
@@ -674,8 +674,11 @@ class Model(JubilantModelMixin):
         try:
             stdout = _juju.cli(*cli_args)
         except jubilant.CLIError as exc:
-            logger.warning("Failed to run '%s' on all machines: %s", command, exc)
-            return {}
+            logger.error("Failed to run '%s' on all machines: %s", command, exc)
+            raise CommandRunFailed(
+                cmd=command,
+                result={"return-code": exc.returncode, "stdout": exc.stdout, "stderr": exc.stderr},
+            ) from exc
 
         results: dict[str, Any] = json.loads(stdout) if stdout.strip() else {}
         return {

--- a/cou/utils/juju_utils.py
+++ b/cou/utils/juju_utils.py
@@ -674,11 +674,22 @@ class Model(JubilantModelMixin):
         try:
             stdout = _juju.cli(*cli_args)
         except jubilant.CLIError as exc:
-            logger.error("Failed to run '%s' on all machines: %s", command, exc)
-            raise CommandRunFailed(
-                cmd=command,
-                result={"return-code": exc.returncode, "stdout": exc.stdout, "stderr": exc.stderr},
-            ) from exc
+            # juju exec exits non-zero when any individual machine task fails,
+            # but stdout still contains the full JSON with per-machine results.
+            # Parse it so callers can handle individual machine failures gracefully.
+            # Only raise if stdout is empty, which indicates juju itself failed
+            # (e.g. network error, model not found) rather than a per-task failure.
+            if not exc.stdout or not exc.stdout.strip():
+                logger.error("Failed to run '%s' on all machines: %s", command, exc)
+                raise CommandRunFailed(
+                    cmd=command,
+                    result={
+                        "return-code": exc.returncode,
+                        "stdout": exc.stdout,
+                        "stderr": exc.stderr,
+                    },
+                ) from exc
+            stdout = exc.stdout
 
         results: dict[str, Any] = json.loads(stdout) if stdout.strip() else {}
         return {

--- a/tests/unit/steps/test_apt_sources.py
+++ b/tests/unit/steps/test_apt_sources.py
@@ -13,8 +13,6 @@
 # limitations under the License.
 from unittest.mock import MagicMock, patch
 
-import pytest
-
 from cou.steps.apt_sources import (
     _get_allowed_host_patterns,
     find_unexpected_uris,
@@ -353,7 +351,8 @@ class TestVerifyAptSources:
             "1": self._make_task(stdout=APT_POLICY_CLEAN),
         }
         result = verify_apt_sources(model)
-        assert result == {}
+        assert result.unexpected == {}
+        assert result.failed == {}
 
     def test_machine_with_ppa(self):
         """Test that a machine with PPA is flagged."""
@@ -363,9 +362,9 @@ class TestVerifyAptSources:
             "1": self._make_task(stdout=APT_POLICY_WITH_PPA),
         }
         result = verify_apt_sources(model)
-        assert "1" in result
-        assert "http://ppa.launchpad.net/some-user/some-ppa/ubuntu" in result["1"]
-        assert "0" not in result
+        assert "1" in result.unexpected
+        assert "http://ppa.launchpad.net/some-user/some-ppa/ubuntu" in result.unexpected["1"]
+        assert "0" not in result.unexpected
 
     def test_machine_with_third_party(self):
         """Test that a machine with third-party repo is flagged."""
@@ -374,29 +373,26 @@ class TestVerifyAptSources:
             "0": self._make_task(stdout=APT_POLICY_WITH_THIRD_PARTY),
         }
         result = verify_apt_sources(model)
-        assert "0" in result
-        assert "https://packages.example.com/stable" in result["0"]
+        assert "0" in result.unexpected
+        assert "https://packages.example.com/stable" in result.unexpected["0"]
 
     def test_machine_failure_handled(self):
-        """Test that machine command failures raise CommandRunFailed."""
-        from cou.exceptions import CommandRunFailed
-
+        """Test that machine command failures are collected without aborting other machines."""
         model = MagicMock()
         model.run_on_all_machines.return_value = {
             "0": self._make_task(stdout=APT_POLICY_CLEAN),
             "1": self._make_task(
                 stdout="", stderr="connection refused", return_code=1, status="failed"
             ),
+            "2": self._make_task(stdout=APT_POLICY_WITH_PPA),
+            "3": self._make_task(stdout="", stderr="timeout", return_code=1, status="failed"),
         }
-        with pytest.raises(CommandRunFailed):
-            verify_apt_sources(model)
-
-    def test_no_results(self):
-        """Test handling when no results are returned."""
-        model = MagicMock()
-        model.run_on_all_machines.return_value = {}
         result = verify_apt_sources(model)
-        assert result == {}
+        assert result.failed == {"1": "connection refused", "3": "timeout"}
+        assert "2" in result.unexpected
+        assert "0" not in result.unexpected
+        assert "1" not in result.unexpected
+        assert "3" not in result.unexpected
 
     def test_country_mirror_clean(self):
         """Test that country mirrors are accepted."""
@@ -405,7 +401,7 @@ class TestVerifyAptSources:
             "0": self._make_task(stdout=APT_POLICY_WITH_COUNTRY_MIRROR),
         }
         result = verify_apt_sources(model)
-        assert result == {}
+        assert result.unexpected == {}
 
     def test_ports_clean(self):
         """Test that ports.ubuntu.com sources are accepted."""
@@ -414,7 +410,7 @@ class TestVerifyAptSources:
             "0": self._make_task(stdout=APT_POLICY_PORTS),
         }
         result = verify_apt_sources(model)
-        assert result == {}
+        assert result.unexpected == {}
 
     def test_esm_clean(self):
         """Test that esm.ubuntu.com sources are accepted."""
@@ -423,7 +419,7 @@ class TestVerifyAptSources:
             "0": self._make_task(stdout=APT_POLICY_ESM),
         }
         result = verify_apt_sources(model)
-        assert result == {}
+        assert result.unexpected == {}
 
     def test_cloud_archive_ppa_flagged(self):
         """Test that ubuntu-cloud-archive PPA is flagged by verify_apt_sources."""
@@ -432,9 +428,10 @@ class TestVerifyAptSources:
             "0": self._make_task(stdout=APT_POLICY_CLOUD_ARCHIVE_PPA),
         }
         result = verify_apt_sources(model)
-        assert "0" in result
+        assert "0" in result.unexpected
         assert (
-            "http://ppa.launchpadcontent.net/ubuntu-cloud-archive/antelope/ubuntu" in result["0"]
+            "http://ppa.launchpadcontent.net/ubuntu-cloud-archive/antelope/ubuntu"
+            in result.unexpected["0"]
         )
 
     @patch.dict("os.environ", {"LANDSCAPE_MIRROR_URI": "http://landscape.example.com/repository"})
@@ -445,7 +442,7 @@ class TestVerifyAptSources:
             "0": self._make_task(stdout=APT_POLICY_LANDSCAPE),
         }
         result = verify_apt_sources(model)
-        assert result == {}
+        assert result.unexpected == {}
 
     def test_landscape_mirror_unexpected_without_env(self):
         """Test that landscape mirror sources are flagged when env var is not set."""
@@ -454,8 +451,11 @@ class TestVerifyAptSources:
             "0": self._make_task(stdout=APT_POLICY_LANDSCAPE_MIRROR),
         }
         result = verify_apt_sources(model)
-        assert "0" in result
-        assert "https://repo.mirror.example.com/repository/standalone/ubuntu" in result["0"]
+        assert "0" in result.unexpected
+        assert (
+            "https://repo.mirror.example.com/repository/standalone/ubuntu"
+            in result.unexpected["0"]
+        )
 
     @patch.dict(
         "os.environ",
@@ -468,7 +468,7 @@ class TestVerifyAptSources:
             "0": self._make_task(stdout=APT_POLICY_LANDSCAPE_MIRROR),
         }
         result = verify_apt_sources(model)
-        assert result == {}
+        assert result.unexpected == {}
 
     def test_multiple_machines_mixed(self):
         """Test with multiple machines, some clean and some with issues."""
@@ -480,8 +480,8 @@ class TestVerifyAptSources:
             "3": self._make_task(stdout=APT_POLICY_CLEAN),
         }
         result = verify_apt_sources(model)
-        assert len(result) == 2
-        assert "1" in result
-        assert "2" in result
-        assert "0" not in result
-        assert "3" not in result
+        assert len(result.unexpected) == 2
+        assert "1" in result.unexpected
+        assert "2" in result.unexpected
+        assert "0" not in result.unexpected
+        assert "3" not in result.unexpected

--- a/tests/unit/steps/test_apt_sources.py
+++ b/tests/unit/steps/test_apt_sources.py
@@ -1,0 +1,483 @@
+# Copyright 2025 Canonical Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from unittest.mock import MagicMock, patch
+
+from cou.steps.apt_sources import (
+    _get_allowed_host_patterns,
+    find_unexpected_uris,
+    parse_apt_policy_uris,
+    verify_apt_sources,
+)
+
+# Realistic apt-cache policy output snippets for testing
+APT_POLICY_CLEAN = """\
+Package files:
+ 100 /var/lib/dpkg/status
+     release a=now
+ 500 http://archive.ubuntu.com/ubuntu jammy/main amd64 Packages
+     release v=22.04,o=Ubuntu,a=jammy,n=jammy,l=Ubuntu,c=main,b=amd64
+     origin archive.ubuntu.com
+ 500 http://archive.ubuntu.com/ubuntu jammy/restricted amd64 Packages
+     release v=22.04,o=Ubuntu,a=jammy,n=jammy,l=Ubuntu,c=restricted,b=amd64
+     origin archive.ubuntu.com
+ 500 http://archive.ubuntu.com/ubuntu jammy-updates/main amd64 Packages
+     release v=22.04,o=Ubuntu,a=jammy-updates,n=jammy,l=Ubuntu,c=main,b=amd64
+     origin archive.ubuntu.com
+ 500 http://security.ubuntu.com/ubuntu jammy-security/main amd64 Packages
+     release v=22.04,o=Ubuntu,a=jammy-security,n=jammy,l=Ubuntu,c=main,b=amd64
+     origin security.ubuntu.com
+ 500 http://ubuntu-cloud.archive.canonical.com/ubuntu jammy-updates/antelope/main amd64 Packages
+     release v=22.04,o=Ubuntu Cloud Archive,a=jammy-updates/antelope,n=jammy,l=Ubuntu
+     origin ubuntu-cloud.archive.canonical.com
+Pinned packages:
+"""
+
+APT_POLICY_WITH_PPA = """\
+Package files:
+ 100 /var/lib/dpkg/status
+     release a=now
+ 500 http://archive.ubuntu.com/ubuntu jammy/main amd64 Packages
+     release v=22.04,o=Ubuntu,a=jammy,n=jammy,l=Ubuntu,c=main,b=amd64
+     origin archive.ubuntu.com
+ 500 http://ppa.launchpad.net/some-user/some-ppa/ubuntu jammy/main amd64 Packages
+     release v=22.04,o=LP-PPA-some-user-some-ppa,a=jammy,n=jammy,l=some-ppa
+     origin ppa.launchpad.net
+Pinned packages:
+"""
+
+APT_POLICY_WITH_THIRD_PARTY = """\
+Package files:
+ 100 /var/lib/dpkg/status
+     release a=now
+ 500 http://archive.ubuntu.com/ubuntu jammy/main amd64 Packages
+     release v=22.04,o=Ubuntu,a=jammy,n=jammy,l=Ubuntu,c=main,b=amd64
+     origin archive.ubuntu.com
+ 500 https://packages.example.com/stable jammy/main amd64 Packages
+     release o=Example,a=jammy
+     origin packages.example.com
+ 500 http://security.ubuntu.com/ubuntu jammy-security/main amd64 Packages
+     release v=22.04,o=Ubuntu,a=jammy-security,n=jammy,l=Ubuntu,c=main,b=amd64
+     origin security.ubuntu.com
+Pinned packages:
+"""
+
+APT_POLICY_WITH_COUNTRY_MIRROR = """\
+Package files:
+ 100 /var/lib/dpkg/status
+     release a=now
+ 500 http://br.archive.ubuntu.com/ubuntu jammy/main amd64 Packages
+     release v=22.04,o=Ubuntu,a=jammy,n=jammy,l=Ubuntu,c=main,b=amd64
+     origin br.archive.ubuntu.com
+ 500 http://security.ubuntu.com/ubuntu jammy-security/main amd64 Packages
+     release v=22.04,o=Ubuntu,a=jammy-security,n=jammy,l=Ubuntu,c=main,b=amd64
+     origin security.ubuntu.com
+Pinned packages:
+"""
+
+APT_POLICY_LANDSCAPE = """\
+Package files:
+ 100 /var/lib/dpkg/status
+     release a=now
+ 500 http://landscape.example.com/ubuntu jammy/main amd64 Packages
+     release v=22.04,o=Ubuntu,a=jammy,n=jammy,l=Ubuntu,c=main,b=amd64
+     origin landscape.example.com
+Pinned packages:
+"""
+
+APT_POLICY_LANDSCAPE_MIRROR = """\
+Package files:
+ 100 /var/lib/dpkg/status
+     release a=now
+ 500 https://repo.mirror.example.com/repository/standalone/ubuntu jammy/main amd64 Packages
+     release a=jammy,n=jammy,c=main,b=amd64
+     origin repo.mirror.example.com
+ 500 https://repo.mirror.example.com/repository/standalone/ubuntu jammy-updates/main amd64 Packages
+     release a=jammy-updates,n=jammy-updates,c=main,b=amd64
+     origin repo.mirror.example.com
+Pinned packages:
+"""
+
+APT_POLICY_PORTS = """\
+Package files:
+ 100 /var/lib/dpkg/status
+     release a=now
+ 500 http://ports.ubuntu.com/ubuntu-ports jammy/main arm64 Packages
+     release v=22.04,o=Ubuntu,a=jammy,n=jammy,l=Ubuntu,c=main,b=arm64
+     origin ports.ubuntu.com
+Pinned packages:
+"""
+
+APT_POLICY_ESM = """\
+Package files:
+ 100 /var/lib/dpkg/status
+     release a=now
+ 500 https://esm.ubuntu.com/infra/ubuntu jammy-infra-security/main amd64 Packages
+     release v=22.04,o=UbuntuESMApps,a=jammy-apps-security
+     origin esm.ubuntu.com
+Pinned packages:
+"""
+
+APT_POLICY_CLOUD_ARCHIVE_PPA = """\
+Package files:
+ 100 /var/lib/dpkg/status
+     release a=now
+ 500 http://ppa.launchpadcontent.net/ubuntu-cloud-archive/antelope/ubuntu jammy/main amd64 Packages
+     release v=22.04,o=LP-PPA-ubuntu-cloud-archive-antelope,a=jammy,n=jammy,l=antelope
+     origin ppa.launchpadcontent.net
+Pinned packages:
+"""
+
+
+class TestParseAptPolicyUris:
+    def test_clean_output(self):
+        """Test parsing apt-cache policy with only standard Ubuntu and UCA sources."""
+        uris = parse_apt_policy_uris(APT_POLICY_CLEAN)
+        assert uris == {
+            "http://archive.ubuntu.com/ubuntu",
+            "http://security.ubuntu.com/ubuntu",
+            "http://ubuntu-cloud.archive.canonical.com/ubuntu",
+        }
+
+    def test_with_ppa(self):
+        """Test parsing output containing a PPA source."""
+        uris = parse_apt_policy_uris(APT_POLICY_WITH_PPA)
+        assert "http://ppa.launchpad.net/some-user/some-ppa/ubuntu" in uris
+        assert "http://archive.ubuntu.com/ubuntu" in uris
+
+    def test_with_third_party(self):
+        """Test parsing output containing a third-party source."""
+        uris = parse_apt_policy_uris(APT_POLICY_WITH_THIRD_PARTY)
+        assert "https://packages.example.com/stable" in uris
+
+    def test_with_country_mirror(self):
+        """Test parsing output with a country-specific Ubuntu mirror."""
+        uris = parse_apt_policy_uris(APT_POLICY_WITH_COUNTRY_MIRROR)
+        assert "http://br.archive.ubuntu.com/ubuntu" in uris
+
+    def test_empty_output(self):
+        """Test parsing empty output."""
+        uris = parse_apt_policy_uris("")
+        assert uris == set()
+
+    def test_no_uris(self):
+        """Test output with only local dpkg status and no remote repos."""
+        output = """\
+Package files:
+ 100 /var/lib/dpkg/status
+     release a=now
+Pinned packages:
+"""
+        uris = parse_apt_policy_uris(output)
+        assert uris == set()
+
+    def test_https_uris(self):
+        """Test that both http and https URIs are parsed."""
+        uris = parse_apt_policy_uris(APT_POLICY_WITH_THIRD_PARTY)
+        assert any(uri.startswith("https://") for uri in uris)
+        assert any(uri.startswith("http://") for uri in uris)
+
+
+class TestFindUnexpectedUris:
+    def test_all_allowed(self):
+        """Test with only standard Ubuntu and UCA sources."""
+        uris = {
+            "http://archive.ubuntu.com/ubuntu",
+            "http://security.ubuntu.com/ubuntu",
+            "http://ubuntu-cloud.archive.canonical.com/ubuntu",
+        }
+        assert find_unexpected_uris(uris) == set()
+
+    def test_country_mirror_allowed(self):
+        """Test that country-specific Ubuntu mirrors are allowed."""
+        uris = {
+            "http://br.archive.ubuntu.com/ubuntu",
+            "http://us.archive.ubuntu.com/ubuntu",
+        }
+        assert find_unexpected_uris(uris) == set()
+
+    def test_ppa_unexpected(self):
+        """Test that PPA sources are flagged as unexpected."""
+        uris = {
+            "http://archive.ubuntu.com/ubuntu",
+            "http://ppa.launchpad.net/some-user/some-ppa/ubuntu",
+        }
+        unexpected = find_unexpected_uris(uris)
+        assert unexpected == {"http://ppa.launchpad.net/some-user/some-ppa/ubuntu"}
+
+    def test_third_party_unexpected(self):
+        """Test that third-party sources are flagged as unexpected."""
+        uris = {
+            "http://archive.ubuntu.com/ubuntu",
+            "https://packages.example.com/stable",
+        }
+        unexpected = find_unexpected_uris(uris)
+        assert unexpected == {"https://packages.example.com/stable"}
+
+    def test_ports_allowed(self):
+        """Test that ports.ubuntu.com is allowed."""
+        uris = {"http://ports.ubuntu.com/ubuntu-ports"}
+        assert find_unexpected_uris(uris) == set()
+
+    def test_esm_allowed(self):
+        """Test that esm.ubuntu.com is allowed."""
+        uris = {"https://esm.ubuntu.com/infra/ubuntu"}
+        assert find_unexpected_uris(uris) == set()
+
+    def test_cloud_archive_ppa_unexpected(self):
+        """Test that the ubuntu-cloud-archive PPA is flagged as unexpected."""
+        uris = {
+            "http://ppa.launchpadcontent.net/ubuntu-cloud-archive/antelope/ubuntu",
+        }
+        unexpected = find_unexpected_uris(uris)
+        assert unexpected == {
+            "http://ppa.launchpadcontent.net/ubuntu-cloud-archive/antelope/ubuntu",
+        }
+
+    @patch.dict("os.environ", {"LANDSCAPE_MIRROR_URI": "http://landscape.example.com/repository"})
+    def test_landscape_allowed(self):
+        """Test that landscape mirror URI is allowed when env var is set."""
+        uris = {"http://landscape.example.com/ubuntu"}
+        assert find_unexpected_uris(uris) == set()
+
+    def test_landscape_not_set(self):
+        """Test that landscape URI is unexpected when env var is not set."""
+        uris = {"http://landscape.example.com/ubuntu"}
+        unexpected = find_unexpected_uris(uris)
+        assert unexpected == {"http://landscape.example.com/ubuntu"}
+
+    @patch.dict(
+        "os.environ",
+        {"LANDSCAPE_MIRROR_URI": "https://repo.mirror.example.com/repository/standalone"},
+    )
+    def test_landscape_mirror_with_path_allowed(self):
+        """Test that a landscape mirror with a path in the URI is allowed."""
+        uris = {"https://repo.mirror.example.com/repository/standalone/ubuntu"}
+        assert find_unexpected_uris(uris) == set()
+
+    def test_landscape_mirror_unexpected_without_env(self):
+        """Test that a landscape mirror is unexpected when LANDSCAPE_MIRROR_URI is not set."""
+        uris = {"https://repo.mirror.example.com/repository/standalone/ubuntu"}
+        unexpected = find_unexpected_uris(uris)
+        assert unexpected == {"https://repo.mirror.example.com/repository/standalone/ubuntu"}
+
+    @patch.dict(
+        "os.environ",
+        {"LANDSCAPE_MIRROR_URI": "http://mirror-a.example.com/repository"},
+    )
+    def test_landscape_different_host_unexpected(self):
+        """Test is unexpected when LANDSCAPE_MIRROR_URI points to a different host."""
+        uris = {"http://mirror-b.example.com/repository/ubuntu"}
+        unexpected = find_unexpected_uris(uris)
+        assert unexpected == {"http://mirror-b.example.com/repository/ubuntu"}
+
+    def test_empty_uris(self):
+        """Test with empty set of URIs."""
+        assert find_unexpected_uris(set()) == set()
+
+    def test_multiple_unexpected(self):
+        """Test with multiple unexpected sources."""
+        uris = {
+            "http://archive.ubuntu.com/ubuntu",
+            "http://ppa.launchpad.net/some-user/ppa/ubuntu",
+            "https://packages.example.com/repo",
+        }
+        unexpected = find_unexpected_uris(uris)
+        assert len(unexpected) == 2
+        assert "http://ppa.launchpad.net/some-user/ppa/ubuntu" in unexpected
+        assert "https://packages.example.com/repo" in unexpected
+
+    @patch("cou.steps.apt_sources.urlparse")
+    def test_urlparse_valueerror(self, mock_urlparse):
+        """Test that ValueError from urlparse is handled gracefully."""
+        mock_urlparse.side_effect = ValueError("invalid URI")
+        uris = {"http://invalid-uri"}
+        unexpected = find_unexpected_uris(uris)
+        assert unexpected == {"http://invalid-uri"}
+
+
+class TestGetAllowedHostPatterns:
+    def test_without_landscape(self):
+        """Test patterns without LANDSCAPE_MIRROR_URI set."""
+        patterns = _get_allowed_host_patterns()
+        # Should have the default patterns only
+        assert len(patterns) >= 6
+
+    @patch.dict("os.environ", {"LANDSCAPE_MIRROR_URI": "http://landscape.example.com/repository"})
+    def test_with_landscape(self):
+        """Test patterns with LANDSCAPE_MIRROR_URI set."""
+        patterns = _get_allowed_host_patterns()
+        # Should have default patterns + landscape pattern
+        pattern_strs = [p.pattern for p in patterns]
+        assert any("landscape" in p for p in pattern_strs)
+
+    @patch("cou.steps.apt_sources.urlparse")
+    @patch.dict("os.environ", {"LANDSCAPE_MIRROR_URI": "http://landscape.example.com/repo"})
+    def test_landscape_urlparse_valueerror(self, mock_urlparse):
+        """Test that ValueError from urlparse for landscape URI is handled."""
+        mock_urlparse.side_effect = ValueError("invalid URI")
+        patterns = _get_allowed_host_patterns()
+        # Should still return default patterns without landscape
+        assert len(patterns) == len([p for p in patterns if "landscape" not in p.pattern])
+
+
+class TestVerifyAptSources:
+    def _make_task(self, stdout="", stderr="", return_code=0, status="completed"):
+        """Create mocks for jubilant Task."""
+        task = MagicMock()
+        task.stdout = stdout
+        task.stderr = stderr
+        task.return_code = return_code
+        task.status = status
+        task.success = status == "completed" and return_code == 0
+        task.message = ""
+        return task
+
+    def test_clean_machines(self):
+        """Test that clean machines return no unexpected sources."""
+        model = MagicMock()
+        model.run_on_all_machines.return_value = {
+            "0": self._make_task(stdout=APT_POLICY_CLEAN),
+            "1": self._make_task(stdout=APT_POLICY_CLEAN),
+        }
+        result = verify_apt_sources(model)
+        assert result == {}
+
+    def test_machine_with_ppa(self):
+        """Test that a machine with PPA is flagged."""
+        model = MagicMock()
+        model.run_on_all_machines.return_value = {
+            "0": self._make_task(stdout=APT_POLICY_CLEAN),
+            "1": self._make_task(stdout=APT_POLICY_WITH_PPA),
+        }
+        result = verify_apt_sources(model)
+        assert "1" in result
+        assert "http://ppa.launchpad.net/some-user/some-ppa/ubuntu" in result["1"]
+        assert "0" not in result
+
+    def test_machine_with_third_party(self):
+        """Test that a machine with third-party repo is flagged."""
+        model = MagicMock()
+        model.run_on_all_machines.return_value = {
+            "0": self._make_task(stdout=APT_POLICY_WITH_THIRD_PARTY),
+        }
+        result = verify_apt_sources(model)
+        assert "0" in result
+        assert "https://packages.example.com/stable" in result["0"]
+
+    def test_machine_failure_handled(self):
+        """Test that machine command failures are handled gracefully."""
+        model = MagicMock()
+        model.run_on_all_machines.return_value = {
+            "0": self._make_task(stdout=APT_POLICY_CLEAN),
+            "1": self._make_task(
+                stdout="", stderr="connection refused", return_code=1, status="failed"
+            ),
+        }
+        result = verify_apt_sources(model)
+        assert result == {}
+
+    def test_no_results(self):
+        """Test handling when no results are returned."""
+        model = MagicMock()
+        model.run_on_all_machines.return_value = {}
+        result = verify_apt_sources(model)
+        assert result == {}
+
+    def test_country_mirror_clean(self):
+        """Test that country mirrors are accepted."""
+        model = MagicMock()
+        model.run_on_all_machines.return_value = {
+            "0": self._make_task(stdout=APT_POLICY_WITH_COUNTRY_MIRROR),
+        }
+        result = verify_apt_sources(model)
+        assert result == {}
+
+    def test_ports_clean(self):
+        """Test that ports.ubuntu.com sources are accepted."""
+        model = MagicMock()
+        model.run_on_all_machines.return_value = {
+            "0": self._make_task(stdout=APT_POLICY_PORTS),
+        }
+        result = verify_apt_sources(model)
+        assert result == {}
+
+    def test_esm_clean(self):
+        """Test that esm.ubuntu.com sources are accepted."""
+        model = MagicMock()
+        model.run_on_all_machines.return_value = {
+            "0": self._make_task(stdout=APT_POLICY_ESM),
+        }
+        result = verify_apt_sources(model)
+        assert result == {}
+
+    def test_cloud_archive_ppa_flagged(self):
+        """Test that ubuntu-cloud-archive PPA is flagged by verify_apt_sources."""
+        model = MagicMock()
+        model.run_on_all_machines.return_value = {
+            "0": self._make_task(stdout=APT_POLICY_CLOUD_ARCHIVE_PPA),
+        }
+        result = verify_apt_sources(model)
+        assert "0" in result
+        assert (
+            "http://ppa.launchpadcontent.net/ubuntu-cloud-archive/antelope/ubuntu" in result["0"]
+        )
+
+    @patch.dict("os.environ", {"LANDSCAPE_MIRROR_URI": "http://landscape.example.com/repository"})
+    def test_landscape_clean(self):
+        """Test that landscape sources are accepted when env var is set."""
+        model = MagicMock()
+        model.run_on_all_machines.return_value = {
+            "0": self._make_task(stdout=APT_POLICY_LANDSCAPE),
+        }
+        result = verify_apt_sources(model)
+        assert result == {}
+
+    def test_landscape_mirror_unexpected_without_env(self):
+        """Test that landscape mirror sources are flagged when env var is not set."""
+        model = MagicMock()
+        model.run_on_all_machines.return_value = {
+            "0": self._make_task(stdout=APT_POLICY_LANDSCAPE_MIRROR),
+        }
+        result = verify_apt_sources(model)
+        assert "0" in result
+        assert "https://repo.mirror.example.com/repository/standalone/ubuntu" in result["0"]
+
+    @patch.dict(
+        "os.environ",
+        {"LANDSCAPE_MIRROR_URI": "https://repo.mirror.example.com/repository/standalone"},
+    )
+    def test_landscape_mirror_clean(self):
+        """Test that landscape mirror sources are accepted when env var matches."""
+        model = MagicMock()
+        model.run_on_all_machines.return_value = {
+            "0": self._make_task(stdout=APT_POLICY_LANDSCAPE_MIRROR),
+        }
+        result = verify_apt_sources(model)
+        assert result == {}
+
+    def test_multiple_machines_mixed(self):
+        """Test with multiple machines, some clean and some with issues."""
+        model = MagicMock()
+        model.run_on_all_machines.return_value = {
+            "0": self._make_task(stdout=APT_POLICY_CLEAN),
+            "1": self._make_task(stdout=APT_POLICY_WITH_PPA),
+            "2": self._make_task(stdout=APT_POLICY_WITH_THIRD_PARTY),
+            "3": self._make_task(stdout=APT_POLICY_CLEAN),
+        }
+        result = verify_apt_sources(model)
+        assert len(result) == 2
+        assert "1" in result
+        assert "2" in result
+        assert "0" not in result
+        assert "3" not in result

--- a/tests/unit/steps/test_apt_sources.py
+++ b/tests/unit/steps/test_apt_sources.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from cou.steps.apt_sources import (
     _get_allowed_host_patterns,
     find_unexpected_uris,
@@ -376,7 +378,9 @@ class TestVerifyAptSources:
         assert "https://packages.example.com/stable" in result["0"]
 
     def test_machine_failure_handled(self):
-        """Test that machine command failures are handled gracefully."""
+        """Test that machine command failures raise CommandRunFailed."""
+        from cou.exceptions import CommandRunFailed
+
         model = MagicMock()
         model.run_on_all_machines.return_value = {
             "0": self._make_task(stdout=APT_POLICY_CLEAN),
@@ -384,8 +388,8 @@ class TestVerifyAptSources:
                 stdout="", stderr="connection refused", return_code=1, status="failed"
             ),
         }
-        result = verify_apt_sources(model)
-        assert result == {}
+        with pytest.raises(CommandRunFailed):
+            verify_apt_sources(model)
 
     def test_no_results(self):
         """Test handling when no results are returned."""

--- a/tests/unit/steps/test_plan.py
+++ b/tests/unit/steps/test_plan.py
@@ -1857,14 +1857,33 @@ def test_verify_apt_sources_clean(mock_verify_apt_sources, mock_analysis, mock_p
 def test_verify_apt_sources_exception_handled(
     mock_verify_apt_sources, mock_analysis, mock_plan_status
 ):
-    """Test _verify_apt_sources handles exceptions gracefully."""
+    """Test _verify_apt_sources handles exceptions gracefully with --force set."""
     mock_verify_apt_sources.side_effect = Exception("connection failed")
     mock_args = MagicMock(spec_set=CLIargs(command="plan"))()
+    mock_args.force = True
     cou_plan._verify_apt_sources(mock_args, mock_analysis)
     mock_plan_status.add_message.assert_called_once()
     call_args = mock_plan_status.add_message.call_args
     assert "Failed to verify APT sources" in call_args.args[0]
     assert call_args.args[1] == cou_plan.MessageType.WARNING
+
+
+@patch("cou.steps.plan.PlanStatus")
+@patch("cou.steps.analyze.Analysis")
+@patch("cou.steps.plan.verify_apt_sources")
+def test_verify_apt_sources_exception_handled_no_force(
+    mock_verify_apt_sources, mock_analysis, mock_plan_status
+):
+    """Test _verify_apt_sources handles exceptions with --force not set."""
+    mock_verify_apt_sources.side_effect = Exception("connection failed")
+    mock_args = MagicMock(spec_set=CLIargs(command="plan"))()
+    mock_args.force = False
+    cou_plan._verify_apt_sources(mock_args, mock_analysis)
+    mock_plan_status.add_message.assert_called_once()
+    call_args = mock_plan_status.add_message.call_args
+    assert "Failed to verify APT sources" in call_args.args[0]
+    assert "--force" in call_args.args[0]
+    assert call_args.args[1] == cou_plan.MessageType.ERROR
 
 
 @patch("cou.steps.analyze.Analysis")

--- a/tests/unit/steps/test_plan.py
+++ b/tests/unit/steps/test_plan.py
@@ -508,6 +508,7 @@ def test_planstatus_warnings_property():
 @patch("cou.steps.plan._verify_model_idle")
 @patch("cou.steps.plan._verify_osd_noout_unset")
 @patch("cou.steps.plan._verify_vault_is_unsealed")
+@patch("cou.steps.plan._verify_apt_sources")
 @patch("cou.steps.plan._verify_hypervisors_cli_input")
 @patch("cou.steps.plan._verify_supported_series")
 @patch("cou.steps.plan._verify_highest_release_achieved")
@@ -519,6 +520,7 @@ async def test_pre_plan_sanity_checks(
     mock_verify_highest_release_achieved,
     mock_verify_supported_series,
     mock_verify_hypervisors_cli_input,
+    mock_verify_apt_sources,
     mock_verify_vault_is_unsealed,
     mock_verify_osd_noout_unset,
     mock_verify_model_idle,
@@ -535,6 +537,7 @@ async def test_pre_plan_sanity_checks(
     mock_verify_nova_cloud_controller_scheduler_default_filters.assert_called_once_with(
         cli_args, mock_analysis_result
     )
+    mock_verify_apt_sources.assert_called_once_with(cli_args, mock_analysis_result)
     mock_verify_vault_is_unsealed.assert_awaited_once_with(mock_analysis_result)
     mock_verify_osd_noout_unset.assert_awaited_once_with(mock_analysis_result)
     mock_verify_model_idle.assert_awaited_once_with(mock_analysis_result)
@@ -1793,7 +1796,75 @@ async def test_post_upgrade_sanity_checks_no_exception(
     """Test post_upgrade_sanity_checks without exception."""
     mock_ceph.assert_osd_noout_state = AsyncMock()
     await cou_plan.post_upgrade_sanity_checks(mock_analysis)
+
     mock_print_and_debug.assert_not_called()
+
+
+@patch("cou.steps.plan.PlanStatus")
+@patch("cou.steps.analyze.Analysis")
+@patch("cou.steps.plan.verify_apt_sources")
+def test_verify_apt_sources_unexpected_no_force(
+    mock_verify_apt_sources, mock_analysis, mock_plan_status
+):
+    """Test _verify_apt_sources with unexpected sources and no --force flag."""
+    mock_verify_apt_sources.return_value = {
+        "0": {"http://ppa.launchpad.net/some-user/ppa/ubuntu"},
+    }
+    mock_args = MagicMock(spec_set=CLIargs(command="plan"))()
+    mock_args.force = False
+    cou_plan._verify_apt_sources(mock_args, mock_analysis)
+    mock_plan_status.add_message.assert_called_once()
+    call_args = mock_plan_status.add_message.call_args
+    assert "Unexpected APT sources" in call_args.args[0]
+    assert "Machine 0" in call_args.args[0]
+    assert "--force" in call_args.args[0]
+    assert call_args.args[1] == cou_plan.MessageType.ERROR
+
+
+@patch("cou.steps.plan.PlanStatus")
+@patch("cou.steps.analyze.Analysis")
+@patch("cou.steps.plan.verify_apt_sources")
+def test_verify_apt_sources_unexpected_with_force(
+    mock_verify_apt_sources, mock_analysis, mock_plan_status
+):
+    """Test _verify_apt_sources with unexpected sources and --force flag."""
+    mock_verify_apt_sources.return_value = {
+        "0": {"http://ppa.launchpad.net/some-user/ppa/ubuntu"},
+    }
+    mock_args = MagicMock(spec_set=CLIargs(command="plan"))()
+    mock_args.force = True
+    cou_plan._verify_apt_sources(mock_args, mock_analysis)
+    mock_plan_status.add_message.assert_called_once()
+    call_args = mock_plan_status.add_message.call_args
+    assert "Unexpected APT sources" in call_args.args[0]
+    assert call_args.args[1] == cou_plan.MessageType.WARNING
+
+
+@patch("cou.steps.plan.PlanStatus")
+@patch("cou.steps.analyze.Analysis")
+@patch("cou.steps.plan.verify_apt_sources")
+def test_verify_apt_sources_clean(mock_verify_apt_sources, mock_analysis, mock_plan_status):
+    """Test _verify_apt_sources with no unexpected sources."""
+    mock_verify_apt_sources.return_value = {}
+    mock_args = MagicMock(spec_set=CLIargs(command="plan"))()
+    cou_plan._verify_apt_sources(mock_args, mock_analysis)
+    mock_plan_status.add_message.assert_not_called()
+
+
+@patch("cou.steps.plan.PlanStatus")
+@patch("cou.steps.analyze.Analysis")
+@patch("cou.steps.plan.verify_apt_sources")
+def test_verify_apt_sources_exception_handled(
+    mock_verify_apt_sources, mock_analysis, mock_plan_status
+):
+    """Test _verify_apt_sources handles exceptions gracefully."""
+    mock_verify_apt_sources.side_effect = Exception("connection failed")
+    mock_args = MagicMock(spec_set=CLIargs(command="plan"))()
+    cou_plan._verify_apt_sources(mock_args, mock_analysis)
+    mock_plan_status.add_message.assert_called_once()
+    call_args = mock_plan_status.add_message.call_args
+    assert "Failed to verify APT sources" in call_args.args[0]
+    assert call_args.args[1] == cou_plan.MessageType.WARNING
 
 
 @patch("cou.steps.analyze.Analysis")

--- a/tests/unit/steps/test_plan.py
+++ b/tests/unit/steps/test_plan.py
@@ -43,6 +43,7 @@ from cou.steps import (
 )
 from cou.steps import plan as cou_plan
 from cou.steps.analyze import Analysis
+from cou.steps.apt_sources import AptSourcesVerification
 from cou.steps.backup import backup
 from cou.steps.ceph import set_require_osd_release_option
 from cou.steps.hypervisor import HypervisorGroup, HypervisorUpgradePlanner
@@ -1807,9 +1808,10 @@ def test_verify_apt_sources_unexpected_no_force(
     mock_verify_apt_sources, mock_analysis, mock_plan_status
 ):
     """Test _verify_apt_sources with unexpected sources and no --force flag."""
-    mock_verify_apt_sources.return_value = {
-        "0": {"http://ppa.launchpad.net/some-user/ppa/ubuntu"},
-    }
+    mock_verify_apt_sources.return_value = AptSourcesVerification(
+        failed={},
+        unexpected={"0": {"http://ppa.launchpad.net/some-user/ppa/ubuntu"}},
+    )
     mock_args = MagicMock(spec_set=CLIargs(command="plan"))()
     mock_args.force = False
     cou_plan._verify_apt_sources(mock_args, mock_analysis)
@@ -1828,9 +1830,10 @@ def test_verify_apt_sources_unexpected_with_force(
     mock_verify_apt_sources, mock_analysis, mock_plan_status
 ):
     """Test _verify_apt_sources with unexpected sources and --force flag."""
-    mock_verify_apt_sources.return_value = {
-        "0": {"http://ppa.launchpad.net/some-user/ppa/ubuntu"},
-    }
+    mock_verify_apt_sources.return_value = AptSourcesVerification(
+        failed={},
+        unexpected={"0": {"http://ppa.launchpad.net/some-user/ppa/ubuntu"}},
+    )
     mock_args = MagicMock(spec_set=CLIargs(command="plan"))()
     mock_args.force = True
     cou_plan._verify_apt_sources(mock_args, mock_analysis)
@@ -1845,7 +1848,7 @@ def test_verify_apt_sources_unexpected_with_force(
 @patch("cou.steps.plan.verify_apt_sources")
 def test_verify_apt_sources_clean(mock_verify_apt_sources, mock_analysis, mock_plan_status):
     """Test _verify_apt_sources with no unexpected sources."""
-    mock_verify_apt_sources.return_value = {}
+    mock_verify_apt_sources.return_value = AptSourcesVerification(failed={}, unexpected={})
     mock_args = MagicMock(spec_set=CLIargs(command="plan"))()
     cou_plan._verify_apt_sources(mock_args, mock_analysis)
     mock_plan_status.add_message.assert_not_called()
@@ -1884,6 +1887,74 @@ def test_verify_apt_sources_exception_handled_no_force(
     assert "Failed to verify APT sources" in call_args.args[0]
     assert "--force" in call_args.args[0]
     assert call_args.args[1] == cou_plan.MessageType.ERROR
+
+
+@patch("cou.steps.plan.PlanStatus")
+@patch("cou.steps.analyze.Analysis")
+@patch("cou.steps.plan.verify_apt_sources")
+def test_verify_apt_sources_failed_machines_no_force(
+    mock_verify_apt_sources, mock_analysis, mock_plan_status
+):
+    """Test _verify_apt_sources with failed machines and no --force flag."""
+    mock_verify_apt_sources.return_value = AptSourcesVerification(
+        failed={"2": "connection refused", "5": "timeout"},
+        unexpected={},
+    )
+    mock_args = MagicMock(spec_set=CLIargs(command="plan"))()
+    mock_args.force = False
+    cou_plan._verify_apt_sources(mock_args, mock_analysis)
+    mock_plan_status.add_message.assert_called_once()
+    call_args = mock_plan_status.add_message.call_args
+    assert "manually check apt-cache policy" in call_args.args[0]
+    assert "Machine 2" in call_args.args[0]
+    assert "Machine 5" in call_args.args[0]
+    assert "--force" in call_args.args[0]
+    assert call_args.args[1] == cou_plan.MessageType.ERROR
+
+
+@patch("cou.steps.plan.PlanStatus")
+@patch("cou.steps.analyze.Analysis")
+@patch("cou.steps.plan.verify_apt_sources")
+def test_verify_apt_sources_failed_and_unexpected_no_force(
+    mock_verify_apt_sources, mock_analysis, mock_plan_status
+):
+    """Test _verify_apt_sources with both failed machines and unexpected sources, no --force."""
+    mock_verify_apt_sources.return_value = AptSourcesVerification(
+        failed={"3": "connection refused"},
+        unexpected={"1": {"http://ppa.launchpad.net/some-user/ppa/ubuntu"}},
+    )
+    mock_args = MagicMock(spec_set=CLIargs(command="plan"))()
+    mock_args.force = False
+    cou_plan._verify_apt_sources(mock_args, mock_analysis)
+    mock_plan_status.add_message.assert_called_once()
+    call_args = mock_plan_status.add_message.call_args
+    assert "manually check apt-cache policy" in call_args.args[0]
+    assert "Machine 3" in call_args.args[0]
+    assert "Unexpected APT sources" in call_args.args[0]
+    assert "Machine 1" in call_args.args[0]
+    assert "--force" in call_args.args[0]
+    assert call_args.args[1] == cou_plan.MessageType.ERROR
+
+
+@patch("cou.steps.plan.PlanStatus")
+@patch("cou.steps.analyze.Analysis")
+@patch("cou.steps.plan.verify_apt_sources")
+def test_verify_apt_sources_failed_and_unexpected_with_force(
+    mock_verify_apt_sources, mock_analysis, mock_plan_status
+):
+    """Test _verify_apt_sources with both failed machines and unexpected sources, with --force."""
+    mock_verify_apt_sources.return_value = AptSourcesVerification(
+        failed={"3": "connection refused"},
+        unexpected={"1": {"http://ppa.launchpad.net/some-user/ppa/ubuntu"}},
+    )
+    mock_args = MagicMock(spec_set=CLIargs(command="plan"))()
+    mock_args.force = True
+    cou_plan._verify_apt_sources(mock_args, mock_analysis)
+    mock_plan_status.add_message.assert_called_once()
+    call_args = mock_plan_status.add_message.call_args
+    assert "manually check apt-cache policy" in call_args.args[0]
+    assert "Unexpected APT sources" in call_args.args[0]
+    assert call_args.args[1] == cou_plan.MessageType.WARNING
 
 
 @patch("cou.steps.analyze.Analysis")

--- a/tests/unit/utils/test_juju_utils.py
+++ b/tests/unit/utils/test_juju_utils.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import asyncio
+import json
 from unittest.mock import AsyncMock, MagicMock, call, patch
 
 import jubilant
@@ -1227,3 +1228,69 @@ async def test_coumodel_get_application_status_failed(mocked_model):
         match="Cannot find 'app-not-exists' in model 'mocked-model'.",
     ):
         await model.get_application_status(app_name="app-not-exists")
+
+
+def test_coumodel_run_on_all_machines(mocked_model):
+    """Test Model run_on_all_machines."""
+    exec_output = json.dumps(
+        {
+            "0": {
+                "id": "1",
+                "status": "completed",
+                "results": {"return-code": 0, "stdout": "output from machine 0", "stderr": ""},
+            },
+            "1": {
+                "id": "2",
+                "status": "completed",
+                "results": {"return-code": 0, "stdout": "output from machine 1", "stderr": ""},
+            },
+        }
+    )
+    model = juju_utils.Model("test-model")
+    with patch("cou.utils.juju_utils.jubilant.Juju") as mock_juju_class:
+        mock_juju_instance = mock_juju_class.return_value
+        mock_juju_instance.cli.return_value = exec_output
+        results = model.run_on_all_machines("apt-cache policy")
+
+    assert len(results) == 2
+    assert results["0"].stdout == "output from machine 0"
+    assert results["1"].stdout == "output from machine 1"
+    assert results["0"].success
+    assert results["1"].success
+
+
+def test_coumodel_run_on_all_machines_cli_error(mocked_model):
+    """Test Model run_on_all_machines when juju CLI fails."""
+    import jubilant
+
+    model = juju_utils.Model("test-model")
+    with patch("cou.utils.juju_utils.jubilant.Juju") as mock_juju_class:
+        mock_juju_instance = mock_juju_class.return_value
+        mock_juju_instance.cli.side_effect = jubilant.CLIError(1, ["juju", "exec"], "out", "err")
+        results = model.run_on_all_machines("apt-cache policy")
+
+    assert results == {}
+
+
+def test_coumodel_run_on_all_machines_with_timeout(mocked_model):
+    """Test Model run_on_all_machines with timeout parameter."""
+    exec_output = json.dumps(
+        {
+            "0": {
+                "id": "1",
+                "status": "completed",
+                "results": {"return-code": 0, "stdout": "output", "stderr": ""},
+            },
+        }
+    )
+    model = juju_utils.Model("test-model")
+    with patch("cou.utils.juju_utils.jubilant.Juju") as mock_juju_class:
+        mock_juju_instance = mock_juju_class.return_value
+        mock_juju_instance.cli.return_value = exec_output
+        results = model.run_on_all_machines("apt-cache policy", timeout=60)
+
+    mock_juju_instance.cli.assert_called_once()
+    call_args = mock_juju_instance.cli.call_args[0]
+    assert "--wait" in call_args
+    assert "60s" in call_args
+    assert len(results) == 1

--- a/tests/unit/utils/test_juju_utils.py
+++ b/tests/unit/utils/test_juju_utils.py
@@ -1263,13 +1263,14 @@ def test_coumodel_run_on_all_machines_cli_error(mocked_model):
     """Test Model run_on_all_machines when juju CLI fails."""
     import jubilant
 
+    from cou.exceptions import CommandRunFailed
+
     model = juju_utils.Model("test-model")
     with patch("cou.utils.juju_utils.jubilant.Juju") as mock_juju_class:
         mock_juju_instance = mock_juju_class.return_value
         mock_juju_instance.cli.side_effect = jubilant.CLIError(1, ["juju", "exec"], "out", "err")
-        results = model.run_on_all_machines("apt-cache policy")
-
-    assert results == {}
+        with pytest.raises(CommandRunFailed):
+            model.run_on_all_machines("apt-cache policy")
 
 
 def test_coumodel_run_on_all_machines_with_timeout(mocked_model):

--- a/tests/unit/utils/test_juju_utils.py
+++ b/tests/unit/utils/test_juju_utils.py
@@ -1259,8 +1259,53 @@ def test_coumodel_run_on_all_machines(mocked_model):
     assert results["1"].success
 
 
-def test_coumodel_run_on_all_machines_cli_error(mocked_model):
-    """Test Model run_on_all_machines when juju CLI fails."""
+def test_coumodel_run_on_all_machines_cli_error_with_results(mocked_model):
+    """Test Model run_on_all_machines when juju exits non-zero but stdout has per-machine JSON.
+
+    This happens when one or more machines fail their task — juju exec exits with a
+    non-zero return code but stdout still contains the full JSON result set.
+    The method should parse and return the per-machine results instead of raising.
+    """
+    import jubilant
+
+    exec_output = json.dumps(
+        {
+            "0": {
+                "id": "1",
+                "status": "completed",
+                "results": {"return-code": 0, "stdout": "output from machine 0", "stderr": ""},
+            },
+            "1": {
+                "id": "2",
+                "status": "completed",
+                "results": {
+                    "return-code": 127,
+                    "stdout": "",
+                    "stderr": "apt-cache: command not found",
+                },
+            },
+        }
+    )
+    model = juju_utils.Model("test-model")
+    with patch("cou.utils.juju_utils.jubilant.Juju") as mock_juju_class:
+        mock_juju_instance = mock_juju_class.return_value
+        mock_juju_instance.cli.side_effect = jubilant.CLIError(
+            1, ["juju", "exec"], exec_output, ""
+        )
+        results = model.run_on_all_machines("apt-cache policy")
+
+    assert len(results) == 2
+    assert results["0"].success
+    assert not results["1"].success
+    assert results["1"].stderr == "apt-cache: command not found"
+
+
+def test_coumodel_run_on_all_machines_cli_error_no_stdout(mocked_model):
+    """Test Model run_on_all_machines raises CommandRunFailed when juju itself fails.
+
+    When stdout is empty the CLI failure is not a per-task failure but a juju-level
+    error (e.g. network issue, model not found), so CommandRunFailed is raised.
+    """
     import jubilant
 
     from cou.exceptions import CommandRunFailed
@@ -1268,7 +1313,7 @@ def test_coumodel_run_on_all_machines_cli_error(mocked_model):
     model = juju_utils.Model("test-model")
     with patch("cou.utils.juju_utils.jubilant.Juju") as mock_juju_class:
         mock_juju_instance = mock_juju_class.return_value
-        mock_juju_instance.cli.side_effect = jubilant.CLIError(1, ["juju", "exec"], "out", "err")
+        mock_juju_instance.cli.side_effect = jubilant.CLIError(1, ["juju", "exec"], "", "err")
         with pytest.raises(CommandRunFailed):
             model.run_on_all_machines("apt-cache policy")
 


### PR DESCRIPTION
Verify that all machines only have expected APT sources configured (standard Ubuntu archives, Ubuntu Cloud Archive, ESM, ports, and Landscape mirrors). PPAs and third party packages are not allowed and will trigger a warning or error depending on the --force flag.

Landscape mirrors are supported via the LANDSCAPE_MIRROR_URI environment variable. The check runs apt-cache policy on all machines using juju exec --all via `jubilant`.


## Testing

I've deployed a simple model with 3 designate-bind. One of then I've added a third-party package and in other I've removed the apt-cache binary.

```
cou plan
Configuring logging... Full execution log: '/home/gabriel.cocenza@canonical.com/.local/share/cou/log/cou-20260522133825.log'
2026-05-22 13:38:25 [WARNING] {'datetime': '2026-05-22T13:38:25.489069-03:00', 'appid': 'cou', 'event': 'sys_startup', 'level': 'WARN', 'description': 'charmed-openstack-upgrader start'}
Connected to 'zaza-9ff073f88fb3' ✔
Analyzing cloud... ✔
2026-05-22 13:38:26 [ERROR] Failed to run 'apt-cache policy' on machine 1: /tmp/juju-exec1372170038/script.sh: line 1: apt-cache: command not found

2026-05-22 13:38:26 [WARNING] Application vault not found, skip
2026-05-22 13:38:26 [WARNING] Application with 'ceph-mon' not found
Verifying cloud... /2026-05-22 13:38:26 [WARNING] Skip verifying 'noout', because there's no ceph-mon applications.
Verifying cloud... ✔
Generating upgrade plan... \2026-05-22 13:40:27 [WARNING] Not changing the install repository of app designate-bind: None already set to cloud:focal-wallaby
Generating upgrade plan... ✔
Upgrade cloud from 'victoria' to 'wallaby'
	Back up MySQL databases
	Archive old database data on nova-cloud-controller
	Control Plane principal(s) upgrade plan
		Upgrade plan for 'designate-bind' to 'wallaby'
			Upgrade software packages of 'designate-bind' from the current APT repositories
				Ψ Upgrade software packages on unit 'designate-bind/0'
				Ψ Upgrade software packages on unit 'designate-bind/1'
				Ψ Upgrade software packages on unit 'designate-bind/2'
			Upgrade 'designate-bind' from 'victoria/stable' to the new channel: 'wallaby/stable'
			Wait for up to 300s for app 'designate-bind' to reach the idle state
			Wait for up to 300s for app 'designate-bind' to reach the idle state
			Verify that the workload of 'designate-bind' has been upgraded on units: designate-bind/0, designate-bind/1, designate-bind/2
	Ensure ceph-mon's 'require-osd-release' option matches the 'ceph-osd' version

2026-05-22 13:40:27 [WARNING] Cannot find nova-cloud-controller apps. Is this a valid OpenStack cloud?
2026-05-22 13:40:27 [WARNING] Setting noout for ceph cluster during upgrade is optional but recommended. You can use `--set-noout` to add this optional step. For more information, Please refer to set-noout action: https://charmhub.io/ceph-mon/actions#set-noout
2026-05-22 13:40:27 [ERROR] Failed to get apt-cache policy on the following machines. It is advised to manually check apt-cache policy on these machines before proceeding:
  - Machine 1: /tmp/juju-exec1372170038/script.sh: line 1: apt-cache: command not found
  
Unexpected APT sources found on machines. This may cause issues during the upgrade. Only standard Ubuntu, Ubuntu Cloud Archive, and Landscape sources are expected.
  - Machine 0: https://pkg.cloudflare.com/cloudflared
Use --force to override this check.
```

Using force:

```
2026-05-22 13:56:05 [WARNING] Failed to get apt-cache policy on the following machines. It is advised to manually check apt-cache policy on these machines before proceeding:
  - Machine 1: /tmp/juju-exec94507995/script.sh: line 1: apt-cache: command not found

Unexpected APT sources found on machines. This may cause issues during the upgrade. Only standard Ubuntu, Ubuntu Cloud Archive, and Landscape sources are expected.
  - Machine 0: https://pkg.cloudflare.com/cloudflared


```

Closes: #685